### PR TITLE
Added GUI integration support for PySide2

### DIFF
--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -132,6 +132,7 @@ class ShellInfo_gui(QtWidgets.QComboBox):
                 ('PyQt5', 'GPL/commercial licensed wrapper to Qt'),
                 ('PyQt4', 'GPL/commercial licensed wrapper to Qt'),
                 ('PySide', 'LGPL licensed wrapper to Qt'),
+                ('PySide2', 'LGPL licensed wrapper to Qt5'),
                 ('Tornado', 'Tornado asynchronous networking library'),
                 ('Tk', 'Tk widget toolkit'),
                 ('WX', 'wxPython'),

--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -434,6 +434,15 @@ class App_pyqt4(App_qt):
         from PyQt4 import QtGui, QtCore
         return QtGui, QtCore
     
+class App_pyside2(App_qt):
+    """ Hijack the PySide2 mainloop.
+    """
+    
+    def importCoreAndGui(self):
+        # Try importing qt        
+        import PySide2
+        from PySide2 import QtGui, QtCore, QtWidgets
+        return QtWidgets, QtCore  # QApp sits on QtWidgets
     
 class App_pyside(App_qt):
     """ Hijack the PySide mainloop.

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -461,6 +461,7 @@ class PyzoInterpreter:
             elif guiName == 'AUTO':
                 for tryName, tryApp in [('PYQT5', guiintegration.App_pyqt5),
                                         ('PYQT4', guiintegration.App_pyqt4),
+                                        ('PYSIDE2', guiintegration.App_pyside2),
                                         ('PYSIDE', guiintegration.App_pyside),
                                         #('WX', guiintegration.App_wx),
                                         ('TK', guiintegration.App_tk),
@@ -481,6 +482,8 @@ class PyzoInterpreter:
                 self.guiApp = guiintegration.App_tornado()
             elif guiName == 'PYSIDE':
                 self.guiApp = guiintegration.App_pyside()
+            elif guiName == 'PYSIDE2':
+                self.guiApp = guiintegration.App_pyside2()
             elif guiName in ['PYQT5', 'QT5']:
                 self.guiApp = guiintegration.App_pyqt5()
             elif guiName in ['PYQT4', 'QT4']:


### PR DESCRIPTION
This PR adds PySide2 GUI integration

PySide2 is not yet very widespread, but is AFAIK the only LGPL solution for Qt on Python >3.4.

This PR was tested on Windows, PySide 2 installed as described here:[Compiling PySide2 from source](https://fredrikaverpil.github.io/2016/08/17/compiling-pyside2/). Furthermore, one may need to copy the Qt binary files to the Python working directory as described here:[Deploy an Application on Windows](http://wiki.qt.io/Deploy_an_Application_on_Windows)

