### PR TITLE
Unify margins between gui elements editor, shell and plugins #627

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -995,8 +995,8 @@ class EditorTabs(QtWidgets.QWidget):
         # spacing of widgets
         self._boxLayout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        self._boxLayout.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        self._boxLayout.setContentsMargins(margin, margin, margin, margin)
         # apply
         self.setLayout(self._boxLayout)
         

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -994,6 +994,9 @@ class EditorTabs(QtWidgets.QWidget):
         self._boxLayout.addWidget(self._findReplace, 0)
         # spacing of widgets
         self._boxLayout.setSpacing(0)
+        # set margins
+        margins = pyzo.config.view.margins
+        self._boxLayout.setContentsMargins(*margins)
         # apply
         self.setLayout(self._boxLayout)
         

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -995,7 +995,7 @@ class EditorTabs(QtWidgets.QWidget):
         # spacing of widgets
         self._boxLayout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         self._boxLayout.setContentsMargins(*margins)
         # apply
         self.setLayout(self._boxLayout)

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -669,7 +669,7 @@ class ZoomMenu(Menu):
             pyzo.config.view.zoom = shell.setZoom(pyzo.config.view.zoom)
         logger = pyzo.toolManager.getTool('pyzologger')
         if logger:
-            logger.setZoom(pyzo.config.view.zoom)
+            logger.updateZoom()
 
 
 class FontMenu(Menu):
@@ -698,7 +698,7 @@ class FontMenu(Menu):
             shell.setFont(pyzo.config.view.fontname)
         logger = pyzo.toolManager.getTool('pyzologger')
         if logger:
-            logger.setFont(pyzo.config.view.fontname)
+            logger.updateFont()
 
 
 # todo: brace matching

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -109,7 +109,10 @@ class ShellStackWidget(QtWidgets.QWidget):
         # widget layout
         layout = QtWidgets.QVBoxLayout()
         layout.setSpacing(0)
-        layout.setContentsMargins(0, 0, 0, 0)
+        # set margins
+        margins = pyzo.config.view.margins
+        layout.setContentsMargins(*margins)
+        
         layout.addWidget(self._toolbar)
         layout.addWidget(self._stack, 0)
         layout.addWidget(self._interpreterhelp, 0)

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -110,8 +110,8 @@ class ShellStackWidget(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout()
         layout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        layout.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        layout.setContentsMargins(margin, margin, margin, margin)
         
         layout.addWidget(self._toolbar)
         layout.addWidget(self._stack, 0)

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -110,7 +110,7 @@ class ShellStackWidget(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout()
         layout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         layout.setContentsMargins(*margins)
         
         layout.addWidget(self._toolbar)

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -38,6 +38,7 @@ view = dict:
     fontname = 'DejaVu Sans Mono'
     zoom = 0  # Both for editor and shell
     tabWidth = 4
+    margins = [4,4,4,4]
 
 settings= dict:
     language = ''

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -38,7 +38,7 @@ view = dict:
     fontname = 'DejaVu Sans Mono'
     zoom = 0  # Both for editor and shell
     tabWidth = 4
-    margins = [4,4,4,4]
+    widgetMargins = [4,4,4,4]
 
 settings= dict:
     language = ''

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -38,7 +38,7 @@ view = dict:
     fontname = 'DejaVu Sans Mono'
     zoom = 0  # Both for editor and shell
     tabWidth = 4
-    widgetMargins = [4,4,4,4]
+    widgetMargin = 4
 
 settings= dict:
     language = ''

--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -104,8 +104,8 @@ class PyzoFileBrowser(QtWidgets.QWidget):
         layout.addWidget(self._browsers[0])
         layout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        layout.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        layout.setContentsMargins(margin, margin, margin, margin)
     
     
     def path(self):

--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -103,7 +103,9 @@ class PyzoFileBrowser(QtWidgets.QWidget):
         self.setLayout(layout)
         layout.addWidget(self._browsers[0])
         layout.setSpacing(0)
-        layout.setContentsMargins(4,4,4,4)
+        # set margins
+        margins = pyzo.config.view.margins
+        layout.setContentsMargins(*margins)
     
     
     def path(self):

--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -104,7 +104,7 @@ class PyzoFileBrowser(QtWidgets.QWidget):
         layout.addWidget(self._browsers[0])
         layout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         layout.setContentsMargins(*margins)
     
     

--- a/pyzo/tools/pyzoHistoryViewer.py
+++ b/pyzo/tools/pyzoHistoryViewer.py
@@ -50,8 +50,8 @@ class PyzoHistoryViewer(QtWidgets.QWidget):
         layout.addWidget(self._search, 0)
         layout.addWidget(self._list, 1)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        layout.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        layout.setContentsMargins(margin, margin, margin, margin)
         
         # Customize line edit
         self._search.setPlaceholderText(translate('menu', 'Search'))

--- a/pyzo/tools/pyzoHistoryViewer.py
+++ b/pyzo/tools/pyzoHistoryViewer.py
@@ -50,7 +50,7 @@ class PyzoHistoryViewer(QtWidgets.QWidget):
         layout.addWidget(self._search, 0)
         layout.addWidget(self._list, 1)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         layout.setContentsMargins(*margins)
         
         # Customize line edit

--- a/pyzo/tools/pyzoHistoryViewer.py
+++ b/pyzo/tools/pyzoHistoryViewer.py
@@ -49,6 +49,9 @@ class PyzoHistoryViewer(QtWidgets.QWidget):
         self.setLayout(layout)
         layout.addWidget(self._search, 0)
         layout.addWidget(self._list, 1)
+        # set margins
+        margins = pyzo.config.view.margins
+        layout.setContentsMargins(*margins)
         
         # Customize line edit
         self._search.setPlaceholderText(translate('menu', 'Search'))

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -88,7 +88,7 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
         #
         self._sizer1.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         self._sizer1.setContentsMargins(*margins)
         
         self.setLayout(self._sizer1)

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -88,8 +88,8 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
         #
         self._sizer1.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        self._sizer1.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        self._sizer1.setContentsMargins(margin, margin, margin, margin)
         
         self.setLayout(self._sizer1)
         

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -87,7 +87,10 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
         self._sizer1.addWidget(self._browser, 1)
         #
         self._sizer1.setSpacing(2)
-        self._sizer1.setContentsMargins(4,4,4,4)
+        # set margins
+        margins = pyzo.config.view.margins
+        self._sizer1.setContentsMargins(*margins)
+        
         self.setLayout(self._sizer1)
         
         # Set config

--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -34,8 +34,8 @@ class PyzoLogger(QtWidgets.QWidget):
         # spacing of widgets
         self.layout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        self.layout.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        self.layout.setContentsMargins(margin, margin, margin, margin)
         self.setLayout(self.layout)
 
     def updateZoom(self):

--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -20,23 +20,30 @@ class PyzoLogger(QtWidgets.QWidget):
 
         The main widget for this tool.
 
-        """
-    
+    """
+
     def __init__(self, parent):
         QtWidgets.QWidget.__init__(self, parent)
 
         # logger widget
         self._logger_shell = PyzoLoggerShell(self)
-
+        
         # set layout
         self.layout = QtWidgets.QVBoxLayout(self)
         self.layout.addWidget(self._logger_shell, 1)
         # spacing of widgets
         self.layout.setSpacing(0)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         self.layout.setContentsMargins(*margins)
         self.setLayout(self.layout)
+
+    def updateZoom(self):
+        self._logger_shell.setZoom(pyzo.config.view.zoom)
+
+    def updateFont(self):
+        self._logger_shell.setFont(pyzo.config.view.fontname)
+        
  
 
 class PyzoLoggerShell(BaseShell):

--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -6,17 +6,40 @@
 
 
 import sys, os, code
-
 import pyzo
+from pyzo.util.qt import QtCore, QtGui, QtWidgets  # noqa
 from pyzo.core.shell import BaseShell
 from pyzo.core.pyzoLogging import splitConsole
 
-
 tool_name = pyzo.translate("pyzoLogger","Logger")
 tool_summary = "Logs messages, warnings and errors within Pyzo."
+
+
+class PyzoLogger(QtWidgets.QWidget):
+    """ PyzoLogger
+
+        The main widget for this tool.
+
+        """
+    
+    def __init__(self, parent):
+        QtWidgets.QWidget.__init__(self, parent)
+
+        # logger widget
+        self._logger_shell = PyzoLoggerShell(self)
+
+        # set layout
+        self.layout = QtWidgets.QVBoxLayout(self)
+        self.layout.addWidget(self._logger_shell, 1)
+        # spacing of widgets
+        self.layout.setSpacing(0)
+        # set margins
+        margins = pyzo.config.view.margins
+        self.layout.setContentsMargins(*margins)
+        self.setLayout(self.layout)
  
 
-class PyzoLogger(BaseShell):
+class PyzoLoggerShell(BaseShell):
     """ Shell that logs all messages produced by pyzo. It also
     allows to look inside pyzo, which can be handy for debugging
     and developing.

--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -88,8 +88,8 @@ class PyzoSourceStructure(QtWidgets.QWidget):
         self._sizer2 = QtWidgets.QHBoxLayout()
         self._sizer1.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        self._sizer1.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        self._sizer1.setContentsMargins(margin, margin, margin, margin)
         
         # Set layout
         self._sizer1.addLayout(self._sizer2, 0)

--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -88,7 +88,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
         self._sizer2 = QtWidgets.QHBoxLayout()
         self._sizer1.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         self._sizer1.setContentsMargins(*margins)
         
         # Set layout

--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -87,7 +87,9 @@ class PyzoSourceStructure(QtWidgets.QWidget):
         self._sizer1 = QtWidgets.QVBoxLayout(self)
         self._sizer2 = QtWidgets.QHBoxLayout()
         self._sizer1.setSpacing(2)
-        self._sizer1.setContentsMargins(4,4,4,4)
+        # set margins
+        margins = pyzo.config.view.margins
+        self._sizer1.setContentsMargins(*margins)
         
         # Set layout
         self._sizer1.addLayout(self._sizer2, 0)

--- a/pyzo/tools/pyzoWebBrowser.py
+++ b/pyzo/tools/pyzoWebBrowser.py
@@ -211,8 +211,8 @@ class PyzoWebBrowser(QtWidgets.QFrame):
         #
         self._sizer1.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        self._sizer1.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        self._sizer1.setContentsMargins(margin, margin, margin, margin)
 
         self.setLayout(self._sizer1)
         

--- a/pyzo/tools/pyzoWebBrowser.py
+++ b/pyzo/tools/pyzoWebBrowser.py
@@ -210,6 +210,10 @@ class PyzoWebBrowser(QtWidgets.QFrame):
         self._sizer1.addWidget(self._view, 1)
         #
         self._sizer1.setSpacing(2)
+        # set margins
+        margins = pyzo.config.view.margins
+        self._sizer1.setContentsMargins(*margins)
+
         self.setLayout(self._sizer1)
         
         # Bind signals

--- a/pyzo/tools/pyzoWebBrowser.py
+++ b/pyzo/tools/pyzoWebBrowser.py
@@ -211,7 +211,7 @@ class PyzoWebBrowser(QtWidgets.QFrame):
         #
         self._sizer1.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         self._sizer1.setContentsMargins(*margins)
 
         self.setLayout(self._sizer1)

--- a/pyzo/tools/pyzoWorkspace.py
+++ b/pyzo/tools/pyzoWorkspace.py
@@ -375,8 +375,8 @@ Currently, there are none. Some of them may be hidden because of the filters you
         mainLayout.addWidget(self._tree, 2)
         mainLayout.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.widgetMargins
-        mainLayout.setContentsMargins(*margins)
+        margin = pyzo.config.view.widgetMargin
+        mainLayout.setContentsMargins(margin, margin, margin, margin)
         self.setLayout(mainLayout)
         
         # Bind events

--- a/pyzo/tools/pyzoWorkspace.py
+++ b/pyzo/tools/pyzoWorkspace.py
@@ -375,7 +375,7 @@ Currently, there are none. Some of them may be hidden because of the filters you
         mainLayout.addWidget(self._tree, 2)
         mainLayout.setSpacing(2)
         # set margins
-        margins = pyzo.config.view.margins
+        margins = pyzo.config.view.widgetMargins
         mainLayout.setContentsMargins(*margins)
         self.setLayout(mainLayout)
         

--- a/pyzo/tools/pyzoWorkspace.py
+++ b/pyzo/tools/pyzoWorkspace.py
@@ -374,7 +374,9 @@ Currently, there are none. Some of them may be hidden because of the filters you
         mainLayout.addWidget(self._initText, 1)
         mainLayout.addWidget(self._tree, 2)
         mainLayout.setSpacing(2)
-        mainLayout.setContentsMargins(4,4,4,4)
+        # set margins
+        margins = pyzo.config.view.margins
+        mainLayout.setContentsMargins(*margins)
         self.setLayout(mainLayout)
         
         # Bind events


### PR DESCRIPTION
Margins between gui elements editor, shell, logger and plugins are consistent as shown in the image below. New config option added: margins=[4,4,4,4].

![new_margins](https://user-images.githubusercontent.com/19865053/62562823-235bf880-b882-11e9-8206-35c8a272d74f.png)
