### PR TITLE
ShowWhitespace and HighlightMatchingBracket options for shell

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -136,7 +136,7 @@ class _ParenIterator :
         try:
             return list(filter(lambda x : isinstance(x, ParenthesisToken), self.cur_block.userData().tokens))
         except AttributeError:
-            return []  # can be a piece of text that we do not tokenize (e.g. in shell)
+            return []  # can be a piece of text that we do not tokenize or have not stored tokens
     
     def __iter__(self) :
         return self

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -211,7 +211,9 @@ class BaseTextCtrl(codeeditor.CodeEditor):
         # Set font and zooming
         self.setFont(pyzo.config.view.fontname)
         self.setZoom(pyzo.config.view.zoom)
-        
+        self.setShowWhitespace(pyzo.config.view.showWhitespace)
+        self.setHighlightMatchingBracket(pyzo.config.view.highlightMatchingBracket)
+
         # Create timer for autocompletion delay
         self._delayTimer = QtCore.QTimer(self)
         self._delayTimer.setSingleShot(True)

--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -265,7 +265,6 @@ class PyzoEditor(BaseTextCtrl):
         self._name = '<TMP>'
 
         # View settings
-        self.setShowWhitespace(pyzo.config.view.showWhitespace)
         #TODO: self.setViewWrapSymbols(view.showWrapSymbols)
         self.setShowLineEndings(pyzo.config.view.showLineEndings)
         self.setShowIndentationGuides(pyzo.config.view.showIndentationGuides)
@@ -273,7 +272,6 @@ class PyzoEditor(BaseTextCtrl):
         self.setWrap(bool(pyzo.config.view.wrap))
         self.setHighlightCurrentLine(pyzo.config.view.highlightCurrentLine)
         self.setLongLineIndicatorPosition(pyzo.config.view.edgeColumn)
-        self.setHighlightMatchingBracket(pyzo.config.view.highlightMatchingBracket)
         #TODO: self.setFolding( int(view.codeFolding)*5 )
         # bracematch is set in baseTextCtrl, since it also applies to shells
         # dito for zoom and tabWidth

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -774,7 +774,7 @@ class ViewMenu(Menu):
             icons.application_double, pyzo.editors._tabs.selectPreviousItem)
         self.addSeparator()
         self.addEditorItem(translate("menu", "Show whitespace ::: Show spaces and tabs."),
-            None, "showWhitespace")
+            None, "showWhitespace", True)
         self.addEditorItem(translate("menu", "Show line endings ::: Show the end of each line."),
             None, "showLineEndings")
         self.addEditorItem(translate("menu", "Show indentation guides ::: Show vertical lines to indicate indentation."),
@@ -785,7 +785,7 @@ class ViewMenu(Menu):
         self.addEditorItem(translate("menu", "Highlight current line ::: Highlight the line where the cursor is."),
             None, "highlightCurrentLine")
         self.addEditorItem(translate("menu", "Highlight brackets ::: Highlight matched and unmatched brackets."),
-            None, "highlightMatchingBracket")
+            None, "highlightMatchingBracket", True)
         self.addSeparator()
         self.addItem(translate("menu", "Previous cell ::: Go back to the previous cell."),
             None, self._previousCell )

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -801,7 +801,7 @@ class ViewMenu(Menu):
         self.addMenu(ZoomMenu(self, translate("menu", "Zooming")), icons.magnifier)
         self.addMenu(self._qtThemeMenu, icons.application_view_tile)
     
-    def addEditorItem(self, name, icon, param):
+    def addEditorItem(self, name, icon, param, shellsToo = False):
         """
         Create a boolean item that reperesents a property of the editors,
         whose value is stored in pyzo.config.view.param
@@ -811,9 +811,9 @@ class ViewMenu(Menu):
         else:
             default = True
             
-        self.addCheckItem(name, icon, self._configEditor, param, default)
+        self.addCheckItem(name, icon, lambda state, param : self._configEditor(state, param, shellsToo), param, default)
     
-    def _configEditor(self, state, param):
+    def _configEditor(self, state, param, shellsToo = False):
         """
         Callback for addEditorItem items
         """
@@ -823,6 +823,9 @@ class ViewMenu(Menu):
         setter = 'set' + param[0].upper() + param[1:]
         for editor in pyzo.editors:
             getattr(editor,setter)(state)
+        if shellsToo :
+            for shell in pyzo.shells :
+                getattr(shell,setter)(state)
     
     def _selectShell(self):
         shell = pyzo.shells.getCurrentShell()

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -148,6 +148,8 @@ class ShellHighlighter(Highlighter):
             # Do not highlight anything but current and last prompts
             return
         
+        # Get user data
+        bd = self.getCurrentBlockUserData()
         
         if parser:
             if atCurrentPrompt:
@@ -164,7 +166,9 @@ class ShellHighlighter(Highlighter):
             if specialinput:
                 pass # Let the kernel decide formatting
             else:
-                for token in parser.parseLine(line, previousState):
+                tokens = list(parser.parseLine(line, previousState))
+                bd.tokens = tokens
+                for token in tokens :
                     # Handle block state
                     if isinstance(token, parsers.BlockState):
                         self.setCurrentBlockState(token.state)
@@ -189,8 +193,6 @@ class ShellHighlighter(Highlighter):
         #Get the indentation setting of the editors
         indentUsingSpaces = self._codeEditor.indentUsingSpaces()
         
-        # Get user data
-        bd = self.getCurrentBlockUserData()
         
         leadingWhitespace=line[:len(line)-len(line.lstrip())]
         if '\t' in leadingWhitespace and ' ' in leadingWhitespace:


### PR DESCRIPTION
This shuffles options management a little so that ShowWhitespace and HightLightMatchingBracket are also applied to shells, not only code editors.

This adds support for highlighting matching brackets in shell : in fact the heavy work (parsing the line to get tokens) was already done, the tokens were just not stored in the block's userData.