### PR TITLE
fix block commenting when having empty lines

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -630,6 +630,7 @@ class PyzoEditor(BaseTextCtrl):
         Comment the lines that are currently selected
         """
         indents = []
+        indentChar = ' ' if self.indentUsingSpaces() else '\t'
 
         def getIndent(cursor):
             text = cursor.block().text().rstrip()
@@ -637,6 +638,13 @@ class PyzoEditor(BaseTextCtrl):
                 indents.append(len(text) - len(text.lstrip()))
 
         def commentBlock(cursor):
+            blockText = cursor.block().text()
+            numMissingIndentChars = (minindent -
+                (len(blockText) - len(blockText.lstrip(indentChar))))
+            if numMissingIndentChars > 0:
+                # Prevent setPosition from leaving bounds of the current block
+                # if there are too few indent characters (e.g. an empty line)
+                cursor.insertText(indentChar * numMissingIndentChars)
             cursor.setPosition(cursor.block().position() + minindent)
             cursor.insertText('# ')
 


### PR DESCRIPTION
When commenting a code (using e.g. Ctrl+R):
[4 spaces]some_text_1
[empty line]
[4 spaces]some_text_2

I got:
[4 spaces]# some_text_1
[empty line]
[3 spaces]## some_text_2

Using the modificated code, I get:
[4 spaces]# some_text_1
[4 spaces]#[1 space]
[4 spaces]# some_text_2


As this is my first pull request I want to say big thanks to almarklein and all other contributors for this great Python IDE.