### PR TITLE
Disambiguate Python 2 and 3

### DIFF
--- a/pyzo/codeeditor/manager.py
+++ b/pyzo/codeeditor/manager.py
@@ -115,11 +115,7 @@ class Manager:
         # Put in list with the parser names as keys
         parserInstances = {}
         for parserClass in foundParsers:
-            name = parserClass.__name__
-            if name.endswith('Parser') and len(name)>6:
-                
-                # Get parser identifier name
-                name = name[:-6].lower()
+                name = cls.getParserName(parserClass)
                 
                 # Try instantiating the parser
                 try:
@@ -139,6 +135,15 @@ class Manager:
         # Store
         cls._parserInstances = parserInstances
     
+    
+    @staticmethod
+    def getParserName(parserClass) :
+        name = parserClass.__name__
+        if name.endswith('Parser') and len(name)>6:
+            
+            # Get parser identifier name
+            name = name[:-6].lower()
+        return name
     
     @classmethod
     def getParserNames(cls):

--- a/pyzo/codeeditor/manager.py
+++ b/pyzo/codeeditor/manager.py
@@ -260,9 +260,9 @@ class Manager:
         
         See also registerFilenameExtension() and registerShebangKeyword()
         """
-        parser = cls.suggestParserfromFilenameExtension(ext)
+        parser = cls.suggestParserfromText(text)
         if parser == "" :
-            parser = cls.suggestParserfromText(text)
+            parser = cls.suggestParserfromFilenameExtension(ext)
         return parser
     
     @classmethod

--- a/pyzo/codeeditor/manager.py
+++ b/pyzo/codeeditor/manager.py
@@ -115,7 +115,7 @@ class Manager:
         # Put in list with the parser names as keys
         parserInstances = {}
         for parserClass in foundParsers:
-                name = cls.getParserName(parserClass)
+                name = parserClass.getParserName()
                 
                 # Try instantiating the parser
                 try:
@@ -134,16 +134,6 @@ class Manager:
         
         # Store
         cls._parserInstances = parserInstances
-    
-    
-    @staticmethod
-    def getParserName(parserClass) :
-        name = parserClass.__name__
-        if name.endswith('Parser') and len(name)>6:
-            
-            # Get parser identifier name
-            name = name[:-6].lower()
-        return name
     
     @classmethod
     def getParserNames(cls):
@@ -263,7 +253,7 @@ class Manager:
         parser = cls.suggestParserfromText(text)
         if parser == "" :
             parser = cls.suggestParserfromFilenameExtension(ext)
-        parser = cls.getParserName(cls.getParserByName(parser).disambiguate(text))
+        parser = cls.getParserByName(parser).disambiguate(text)
         return parser
     
     @classmethod

--- a/pyzo/codeeditor/manager.py
+++ b/pyzo/codeeditor/manager.py
@@ -263,6 +263,7 @@ class Manager:
         parser = cls.suggestParserfromText(text)
         if parser == "" :
             parser = cls.suggestParserfromFilenameExtension(ext)
+        parser = cls.getParserName(cls.getParserByName(parser).disambiguate(text))
         return parser
     
     @classmethod

--- a/pyzo/codeeditor/parsers/__init__.py
+++ b/pyzo/codeeditor/parsers/__init__.py
@@ -79,8 +79,17 @@ class Parser(object):
     _keywords = []
     
     @classmethod
+    def getParserName(cls) :
+        name = cls.__name__
+        if name.endswith('Parser') and len(name)>6:
+
+            # Get parser identifier name
+            name = name[:-6].lower()
+        return name
+
+    @classmethod
     def disambiguate(cls, text) :
-        return cls
+        return cls.getParserName()
     
     def parseLine(self, line, previousState=0):
         """ parseLine(line, previousState=0)

--- a/pyzo/codeeditor/parsers/__init__.py
+++ b/pyzo/codeeditor/parsers/__init__.py
@@ -78,6 +78,9 @@ class Parser(object):
     _shebangKeywords = []
     _keywords = []
     
+    @classmethod
+    def disambiguate(cls, text) :
+        return cls
     
     def parseLine(self, line, previousState=0):
         """ parseLine(line, previousState=0)

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -149,15 +149,15 @@ endProgs = {
 
 
 class PythonParser(Parser):
-    """ Parser for Python in general (2.x or 3.x).
+    """ Parser for Python in general.
     """
-    _extensions = ['.py' , '.pyw']
-    _shebangKeywords = ["python", "python3", "python2"]
+    _extensions = []
+    _shebangKeywords = []
     # The list of keywords is overridden by the Python2/3 specific parsers
-    _keywords = pythonKeywords
+    _keywords = set()
     # The list of builtins and instances is overridden by the Python2/3 specific parsers
-    _builtins = pythonBuiltins
-    _instance = pythonInstance
+    _builtins = set()
+    _instance = set()
     
     
     def _identifierState(self, identifier=None):
@@ -402,13 +402,27 @@ class PythonParser(Parser):
         # Done
         return tokens
 
+class AmbiguousPythonParser(PythonParser):
+    """ Parser for either Python2 or Python3, and we do not know which.
+    """
+    _extensions = ['.py', '.pyw']
+    _shebangKeywords = ['python']
+    # The list of keywords is overridden by the Python2/3 specific parsers
+    _keywords = pythonKeywords
+    # The list of builtins and instances is overridden by the Python2/3 specific parsers
+    _builtins = pythonBuiltins
+    _instance = pythonInstance
+
+    @classmethod
+    def disambiguate(cls, text) :
+        return cls
 
 class Python2Parser(PythonParser):
     """ Parser for Python 2.x code.
     """
     # The application should choose whether to set the Py 2 specific parser
     _extensions = []
-    _shebangKeywords = []
+    _shebangKeywords = ["python2"]
     _keywords = python2Keywords
     _builtins = python2Builtins
     _instance = python2Instance
@@ -419,7 +433,7 @@ class Python3Parser(PythonParser):
     """
     # The application should choose whether to set the Py 3 specific parser
     _extensions = []
-    _shebangKeywords = []
+    _shebangKeywords = ["python3"]
     _keywords = python3Keywords
     _builtins = python3Builtins
     _instance = python3Instance

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -8,6 +8,7 @@ import re
 from . import Parser, BlockState, text_type
 from .tokens import ALPHANUM
 from ..misc import ustr
+import pyzo
 
 # Import tokens in module namespace
 from .tokens import (CommentToken, StringToken,
@@ -415,7 +416,10 @@ class AmbiguousPythonParser(PythonParser):
 
     @classmethod
     def disambiguate(cls, text) :
-        return cls
+        # try to look into the source...
+        
+        # if this is inconclusive, use settings.pythonDefaultDisambiguation
+        return pyzo.config.settings.pythonDefaultDisambiguation
 
 class Python2Parser(PythonParser):
     """ Parser for Python 2.x code.

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -999,6 +999,9 @@ class PythonShell(BaseShell):
         # Store info so we can reuse it on a restart
         self._info = info
         
+        parser = info.parser if "parser" in info else pyzo.config.settings.defaultStyle
+        self.setParser(parser)
+
         # For the editor to keep track of attempted imports
         self._importAttempts = []
         

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -999,7 +999,10 @@ class PythonShell(BaseShell):
         # Store info so we can reuse it on a restart
         self._info = info
         
-        parser = info.parser if "parser" in info else pyzo.config.settings.defaultStyle
+        if "parser" in info and info.parser != '' :
+            parser = info.parser
+        else :
+            parser = pyzo.config.settings.defaultStyle
         self.setParser(parser)
 
         # For the editor to keep track of attempted imports

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -55,7 +55,7 @@ class ShellInfo_parser(ShellInfoLineEdit):
     def __init__(self, *args, **kwargs):
         ShellInfoLineEdit.__init__(self, *args, **kwargs)
         t = translate('shell', 'parser ::: The name of the parser to use for highlighting.')
-        self.setPlaceholderText(t.tt)
+        self.setPlaceholderText("Typically python3 or python2")
     
     def setTheText(self, value):
         ShellInfoLineEdit.setTheText(self, value)

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -50,7 +50,18 @@ class ShellInfo_name(ShellInfoLineEdit):
     def onValueChanged(self):
         self.parent().parent().parent().setTabTitle(self.getTheText())
 
-
+class ShellInfo_parser(ShellInfoLineEdit):
+    
+    def __init__(self, *args, **kwargs):
+        ShellInfoLineEdit.__init__(self, *args, **kwargs)
+        t = translate('shell', 'parser ::: The name of the parser to use for highlighting.')
+        self.setPlaceholderText(t.tt)
+    
+    def setTheText(self, value):
+        ShellInfoLineEdit.setTheText(self, value)
+    
+    def getTheText(self) :
+        return self.text().strip()
 
 class ShellInfo_exe(QtWidgets.QComboBox):
     
@@ -474,6 +485,7 @@ class ShellInfoTab(QtWidgets.QScrollArea):
     
     INFO_KEYS = [   translate('shell', 'name ::: The name of this configuration.'),
                     translate('shell', 'exe ::: The Python executable.'),
+                    translate('shell', 'parser ::: The name of the parser to use for highlighting.'),
                     translate('shell', 'ipython ::: Use IPython shell if available.'),
                     translate('shell', 'gui ::: The GUI toolkit to integrate (for interactive plotting, etc.).'),
                     translate('shell', 'pythonPath ::: A list of directories to search for modules and packages. Write each path on a new line, or separate with the default seperator for this OS.'),  # noqa

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -41,7 +41,7 @@ view = dict:
 
 settings= dict:
     language = ''
-    defaultStyle = 'python'
+    defaultStyle = 'python3'
     defaultIndentWidth = 4
     defaultIndentUsingSpaces = 1
     defaultLineEndings = '' # Set depending on OS

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -42,6 +42,7 @@ view = dict:
 settings= dict:
     language = ''
     defaultStyle = 'python3'
+    pythonDefaultDisambiguation='python3'
     defaultIndentWidth = 4
     defaultIndentUsingSpaces = 1
     defaultLineEndings = '' # Set depending on OS


### PR DESCRIPTION
Currently, there is a generic Python parser that has the reunion of the keywords of Python 2 and Python 3. 
In fact this parser is used more frequently than either the specific Python 2 and Python 3 parser due to the detection process.

This is problematic because there does not actually exist a generic Python language. Especially, this generic-python parser will typeset ``print`` as a keyword (like Python 2) although it really is just a function in Python 3. This is misleading for students, who sometimes struggle to understand the difference between a keyword and an identifier, as well as between the semantics of ``print`` and ``return``.

My proposal is to explicitly label such cases as _ambiguous_ rather than _generic_, to try to limit such cases, and, at least in the case of a newly created file, default to Python 3.

To achieve this, I first prioritise the shebang analysis I introduced last year over the filename analysis (in line with the usual unix practices).

I then transform the PythonParser base class into a class that has no keyword instead of the reunion of Python2 and Python3 (we might use the intersection of these keywords sets), add an AmbiguousPythonParser class to serve the old purpose of PythonParser.

I also introduce a mechanism by which a Parser has a [``disambiguate``](https://github.com/pyzo/pyzo/pull/613/files#diff-6f3fb159ab8a06faab8afd3fb5f9ddf2R81) class method taking the text of the code and where we could use rules of thumb to choose between Python2 and Python3. This is the WIP part, for now [this method](https://github.com/pyzo/pyzo/pull/613/commits/dc30bcab544e1ee3cb6124fe59bd36480b88702c#diff-77762366107855b600578ac03a3cf662R417) is just the identity.

This requires a bit of back-and-forth between parser classes and parser names in [``suggestParser``](https://github.com/pyzo/pyzo/pull/613/files#diff-77a55db0c20e5d404787f49d717f98f1R266).

What is your opinion on this ?