### PR TITLE
Highlighting non-breakable spaces

### DIFF
--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -225,6 +225,16 @@ class CodeEditorBase(QtWidgets.QPlainTextEdit):
         # Apply a good default style
         self.setStyle(S)
     
+     # see https://bugreports.qt.io/browse/QTBUG-57552?focusedCommentId=469402&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-469402
+     # and https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qtextdocument.cpp#n1183
+     # and https://doc.qt.io/qt-5/qchar.html
+    _plainTextTrans = str.maketrans({"\u2029":"\n", "\u2028":"\n", "\ufdd0":"\n", "\ufdd1":"\n"})
+    
+    def toPlainText(self) :
+        cursor = self.textCursor()
+        cursor.select(QtGui.QTextCursor.Document)
+        return cursor.selectedText().translate(self._plainTextTrans)
+    
     def _setHighlighter(self, highlighterClass):
         self.__highlighter = highlighterClass(self, self.document())
        

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -13,7 +13,7 @@ from ..misc import ustr
 from .tokens import (CommentToken, StringToken,
     UnterminatedStringToken, IdentifierToken, NonIdentifierToken,
     KeywordToken, BuiltinsToken, InstanceToken, NumberToken, FunctionNameToken, ClassNameToken,
-    TodoCommentToken, OpenParenToken, CloseParenToken)
+    TodoCommentToken, OpenParenToken, CloseParenToken, IllegalToken)
 
 # Keywords sets
 
@@ -131,7 +131,8 @@ tokenProg = re.compile(
     '("""|\'\'\'|"|\')' +		# String start (triple qoutes first, group 4)
     ')|' +						# End of string group
     '(\(|\[|\{)|' +             # Opening parenthesis (gr 5)
-    '(\)|\]|\})'                # Closing parenthesis (gr 6)
+    '(\)|\]|\})|' +              # Closing parenthesis (gr 6)
+    '('+chr(160)+')'                         # non-breaking space (gr 7)
     )
 
 
@@ -398,6 +399,10 @@ class PythonParser(Parser):
         elif match.group(6) is not None :
             token = CloseParenToken(line, match.start(), match.end())
             token._style = match.group(6)
+            tokens.append(token)
+        elif match.group(7) is not None :
+            token = IllegalToken(line, match.start(), match.end())
+            token._style = match.group(7)
             tokens.append(token)
         # Done
         return tokens

--- a/pyzo/codeeditor/parsers/tokens.py
+++ b/pyzo/codeeditor/parsers/tokens.py
@@ -163,5 +163,7 @@ class CloseParenToken(ParenthesisToken) :
     """ Closing parenthesis (and square and curly brackets). """
     defaultStyle = ''
 
-
+class IllegalToken(Token) :
+    """ Illegal tokens, eg. NBSP  . """
+    defaultStyle = 'back:#ffd7c7'
 

--- a/pyzo/codeeditor/style.py
+++ b/pyzo/codeeditor/style.py
@@ -247,6 +247,10 @@ class StyleFormat:
         if self._textCharFormat is None:
             self._textCharFormat = QtGui.QTextCharFormat()
             self._textCharFormat.setForeground(self.fore)
+            try :  # not all styles have a back property
+                self._textCharFormat.setBackground(self.back)
+            except :
+                pass
             self._textCharFormat.setUnderlineStyle(self.underline)
             if self.bold:
                 self._textCharFormat.setFontWeight(QtGui.QFont.Bold)

--- a/pyzo/codeeditor/style.py
+++ b/pyzo/codeeditor/style.py
@@ -127,7 +127,7 @@ class StyleFormat:
         try:
             return self._parts[key]
         except KeyError:
-            raise KeyError('Invalid part key for style format.')
+            raise KeyError('Invalid part key ' + key + ' for style format.')
     
     def __iter__(self):
         """ Yields a series of tuples (key, val).

--- a/pyzo/core/themeEdit.py
+++ b/pyzo/core/themeEdit.py
@@ -373,7 +373,10 @@ class ThemeEditorWidget(QtWidgets.QWidget):
         self.curThemeCmb.setEditable(not self.cur_theme["builtin"])
         
         for key, le in self.styleEdits.items():
-            le.setStyle(self.cur_theme["data"][key])
+            try :
+                le.setStyle(self.cur_theme["data"][key])
+            except Exception as e :
+                print("Exception while setting style", key, "for theme", name, ":", e)
     
     def saveTheme(self):
         """ Saves the current theme to the disk, in appDataDir/themes """        

--- a/pyzo/core/themeEdit.py
+++ b/pyzo/core/themeEdit.py
@@ -19,7 +19,7 @@ class Foo:
         def baz(self, arg1):
             return max(arg1, 42)
     bar = "Hello wor
-"""
+"""+chr(160)
 
 
 class FakeEditor(pyzo.core.baseTextCtrl.BaseTextCtrl):


### PR DESCRIPTION
This creates a new token type, IllegalToken, to represent characters that may not appear in Python identifiers (currently, only nbsp will be parsed as such). The default style of this token type is a reddish background.

Consequently, this also fixes some bugs related to background color for characters in editors (the property was not applied !). However, the interaction between styles and the theme editor when adding a new style category remains a mystery for me.

This also fixes an anomalous yet documented behaviour of QtPlainText.toPlainText where nbsp are replaced by regular spaces : this affected us on saving the document.