### PR TITLE
Fixing advsettings

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -2504,17 +2504,16 @@ class AdvancedSettings(QtWidgets.QDialog):
         """ Save new settings. """
         parent = None
         node = None
-
         if column == 1:
             # node, parent
             parent = item.parent()
-            parent_val = self.tree.indexFromItem(parent, 0).data()
+            parent_val = self._tree.indexFromItem(parent, 0).data()
             node = parent.parent()
-            node_val = self.tree.indexFromItem(node, 0).data()
+            node_val = self._tree.indexFromItem(node, 0).data()
             # key, value
-            key = self.tree.indexFromItem(item, 0).data()
-            value = self.tree.indexFromItem(item, 1).data()
-            typ = self.tree.indexFromItem(item, 2).data()
+            key = self._tree.indexFromItem(item, 0).data()
+            value = self._tree.indexFromItem(item, 1).data()
+            typ = self._tree.indexFromItem(item, 2).data()
 
             # convert type
             if typ is not type(value):

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -2329,25 +2329,21 @@ class AdvancedSettings(QtWidgets.QDialog):
         if not os.path.exists(self.backup_file):
             self.backupConfig()
 
-        text = """
-        Before you begin, backup your settings. To modify an existing setting, click on the value
-        to change it. Note that most settings require a restart for the change to take effect.
-        """
-
         # Set title
         self.setWindowTitle(translate("menu dialog", 'Advanced Settings'))
 
         # Set dialog size
-        size = 800, 600
+        size = 1000, 600
         offset = 0
         size2 = size[0], size[1] + offset
         self.resize(*size2)
-        self.setMaximumSize(*size2)
         self.setMinimumSize(*size2)
         
         # Label
+        text = "Before you begin, backup your settings. To modify an existing setting, click on the value to change it.\nNote that most settings require a restart for the change to take effect."
         self._label = QtWidgets.QLabel(self)
-        self._label.setText(text)
+        self._label.setWordWrap(True)
+        self._label.setText(translate("menu dialog", text))
         
         # Folding buttons
         
@@ -2441,8 +2437,8 @@ class AdvancedSettings(QtWidgets.QDialog):
         self._tree.expandAll()
         
     def searchTextChanged(self):
-        """ As you type hide unmached settings. """
-        # find all mached settings
+        """ As you type hide unmatched settings. """
+        # find all matched settings
         find = self._tree.findItems(self._search.text(), QtCore.Qt.MatchContains | QtCore.Qt.MatchRecursive, 0)
         items = [i.text(0) for i in find]
         


### PR DESCRIPTION
Turns out the Advanced Settings dialog is completely broken ! There is a typo in the code that prevents any actual setting update. Also made help text word-wrap and be translatable, and making the dialog resizable by the user.