### PR TITLE
Bugfix workspace dict

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -49,7 +49,7 @@ class PyzoIntrospector(yoton.RepChannel):
                 if isinstance(ob, dict):
                     NS = {}
                     for el in ob :
-                        NS['[' + repr(el) + ']'] = el
+                        NS['[' + repr(el) + ']'] = ob[el]
                 elif isinstance(ob, (list, tuple)):
                     NS = {}
                     count = -1

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -268,6 +268,8 @@ class PyzoIntrospector(yoton.RepChannel):
                     repres = '<list with %i elements>' % len(val)
                 elif kind == 'tuple':
                     repres = '<tuple with %i elements>' % len(val)
+                elif kind == 'dict' :
+                    repres = '<dict with {:d} keys>'.format(len(val))
                 else:
                     repres = repr(val)
                     if len(repres) > 80:


### PR DESCRIPTION
Fix : When exploring a dict in workspace, the line relevant to a dict key displays the key itself instead of the value associated to that key.

Also : display dicts as ``<dict with {:d} keys>`` instead of the 77 first chars of its representation.