### PR TITLE
Use %run -i to run script when ipython console is used

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1589,7 +1589,14 @@ class RunMenu(Menu):
             saveOk = pyzo.editors.saveFile(editor) # Always try to save
             if saveOk or not editor.document().isModified():
                 self._showWhatToExecute(editor)
-                shell.restart(editor._filename)
+                if shell._startup_info['ipython'] == 'yes':
+                    # If we have a ipython shell we use %run -i instead
+                    # This works better when python autoreload is used
+                    d = os.path.normpath(os.path.normcase(os.path.dirname(editor._filename)))
+                    shell._ctrl_command.send('%%cd %s' % d)
+                    shell._ctrl_command.send('%%run -i %s\n' % editor._filename)                
+                else:
+                    shell.restart(editor._filename)
             else:
                 err = translate("menu", "Could not save the file.")
         else:


### PR DESCRIPTION
I have implemented the use of %run -i, when the shell is an ipython shell