### PR TITLE
Made a few more strings translatable in menu,shell,main.

### DIFF
--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -24,6 +24,7 @@ from pyzo.util.qt import QtCore, QtGui, QtWidgets
 from pyzo.core.splash import SplashWidget
 from pyzo.util import paths
 from pyzo.util import zon as ssdf  # zon is ssdf-light
+from pyzo import translate
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -213,7 +214,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if os.path.isfile(path):
                 pass
             elif name == path:
-                path = 'unsaved'
+                path = translate("main", 'unsaved')
             else:
                 pass  # We hope the given path is informative
             # Set title

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -446,7 +446,7 @@ class FileMenu(Menu):
         from pyzo import codeeditor
         t = translate("menu", "Syntax parser ::: The syntax parser of the current file.")
         self._parserMenu = GeneralOptionsMenu(self, t, self._setParser)
-        self._parserMenu.setOptions(['None'] + codeeditor.Manager.getParserNames())
+        self._parserMenu.setOptions([translate("menu-parser",'None')] + codeeditor.Manager.getParserNames())
         
         # Create line ending menu
         t = translate("menu", "Line endings ::: The line ending character of the current file.")
@@ -720,7 +720,7 @@ class ViewMenu(Menu):
         t = translate("menu", "Location of long line indicator ::: The location of the long-line-indicator.")
         self._edgeColumMenu = GeneralOptionsMenu(self, t, self._setEdgeColumn)
         values = [0] + [i for i in range(60,130,10)]
-        names = ["None"] + [str(i) for i in values[1:]]
+        names = [translate("menu-locationlongline","None")] + [str(i) for i in values[1:]]
         self._edgeColumMenu.setOptions(names, values)
         self._edgeColumMenu.setCheckedOption(None, pyzo.config.view.edgeColumn)
         

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -319,7 +319,7 @@ class ShellControl(QtWidgets.QToolButton):
         
         # Set text and tooltip
         self.setText('Warming up ...')
-        self.setToolTip("Click to select shell.")
+        self.setToolTip(translate("shells", "Click to select shell."))
         self.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
         self.setPopupMode(self.InstantPopup)
         

--- a/pyzo/resources/translations/pyzo_fr_FR.tr
+++ b/pyzo/resources/translations/pyzo_fr_FR.tr
@@ -391,7 +391,7 @@
     <message>
         <location filename="../../core/menu.py" line="667"/>
         <source>Zoom out</source>
-        <translation>Dézommer</translation>
+        <translation>Dézoomer</translation>
     </message>
     <message>
         <location filename="../../core/menu.py" line="668"/>
@@ -561,12 +561,12 @@
     <message>
         <location filename="../../core/menu.py" line="1662"/>
         <source>Edit key mappings... ::: Edit the shortcuts for menu items.</source>
-        <translation>Éditer les racourcis... ::: Modifie les raccourcis pour accéder aux éléments des menus.</translation>
+        <translation>Éditer les raccourcis... ::: Modifie les raccourcis pour accéder aux éléments des menus.</translation>
     </message>
     <message>
         <location filename="../../core/menu.py" line="1664"/>
         <source>Edit syntax styles... ::: Change the coloring of your code.</source>
-        <translation>Éditer les style du code... ::: Modifie la coloration syntaxique du code.</translation>
+        <translation>Éditer les styles du code... ::: Modifie la coloration syntaxique du code.</translation>
     </message>
     <message>
         <location filename="../../core/menu.py" line="966"/>
@@ -696,7 +696,7 @@
     <message>
         <location filename="../../core/menu.py" line="1565"/>
         <source>Report an issue ::: Did you found a bug in Pyzo, or do you have a feature request?</source>
-        <translation>Reporter un problème ::: Vous avez touvé un bug dans Pyzo ? Vous voulez demander l&apos;ajout d&apos;une fonctionnalité ?</translation>
+        <translation>Signaler un problème ::: Vous avez touvé un bug dans Pyzo ? Vous voulez demander l&apos;ajout d&apos;une fonctionnalité ?</translation>
     </message>
     <message>
         <location filename="../../core/menu.py" line="1576"/>
@@ -731,7 +731,7 @@
     <message>
         <location filename="../../core/menu.py" line="760"/>
         <source>Highlight brackets ::: Highlight matched and unmatched brackets.</source>
-        <translation>Montrer la correspondant entre les crochets ouvrant et fermant.</translation>
+        <translation>Surligner les crochets ::: Montrer la correspondance entre les crochets ouvrants et fermants.</translation>
     </message>
     <message>
         <location filename="../../core/menu.py" line="1328"/>
@@ -1070,7 +1070,7 @@
     <message>
         <location filename="../../util/pyzowizard.py" line="323"/>
         <source>*Run cell:* a cell is everything between two lines starting with &apos;##&apos;.</source>
-        <translation>*Exécuter une cellule : * une cellule est tout ce qui se trouve entre deux lignes commençant par &apos;##&apos;.</translation>
+        <translation>*Exécuter une cellule :* une cellule est tout ce qui se trouve entre deux lignes commençant par &apos;##&apos;.</translation>
     </message>
     <message>
         <location filename="../../util/pyzowizard.py" line="325"/>
@@ -1141,7 +1141,7 @@
     <message>
         <location filename="../../util/pyzowizard.py" line="372"/>
         <source>We especially recommend the following tools:</source>
-        <translation>Nous recommandons tout spécialement les outils suivants :</translation>
+        <translation>Nous recommandons tout particulièrement les outils suivants :</translation>
     </message>
     <message>
         <location filename="../../util/pyzowizard.py" line="374"/>
@@ -1168,7 +1168,7 @@
     <message>
         <location filename="../../util/pyzowizard.py" line="165"/>
         <source>This wizard helps you get familiarized with the workings of Pyzo.</source>
-        <translation>Ce guide.vous aide à vous familiariser avec Pyzo.</translation>
+        <translation>Ce guide vous aide à vous familiariser avec le fonctionnement de Pyzo.</translation>
     </message>
     <message>
         <location filename="../../util/pyzowizard.py" line="167"/>
@@ -1192,7 +1192,7 @@ design se veut *simple* et *efficace*.</translation>
         The language has been changed for this wizard.
         Pyzo needs to restart for the change to take effect application-wide.
         </source>
-        <translation>La langue a été modifié. Pyzo doit redémarrer pour que les
+        <translation>La langue a été modifiée. Pyzo doit redémarrer pour que les
 modifications prennent effet dans toute l&apos;application.</translation>
     </message>
     <message>
@@ -1214,7 +1214,7 @@ correspondre à des versions différentes de Python.</translation>
         <source>Shells run in a sub-process, such that when it is busy, Pyzo
         itself stays responsive, allowing you to keep coding and even
         run code in another shell.</source>
-        <translation>Un shell s&apos;exécute dans un processu fils. Ainsi, s&apos;il est occupé, Pyzo lui même
+        <translation>Un shell s&apos;exécute dans un processus fils. Ainsi, s&apos;il est occupé, Pyzo lui même
 continue d&apos;être réactif. Vous pouvez continuer à coder et même exécuter du code
 dans un autre shell.</translation>
     </message>
@@ -1245,7 +1245,7 @@ sélectionnées.</translation>
     <message>
         <location filename="../../util/pyzowizard.py" line="387"/>
         <source>This concludes the Pyzo wizard. Now, get coding and have fun!</source>
-        <translation>Ceci termine le Guide Pyzo. Maintenant, en route pour le code, et amusez-vous bien!</translation>
+        <translation>Ceci termine le Guide Pyzo. Maintenant, en route pour le code, et amusez-vous bien !</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
A few strings needed a "translate" call so that they could be translated. There is also the string in "core/splash.py" and some others (line 673 and more) in "core/shellStack.py", but I'm not sure how to do it since they have three double quotes!

I also fixed a few minor things in the French translation.