### PR TITLE
Improve automatic insertion of braces and brackets

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -482,6 +482,7 @@ class AutoCloseQuotesAndBrackets(object):
         openBrackets = [Qt.Key_BraceLeft,Qt.Key_BracketLeft, Qt.Key_ParenLeft]
         closeBrackets = [Qt.Key_BraceRight, Qt.Key_BracketRight, Qt.Key_ParenRight]
         bracketKeys = openBrackets + closeBrackets
+        closeBracketsCharacters = "}])"
         
         cursor = self.textCursor()
         
@@ -504,7 +505,7 @@ class AutoCloseQuotesAndBrackets(object):
                     cursor.insertText(new_text)
                     cursor.setKeepPositionOnInsert(False)
                     self.setTextCursor(cursor)
-                elif next_character.strip() and next_character not in ['(',')','[',']','{','}'] :  # str.strip() conveniently removes all kinds of whitespace
+                elif next_character.strip() and next_character not in closeBracketsCharacters:  # str.strip() conveniently removes all kinds of whitespace
                     # Only autoclose if the char on the right is whitespace
                     cursor.insertText(chr(event.key()))  # == super().keyPressEvent(event) 
                 else:


### PR DESCRIPTION
>     Add auto removal of ), ], } if (, [, { are removed using backspace, and if they are side by side ( i.e (), [] and {} ).
>     Improve auto-close that prevented the addition of the closing braces and brackets.


Hello! I improved a bit the automatic insertion system of brackets. The previous one was sometime frustrating, because it didn't auto-close brackets correctly in some situations, like this one:

_Auto-close before:_
![v1](https://user-images.githubusercontent.com/23081789/57948797-ee738180-78e2-11e9-80fe-d889138833c8.gif)

_Now:_
![v2](https://user-images.githubusercontent.com/23081789/57948803-f0d5db80-78e2-11e9-9796-5103ae50230a.gif)
I also added a system to auto remove brackets:

_Auto removal of brackets:_
![auto-close-2](https://user-images.githubusercontent.com/23081789/57948824-faf7da00-78e2-11e9-9f92-8490d6dcc9f4.gif)


Now it behaves more like some others editors (like sublime text).

Please note that I'm pretty much a noob in development, so please tell me if there is any problem.