### PR TITLE
Better high resolution (Retina) support on macOS

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -40,5 +40,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSHighResolutionCapable</key> 
+	<string>True</string>
 </dict>
 </plist>


### PR DESCRIPTION
Small addition of 2 lines, but makes Pyzo's text crisp on high DPI/Retina screens for macOS, even if Pyzo's images aren't at the moment.