### PR TITLE
Use standard folders for data and config

### DIFF
--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -153,14 +153,14 @@ def getResourceDirs():
         raise RuntimeError('The Pyzo package cannot be run from a zipfile.')
 
     # Get where the application data is stored (use old behavior on Mac)
-    appDataDir = paths.appdata_dir('pyzo', roaming=True, macAsLinux=True)
+    appDataDir, appConfigDir = paths.appdata_dir('pyzo', roaming=True, macAsLinux=True)
 
     # Create tooldir if necessary
     toolDir = os.path.join(appDataDir, 'tools')
     if not os.path.isdir(toolDir):
         os.mkdir(toolDir)
 
-    return pyzoDir, appDataDir
+    return pyzoDir, appDataDir, appConfigDir
 
 
 def resetConfig(preserveState=True):
@@ -169,7 +169,7 @@ def resetConfig(preserveState=True):
     its config on the next shutdown.
     """
     # Get filenames
-    configFileName2 = os.path.join(appDataDir, 'config.ssdf')
+    configFileName2 = os.path.join(appConfigDir, 'config.ssdf')
     os.remove(configFileName2)
     global _saveConfigFile
     _saveConfigFile = False
@@ -237,7 +237,7 @@ def loadConfig(defaultsOnly=False):
             raise
 
     # Load user config and inject in pyzo.config
-    fname = os.path.join(appDataDir, "config.ssdf")
+    fname = os.path.join(appConfigDir, "config.ssdf")
     if os.path.isfile(fname):
         try:
             userConfig = ssdf.load(fname)
@@ -263,7 +263,7 @@ def saveConfig():
 
     # Store config
     if _saveConfigFile:
-        ssdf.save( os.path.join(appDataDir, "config.ssdf"), config )
+        ssdf.save( os.path.join(appConfigDir, "config.ssdf"), config )
 
 
 
@@ -314,7 +314,7 @@ parser = None # The source parser
 status = None # The statusbar (or None)
 
 # Get directories of interest
-pyzoDir, appDataDir = getResourceDirs()
+pyzoDir, appDataDir, appConfigDir = getResourceDirs()
 
 # Whether the config file should be saved
 _saveConfigFile = True

--- a/pyzo/core/about.py
+++ b/pyzo/core/about.py
@@ -83,6 +83,7 @@ class AboutDialog(QtWidgets.QDialog):
         
         <b>Pyzo directories</b><br>
         Pyzo source directory: {}<br>
+        Pyzo config directory: {}<br>
         Pyzo userdata directory: {}<br>
         <br>
         
@@ -107,7 +108,7 @@ class AboutDialog(QtWidgets.QDialog):
                         sys.platform,
                         sys.version.split(' ')[0],
                         qtVersion, qtWrapper, qtWrapperVersion,
-                        pyzo.pyzoDir, pyzo.appDataDir)
+                        pyzo.pyzoDir, pyzo.appConfigDir, pyzo.appDataDir)
         
         self.addTab("General", aboutText)
     

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -2304,8 +2304,8 @@ class AdvancedSettings(QtWidgets.QDialog):
     def __init__(self, *args):
         QtWidgets.QDialog.__init__(self, *args)
 
-        self.conf_file = os.path.join(pyzo.appDataDir, 'config.ssdf')
-        self.backup_file = os.path.join(pyzo.appDataDir, 'config.ssdf.bak')
+        self.conf_file = os.path.join(pyzo.appConfigDir, 'config.ssdf')
+        self.backup_file = os.path.join(pyzo.appConfigDir, 'config.ssdf.bak')
         
         if not os.path.exists(self.conf_file):
             pyzo.saveConfig()

--- a/pyzo/util/paths.py
+++ b/pyzo/util/paths.py
@@ -20,6 +20,7 @@ This code was first part of pyzolib, and later moved to pyzo.
 # * See docstring: that's why the functions tend to not re-use each-other
 
 import sys
+from pyzo.util.qt import QtCore
 
 ISWIN = sys.platform.startswith('win')
 ISMAC = sys.platform.startswith('darwin')
@@ -72,7 +73,7 @@ def temp_dir(appname=None, nospaces=False):
         path = os.path.join(path, appname)
         if not os.path.isdir(path):
             os.mkdir(path)
-    
+
     # Done
     return path
 
@@ -92,17 +93,22 @@ def user_dir():
 import os, sys
 def appdata_dir(appname=None, roaming=False, macAsLinux=False):
     """ appdata_dir(appname=None, roaming=False,  macAsLinux=False)
-    Get the path to the application directory, where applications are allowed
-    to write user specific files (e.g. configurations). For non-user specific
-    data, consider using common_appdata_dir().
+    Get the path to the application data and config directory, where applications are allowed
+    to write user specific files (e.g. configurations).
+    Applications should write their configurations files in the config folder,
+    and other data (e.g. history files) in the data folder.
+    For non-user specific data, consider using common_appdata_dir().
     If appname is given, a subdir is appended (and created if necessary).
     If roaming is True, will prefer a roaming directory (Windows Vista/7).
     If macAsLinux is True, will return the Linux-like location on Mac.
+
+    The behaviour of this function changed, it now uses QStandardPaths to provide location
+    of data folder and config folder, but for retro-compatibility pyzo will use the old folder if it exists
     """
-    
+
     # Define default user directory
     userDir = os.path.expanduser('~')
-    
+
     # Get system app data dir
     path = None
     if sys.platform.startswith('win'):
@@ -130,18 +136,36 @@ def appdata_dir(appname=None, roaming=False, macAsLinux=False):
             else:
                 path = localpath
                 break
-    
+    data_path, config_path = path, path
+
     # Get path specific for this app
     if appname:
         if path == userDir:
             appname = '.' + appname.lstrip('.') # Make it a hidden directory
         path = os.path.join(path, appname)
-        if not os.path.isdir(path):
-            os.mkdir(path)
-    
-    # Done
-    return path
+        data_path, config_path = path, path
 
+        if not os.path.isdir(path):
+            # Better way to get config/data folder especially on *nix system (see XDG_CONFIG_HOME standard),
+            # but this should work on any os.
+            # For retro-compatibility, check if old folder exist, and if not, use standard path.
+            standard_data_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.AppDataLocation)
+            standard_config_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.ConfigLocation)
+
+            # Check if QStandardPaths succeeded to find the location, otherwise use old path
+            if standard_config_path != "" and standard_data_path != "":
+                data_path, config_path = standard_data_path, standard_config_path
+            appname = appname.lstrip('.')
+            data_path = os.path.join(data_path, appname)
+            config_path = os.path.join(config_path, appname)
+
+            if not os.path.isdir(data_path):
+                os.mkdir(data_path)
+            if not os.path.isdir(config_path):
+                os.mkdir(config_path)
+
+    # Done
+    return data_path, config_path
 
 
 # From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
@@ -174,7 +198,7 @@ def common_appdata_dir(appname=None):
         path = os.path.join(path, appname)
         if not os.path.isdir(path):
             os.mkdir(path)
-    
+
     # Done
     return path
 
@@ -254,7 +278,15 @@ def pyzo_dirs2(path=None, version='0', **kwargs):
     else:
         path = os.path.join(userDir, '.pyzo')  # On Linux and as fallback
     if not os.path.isdir(path):
-        os.mkdir(path)
+        # Better way to get config folder especially on *nix system (see XDG_CONFIG_HOME standard),
+        # but this should work on any os.
+        # For retro-compatibility, check if old folder exist and use new path otherwise.
+        standard_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.ConfigLocation)
+        if standard_path != "":  # Check if QStandardPaths succeeded to find the location, otherwise use old path
+            path = standard_path
+        path = os.path.join(path, 'pyzo')
+        if not os.path.isdir(path):
+            os.mkdir(path)
     # Open file and parse
     fname = os.path.join(path, 'pyzodirs')
     pyzos, npyzos = [], 0

--- a/pyzo/util/paths.py
+++ b/pyzo/util/paths.py
@@ -178,29 +178,29 @@ def common_appdata_dir(appname=None):
     If appname is given, a subdir is appended (and created if necessary).
     """
     
-    # Try to get path
-    path = None
+    # Try to get data_path
+    data_path = None
     if sys.platform.startswith('win'):
-        path = os.getenv('ALLUSERSPROFILE', os.getenv('PROGRAMDATA'))
+        data_path = os.getenv('ALLUSERSPROFILE', os.getenv('PROGRAMDATA'))
     elif sys.platform.startswith('darwin'):
-        path = '/Library/Application Support'
+        data_path = '/Library/Application Support'
     else:
         # Not sure what to use. Apps are only allowed to write to the home
         # dir and tmp dir, right?
         pass
     
     # If no success, use appdata_dir() instead
-    if not (path and os.path.isdir(path)):
-        path = appdata_dir()
+    if not (data_path and os.path.isdir(data_path)):
+        data_path = appdata_dir()[0]
     
     # Get path specific for this app
     if appname:
-        path = os.path.join(path, appname)
-        if not os.path.isdir(path):
-            os.mkdir(path)
+        data_path = os.path.join(data_path, appname)
+        if not os.path.isdir(data_path):
+            os.mkdir(data_path)
 
     # Done
-    return path
+    return data_path
 
 
 


### PR DESCRIPTION
On Unix-like systems, pyzo config folder is located directly inside home folder of users, which is a bit annoying: https://0x46.net/thoughts/2019/02/01/dotfile-madness/

Pyzo should use $XDG_CONFIG_HOME to store configuration, and $XDG_DATA_HOME to store data (e.g. history). (https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
I used QStandardPaths from Qt to get those paths, this should work on any system (MacOs, Windows...).
For retro-compatibility reasons, pyzo will use old its folder if it exists.

I don't really understand the purpose of pyzo_dirs2() and pyzo_dirs(). What path should they use ?