### PR TITLE
Improve default sdist with explicit MANIFEST.in file.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include *.appdata.xml
+include *.md
+include *.plist
+include pyzolauncher.py
+recursive-include doc *.*


### PR DESCRIPTION
This PR improves the current sdist to include additional files and documentation necessary to package the application downstream. Right now, the default provides just the public module and associated `setup.py`, but having the README, RELEASE_NOTES and metadata files are also desirable. I have added the `pyzolauncher.py` script so the tarball on PyPI can also be executed standalone.

Let me know if you have further comments.

Cheers,
Ghis