### PR TITLE
Tweaks after #613

### DIFF
--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -8,7 +8,6 @@ import re
 from . import Parser, BlockState, text_type
 from .tokens import ALPHANUM
 from ..misc import ustr
-import pyzo
 
 # Import tokens in module namespace
 from .tokens import (CommentToken, StringToken,
@@ -417,9 +416,8 @@ class AmbiguousPythonParser(PythonParser):
     @classmethod
     def disambiguate(cls, text) :
         # try to look into the source...
-        
-        # if this is inconclusive, use settings.pythonDefaultDisambiguation
-        return pyzo.config.settings.pythonDefaultDisambiguation
+        # or ... well, ppl should use Python3. Use a shebang to annotate a Python file as Python 2
+        return "python3"
 
 class Python2Parser(PythonParser):
     """ Parser for Python 2.x code.

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1001,12 +1001,6 @@ class PythonShell(BaseShell):
         # Store info so we can reuse it on a restart
         self._info = info
         
-        if "parser" in info and info.parser != '' :
-            parser = info.parser
-        else :
-            parser = pyzo.config.settings.defaultStyle
-        self.setParser(parser)
-
         # For the editor to keep track of attempted imports
         self._importAttempts = []
         
@@ -1139,6 +1133,10 @@ class PythonShell(BaseShell):
         # Set version
         version = startup_info.get('version', None)
         if isinstance(version, tuple):
+            if version < (3, ):
+                self.setParser("python2")
+            else:
+                self.setParser("python3")
             version = [str(v) for v in version]
             self._version = '.'.join(version[:2])
         

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -50,18 +50,6 @@ class ShellInfo_name(ShellInfoLineEdit):
     def onValueChanged(self):
         self.parent().parent().parent().setTabTitle(self.getTheText())
 
-class ShellInfo_parser(ShellInfoLineEdit):
-    
-    def __init__(self, *args, **kwargs):
-        ShellInfoLineEdit.__init__(self, *args, **kwargs)
-        t = translate('shell', 'parser ::: The name of the parser to use for highlighting.')
-        self.setPlaceholderText(translate('shell', "Typically python3 or python2"))
-    
-    def setTheText(self, value):
-        ShellInfoLineEdit.setTheText(self, value)
-    
-    def getTheText(self) :
-        return self.text().strip()
 
 class ShellInfo_exe(QtWidgets.QComboBox):
     
@@ -485,7 +473,6 @@ class ShellInfoTab(QtWidgets.QScrollArea):
     
     INFO_KEYS = [   translate('shell', 'name ::: The name of this configuration.'),
                     translate('shell', 'exe ::: The Python executable.'),
-                    translate('shell', 'parser ::: The name of the parser to use for highlighting.'),
                     translate('shell', 'ipython ::: Use IPython shell if available.'),
                     translate('shell', 'gui ::: The GUI toolkit to integrate (for interactive plotting, etc.).'),
                     translate('shell', 'pythonPath ::: A list of directories to search for modules and packages. Write each path on a new line, or separate with the default seperator for this OS.'),  # noqa

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -3,7 +3,7 @@
 
 # Some parameters are named xxx2. This was done in case the representation
 # of a parameter was changed, or if we wanted to "refresh" the parameter for
-# another reason. This enables using the same config file for all versions, 
+# another reason. This enables using the same config file for all versions,
 # which means that users that start using a new version dont have to recreate
 # all their settings each time.
 
@@ -15,11 +15,11 @@ state = dict:
     find_autoHide = 1
     editorState2 = [] # What files where loaded and where the cursor was
     loadedTools = []
-    windowState = '' # Of window and tools  
+    windowState = '' # Of window and tools
     windowGeometry = '' # Position and size of window, whether maximized, etc.
     newUser = 1 # So we can guide new users a bit
 
-view = dict:       
+view = dict:
     showWhitespace = 0
     showLineEndings = 0
     showWrapSymbols = 0
@@ -34,7 +34,7 @@ view = dict:
     autoComplete_popupSize = [300, 100]
     #
     qtstyle = ''
-    edgeColumn = 80    
+    edgeColumn = 80
     fontname = 'DejaVu Sans Mono'
     zoom = 0  # Both for editor and shell
     tabWidth = 4
@@ -42,7 +42,6 @@ view = dict:
 settings= dict:
     language = ''
     defaultStyle = 'python3'
-    pythonDefaultDisambiguation='python3'
     defaultIndentWidth = 4
     defaultIndentUsingSpaces = 1
     defaultLineEndings = '' # Set depending on OS
@@ -69,7 +68,7 @@ advanced = dict:
     titleText = '{fileName} ({fullPath}) - Interactive Editor for Python'
     homeAndEndWorkOnDisplayedLine = 0
     find_autoHide_timeout = 10
-  
+
 tools = dict:
     pyzologger = dict:
     pyzointeractivehelp = dict:


### PR DESCRIPTION
Post- #613 tweaks.

Remove reference to `pyzo` in `codeeditor` (we try to keep that part free from Pyzo logic). This means we cannot use Pyzo config here ...  we could move the default disambiguation somewhere else, but I do not think that is necessary; you're right, ppl should use Python 3. And those who use Python 2, can use a shebang to mark the code at Python 2. We might implement/improve `AmbiguousPythonParser.disambiguate()` at some point to detect Python 2 files, if needed.

Instead of letting the user mark interpreters as either Python 2 or Python 3, we can just check the version info that we get from the kernel.