### PR TITLE
Solve confusion between open magic command and open python function

### DIFF
--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -110,33 +110,51 @@ class Magician:
         # Get interpreter
         interpreter = sys._pyzoInterpreter
         
-        # Check that line is not some valid python input
-        try :
-            # gets a list of 5-tuples, of which [0] is the type of token and [1] is the token string
-            ltok = list(tokenize.tokenize(io.BytesIO(line.encode('utf-8')).readline))
-        except tokenize.TokenError :  # typically this means an unmatched parenthesis
-                                    # (which should not happen because these are detected before)
-            return
+
+        if PYTHON_VERSION >= 3 :
         
-        # ignore garbage and indentation at the beginning
-        pos = 0
-        while pos < len(ltok) and ltok[pos][0] in [59, token.INDENT, tokenize.ENCODING] : # 59 is BACKQUOTE but there is no token.BACKQUOTE...
+            # Check that line is not some valid python input
+            try :
+                # gets a list of 5-tuples, of which [0] is the type of token and [1] is the token string
+                ltok = list(tokenize.tokenize(io.BytesIO(line.encode('utf-8')).readline))
+            except tokenize.TokenError :  # typically this means an unmatched parenthesis
+                                        # (which should not happen because these are detected before)
+                return
+            
+            # ignore garbage and indentation at the beginning
+            pos = 0
+            while pos < len(ltok) and ltok[pos][0] in [59, token.INDENT, tokenize.ENCODING] : # 59 is BACKQUOTE but there is no token.BACKQUOTE...
+                pos = pos + 1
+            # when line is only garbage or does not begin with a name
+            if pos >= len(ltok) or ltok[pos][0] != token.NAME :
+                return
+            command = ltok[pos][1]
+            if keyword.iskeyword(command) :
+                return
             pos = pos + 1
-        # when line is only garbage or does not begin with a name
-        if pos >= len(ltok) or ltok[pos][0] != token.NAME :
-            return
-        command = ltok[pos][1]
-        if keyword.iskeyword(command) :
-            return
-        pos = pos + 1
-        # command is alone on the line
-        if pos >= len(ltok) or ltok[pos][0] in [token.ENDMARKER, token.COMMENT] :
-            if command in interpreter.locals :
-                return
-            if interpreter.globals and command in interpreter.globals:
-                return
-        else : # command is not alone ; next token should not be an operator (this includes parentheses)
-            if ltok[pos][0] == token.OP :
+            # command is alone on the line
+            if pos >= len(ltok) or ltok[pos][0] in [token.ENDMARKER, token.COMMENT] :
+                if command in interpreter.locals :
+                    return
+                if interpreter.globals and command in interpreter.globals:
+                    return
+            else : # command is not alone ; next token should not be an operator (this includes parentheses)
+                if ltok[pos][0] == token.OP :
+                    return
+        else :
+            # Old, not as good check for outdated Python version
+            # Check if it is a variable
+            command = line.rstrip()
+            if ' ' not in command:
+                if command in interpreter.locals:
+                    return
+                if interpreter.globals and command in interpreter.globals:
+                    return
+            
+            # Clean and make case insensitive
+            command = line.upper().rstrip()
+            
+            if not command:
                 return
 
 

--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -130,7 +130,7 @@ class Magician:
             return
         pos = pos + 1
         # command is alone on the line
-        if pos >= len(ltok) or ltok[pos][0] == token.ENDMARKER :
+        if pos >= len(ltok) or ltok[pos][0] in [token.ENDMARKER, token.COMMENT] :
             if command in interpreter.locals :
                 return
             if interpreter.globals and command in interpreter.globals:


### PR DESCRIPTION
Some of my students have the unpalatable habit of typing a space between the name of a function and the parenthesis, ie. ```open ("/tmp/somefile")``` instead of ```open("/tmp/somefile")```. I think this is bad style, but it is definitely syntactically valid as per [python's lexical analysis rules](https://docs.python.org/3/reference/lexical_analysis.html#whitespace-between-tokens).

The problem is that there is also a magic command with name ``open`` and pyzo gives it precedence when this word is followed by a space. This leads to very strange error messages like
```
Could not determine file name for object "("/tmp/essai")".
```
or even
```
Error in handling magic function:
  invalid syntax (<string>, line 1)
  line 347 in /opt/yann/pyzo-4.4.2/source/pyzo/pyzokernel/magic.py
  line 70 in /opt/yann/pyzo-4.4.2/source/pyzo/pyzokernel/magic.py
```
in response to ```open ("/tmp/essai", mode="r")```.

I see that the magic.py code has some quirks to verify that the command is not a identifier in the current or global scope. But it only does this for a magic command without argument, so that evaluating ```open``` correctly gives ```<function io.open>```.

You have to restrict this disambiguation to commands without arguments because if you did not, it would never be possible to use the ```open``` magic command.

However, this is problematic. Renaming the ```open``` magic command would be of some help, but ultimately one cannot prevent a situation where the new name also happens to be used as an identifier in the python program.

The only solution I can see is to have magic commands with names that are not valid python identifiers.

I propose that magic command be prefixed with a ```%``` (except those which already have a ```?```). This breaks backward compatibility somewhat, but I assume people are not maintaining scripts consisting of pyzo magic commands.