### PR TITLE
Allow for a site-wide config file

### DIFF
--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -170,10 +170,10 @@ def resetConfig(preserveState=True):
     tmp = ssdf.load(configFileName1)
     if preserveState:
         tmp.state = config.state
-    ssdf.save(configFileName2, tmp)
+    os.remove(configFileName2)
     global _saveConfigFile
     _saveConfigFile = False
-    print("Replaced config file. Restart Pyzo to revert to the default config.")
+    print("Deleted user config file. Restart Pyzo to revert to the default config.")
 
 
 def loadConfig(defaultsOnly=False):

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -160,7 +160,7 @@ def getResourceDirs():
 
 def resetConfig(preserveState=True):
     """ resetConfig()
-    Replaces the config file with the default and prevent Pyzo from storing
+    Deletes the config file to revert to default and prevent Pyzo from storing
     its config on the next shutdown.
     """
     # Get filenames
@@ -173,7 +173,7 @@ def resetConfig(preserveState=True):
 
 def loadConfig(defaultsOnly=False):
     """ loadConfig(defaultsOnly=False)
-    Load default configuration file and that of the user (if it exists).
+    Load default and site-wide configuration file(s) and that of the user (if it exists).
     Any missing fields in the user config are set to the defaults.
     """
 

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -164,12 +164,7 @@ def resetConfig(preserveState=True):
     its config on the next shutdown.
     """
     # Get filenames
-    configFileName1 = os.path.join(pyzoDir, 'resources', 'defaultConfig.ssdf')
     configFileName2 = os.path.join(appDataDir, 'config.ssdf')
-    # Read, edit, write
-    tmp = ssdf.load(configFileName1)
-    if preserveState:
-        tmp.state = config.state
     os.remove(configFileName2)
     global _saveConfigFile
     _saveConfigFile = False

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -197,6 +197,17 @@ def loadConfig(defaultsOnly=False):
     if sys.platform == 'darwin':
         config.shortcuts2.view__select_previous_file = 'Alt+Tab,'
 
+    # Load site-wide config if it exists and inject in pyzo.config
+    fname = os.path.join(pyzoDir, 'resources', 'siteConfig.ssdf')
+    if os.path.isfile(fname):
+        try:
+            siteConfig = ssdf.load(fname)
+            replaceFields(config, siteConfig)
+        except Exception:
+            t = 'Error while reading config file %r, maybe its corrupt?'
+            print(t % fname)
+            raise
+
     # Load user config and inject in pyzo.config
     fname = os.path.join(appDataDir, "config.ssdf")
     if os.path.isfile(fname):


### PR DESCRIPTION
This allows somebody who deploys pyzo to a multiuser environment to create a ```pyzo/resources/siteConfig.ssdf``` file the content of which will override the defaultConfig but in turn be overridden by the user configuration file.