### PR TITLE
Fix inclusion pattern for the docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include *.appdata.xml
 include *.md
 include *.plist
 include pyzolauncher.py
-recursive-include doc *.*
+recursive-include doc *


### PR DESCRIPTION
Otherwise, `doc/Makefile` is missing from the source tarball.