### PR TITLE
Update guiintegration.py

### DIFF
--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -501,6 +501,7 @@ class App_pyqt5(App_qt):
     def importCoreAndGui(self):
         # Try importing qt
         import PyQt5  # noqa
+        from PyQt5 import QtWebEngineWidgets
         from PyQt5 import QtGui, QtCore, QtWidgets  # noqa
         return QtWidgets, QtCore  # QApp sits on QtWidgets
 


### PR DESCRIPTION
QtWebEngineWidgets needs to be imported before QCoreApplication is created otherwise it generates the following error:
ImportError: QtWebEngineWidgets must be imported before a QCoreApplication instance is created