### PR TITLE
Allows the Shell window to float (like other tools)

### DIFF
--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -167,7 +167,7 @@ class MainWindow(QtWidgets.QMainWindow):
         
         # Create floater for shell
         self._shellDock = dock = QtWidgets.QDockWidget(self)
-        dock.setFeatures(dock.DockWidgetMovable)
+        dock.setFeatures(dock.DockWidgetMovable|dock.DockWidgetFloatable)
         dock.setObjectName('shells')
         dock.setWindowTitle('Shells')
         self.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)


### PR DESCRIPTION
Allowing shell window to float is useful in dual screen mode