### PR TITLE
respecting option for removing trailing whitespace on save

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -499,7 +499,7 @@ class PyzoEditor(BaseTextCtrl):
             return
 
         # Remove whitespace in a single undo-able action
-        if self.removeTrailingWS or pyzo.config.settings.removeTrailingWhitespaceWhenSaving:
+        if self.removeTrailingWS and pyzo.config.settings.removeTrailingWhitespaceWhenSaving:
             # Original cursor to put state back at the end
             oricursor = self.textCursor()
             # Screen cursor to select document


### PR DESCRIPTION
Previously, the editor would always strip trailing whitespace on save, even when the setting is set to 0, because the setting is compared using `or` rather than `and`. This PR fixes this.