### PR TITLE
Bug or feature?: History Viewer auto scroll fix

### DIFF
--- a/pyzo/tools/pyzoHistoryViewer.py
+++ b/pyzo/tools/pyzoHistoryViewer.py
@@ -75,6 +75,11 @@ class PyzoHistoryViewer(QtWidgets.QWidget):
         for command in pyzo.command_history.get_commands():
             self._list.addItem(command)
         
+        # Scroll to end of list on start up
+        self._list.setCurrentRow(self._list.count()-1)
+        item = self._list.currentItem()
+        self._list.scrollToItem(item)
+        
         # Keep up to date ...
         pyzo.command_history.command_added.connect(self._on_command_added)
         pyzo.command_history.command_removed.connect(self._on_command_removed)
@@ -93,6 +98,7 @@ class PyzoHistoryViewer(QtWidgets.QWidget):
         self._list.addItem(item)
         needle = self._search.text()
         item.setHidden(bool(needle and needle not in command))
+        self._list.scrollToItem(item)
     
     def _on_command_removed(self, index):
         self._list.takeItem(index)


### PR DESCRIPTION
History Viewer now auto scrolls to the bottom of the list when new commands are entered in the shell instead of "getting stuck" at the beginning of the list, with newer commands disappearing out of the window.

Before:
![bug demonstration](https://user-images.githubusercontent.com/36742246/36565314-6539fada-1820-11e8-83d7-c2301050dcde.gif)

After:
![fix demonstration](https://user-images.githubusercontent.com/36742246/36565313-6508e6c0-1820-11e8-8f53-c86acc4da91e.gif)

 In addition, history viewer now scrolls to the bottom automatically when starting the program.

I'm at wit's end as to whether this is a bug or a feature working as intended. Personally I find it frustrating that I have to keep scrolling down the list manually to copy the latest commands from the shell to my editor. I'm anxious to know whether I am the only one with this issue!

In addition, if it _is_ a UI bug, I do not know whether it is only encountered on some configurations or under specific back-ends (i.e. Pyside/pyqt4/pyqt5). I encountered the bug both in a Windows and in a Linux environment (see info below). And, as far as I can recall, auto scroll to the bottom did work in earlier versions of Pyzo/IEP perhaps a year or so back.

In any case, I don't know whether this pull request is warranted. Feedback is appreciated!

Thanks for a great IDE.

Kind regards,
Søren

**OS and version info**
Pyzo version: 4.5.0 (source)
Platform: win32 (Windows 7 Pro 64-bit) (bug also encountered under Ubuntu 17.10 64-bit)
Python version: 3.6.1
Qt version: 5.10.0
PyQt5 version: 5.10