### PR TITLE
Build tweaks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
         vmImage: ubuntu-16.04
         TEST: 1
         FREEZE: 1
+        PY_VERSION: 3.5
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -58,7 +59,7 @@ jobs:
         set -ex
         python -m pip install -U pip
         pip install -U pyqt5
-        pip install -U pytest black flake8 pyinstaller==3.5
+        pip install -U pytest black flake8 pyinstaller==3.6
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
       script: |
         set -ex
         $(PY_EXE) setup.py sdist
-        pip install $(echo "$(Build.SourcesDirectory)" | sed -e 's/\\/\//g')/dist/*.tar.gz
+        $(PY_EXE) -m pip install $(echo "$(Build.SourcesDirectory)" | sed -e 's/\\/\//g')/dist/*.tar.gz
   - task: Bash@3
     displayName: Test
     condition: and(succeeded(), eq(variables['TEST'], '1'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   NAME: pyzo
   PY_ARCH: x64
   PY_VERSION: 3.7
-
+  PY_EXE: python
 
 jobs:
 
@@ -26,6 +26,8 @@ jobs:
         vmImage: ubuntu-16.04
         TEST: 1
         FREEZE: 1
+        PY_VERSION: native
+        PY_EXE: python3
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -47,6 +49,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     displayName: Select Python
+    condition: ne(variables['PY_VERSION'], 'native')
     inputs:
       versionSpec: $(PY_VERSION)
       architecture: $(PY_ARCH)
@@ -56,9 +59,9 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        python -m pip install -U pip
-        pip install -U pyqt5
-        pip install -U pytest black flake8 pyinstaller==3.6
+        $(PY_EXE) -m pip install -U pip
+        $(PY_EXE) -m pip install -U pyqt5
+        $(PY_EXE) -m pip install -U pytest black flake8 pyinstaller==3.6
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')
@@ -83,7 +86,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        python setup.py sdist
+        $(PY_EXE) setup.py sdist
         pip install $(echo "$(Build.SourcesDirectory)" | sed -e 's/\\/\//g')/dist/*.tar.gz
   - task: Bash@3
     displayName: Test
@@ -92,7 +95,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        pytest --junit-xml=results.xml tests || true
+        $(PY_EXE) -m pytest --junit-xml=results.xml tests || true
         # Fail the task if results.xml was not created
         if [[ ! -f results.xml ]]
         then
@@ -112,7 +115,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        python freeze/freezeScript.py
+        $(PY_EXE) freeze/freezeScript.py
         rm -rf ./frozen/pyzo
         rm -rf ./frozen/pyzo.app
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,9 @@ jobs:
           apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
-          apt-get install -y python3.6 python3.6-dev python3.6-pip
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3.6 get-pip.py
+          apt-get install -y python3.6 python3.6-dev
           python3.6 -m pip install -U pip &&\
           python3.6 -m pip install -U pyqt5 pyinstaller &&\
           python3.6 -m pip install . &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
         TEST: 1
       Linux-64:
         vmImage: ubuntu-16.04
-        DOCKERIMAGE: manylinux2010_x86_64
+        DOCKERIMAGE: manylinux2014_x86_64
         FREEZE: 0 because freezing must only happen on container
       MacOS-64:
         vmImage: macOS-10.14

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         FREEZE: 0
         PY_VERSION: native
         #PY_EXE: python
-        DOCKERIMAGE: cdrx/pyinstaller-linux:python3
+        DOCKERIMAGE: python:3.7-stretch
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,6 @@ jobs:
         vmImage: ubuntu-16.04
         TEST: 1
         FREEZE: 1
-        PY_VERSION: 3.5
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -59,7 +58,7 @@ jobs:
         set -ex
         python -m pip install -U pip
         pip install -U pyqt5
-        pip install -U pytest pyinstaller==3.6
+        pip install -U pytest black flake8 pyinstaller==3.6
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')
@@ -75,7 +74,6 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        pip install -U black flake8
         black --check .
         flake8 .
   - task: Bash@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,11 +23,11 @@ jobs:
         LINT: 1
         TEST: 1
       Linux-64:
-        vmImage: ubuntu-16.04
+        vmImage: ubuntu-18.04
         TEST: 1
         FREEZE: 1
         PY_VERSION: native
-        PY_EXE: python3.6
+        PY_EXE: python3
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -54,16 +54,6 @@ jobs:
       versionSpec: $(PY_VERSION)
       architecture: $(PY_ARCH)
   - task: Bash@3
-    displayName: Install Python 3.6 (on Linux)
-    condition: eq(variables['PY_VERSION'], 'native')
-    inputs:
-      targetType: inline
-      script: |
-        set -ex
-        sudo add-apt-repository -y ppa:deadsnakes/ppa
-        sudo apt-get update
-        sudo apt-get install python3.6 python3.6-dev
-  - task: Bash@3
     displayName: Install development requirements
     inputs:
       targetType: inline
@@ -71,8 +61,7 @@ jobs:
         set -ex
         $(PY_EXE) -m pip install -U pip
         $(PY_EXE) -m pip install -U pyqt5
-        $(PY_EXE) -m pip install -U pytest black flake8
-        $(PY_EXE) -m pip install https://github.com/pyinstaller/pyinstaller/tarball/develop
+        $(PY_EXE) -m pip install -U pytest black flake8 pyinstaller
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,7 @@ jobs:
         LINT: 1
         TEST: 1
       Linux-64:
-        vmImage: ubuntu-14.04
-        # DOCKERIMAGE: manylinux2014_x86_64
-        # FREEZE: 0 because freezing must only happen on container
+        vmImage: ubuntu-16.04
         TEST: 1
         FREEZE: 1
       MacOS-64:
@@ -47,44 +45,23 @@ jobs:
     vmImage: $(vmImage)
 
   steps:
-  - task: Bash@3
-    displayName: Docker build
-    condition: and(succeeded(), ne(variables['DOCKERIMAGE'], ''))
-    inputs:
-      targetType: inline
-      script: |
-        set -ex
-        CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
-          cp -r /tmp/src/. . && \
-          rm -rf ./frozen && \
-          /opt/python/cp36-cp36m/bin/python -m pip install -U pip &&\
-          /opt/python/cp36-cp36m/bin/python -m pip install -U pyqt5 pyinstaller &&\
-          /opt/python/cp36-cp36m/bin/python -m pip install . &&\
-          /opt/python/cp36-cp36m/bin/python freeze/freezeScript.py &&\
-          rm -rf ./frozen/pyzo")
-        docker start -ai $CID
-        mkdir -p frozen
-        docker cp $CID:/tmp/pyzo/frozen/. ./frozen/.
-        docker rm $CID
   - task: UsePythonVersion@0
     displayName: Select Python
-    condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
     inputs:
       versionSpec: $(PY_VERSION)
       architecture: $(PY_ARCH)
   - task: Bash@3
     displayName: Install development requirements
-    condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
     inputs:
       targetType: inline
       script: |
         set -ex
         python -m pip install -U pip
         pip install -U pyqt5
-        pip install -U pytest black flake8 pyinstaller
+        pip install -U pytest black flake8 pyinstaller==3.4
   - task: Bash@3
     displayName: Install inno setup (on Windows)
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows'))
+    condition: eq(variables['Agent.OS'], 'Windows')
     inputs:
       targetType: inline
       script: |
@@ -140,7 +117,7 @@ jobs:
         rm -rf ./frozen/pyzo.app
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
-    condition: and(succeeded(), or(ne(variables['DOCKERIMAGE'], ''), eq(variables['FREEZE'], '1')))
+    condition: and(succeeded(), eq(variables['FREEZE'], '1'))
     inputs:
       pathtoPublish: frozen
       artifactName: frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
           apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
-          apt-get install -y python3.6 python3.6-dev
+          apt-get install -y python3.6 python3.6-dev curl
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3.6 get-pip.py
           python3.6 -m pip install -U pip &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,9 +62,9 @@ jobs:
           apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
+          apt-get install -y python3.6 python3.6-dev
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3.6 get-pip.py
-          apt-get install -y python3.6 python3.6-dev
           python3.6 -m pip install -U pip &&\
           python3.6 -m pip install -U pyqt5 pyinstaller &&\
           python3.6 -m pip install . &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro $(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
+          apt-get update
           apt-get install software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,9 +60,9 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        add-apt-repository -y ppa:deadsnakes/ppa
-        apt-get update
-        apt-get install python3.6
+        sudo add-apt-repository -y ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install python3.6
   - task: Bash@3
     displayName: Install development requirements
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
         set -ex
         python -m pip install -U pip
         pip install -U pyqt5
-        pip install -U pytest black flake8 pyinstaller==3.6
+        pip install -U pytest pyinstaller==3.6
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')
@@ -75,6 +75,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
+        pip install -U black flake8
         black --check .
         flake8 .
   - task: Bash@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro $(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
+          apt-get install software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
           apt-get install python3.6 python3.6-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         FREEZE: 0
         PY_VERSION: native
         #PY_EXE: python
-        DOCKERIMAGE: python:3.7-stretch
+        DOCKERIMAGE: ubuntu:16.04
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -58,10 +58,13 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro $(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
-          python -m pip install -U pip &&\
-          python -m pip install -U pyqt5 pyinstaller &&\
-          python -m pip install . &&\
-          python freeze/freezeScript.py &&\
+          sudo add-apt-repository -y ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install python3.6 python3.6-dev
+          python3.6 -m pip install -U pip &&\
+          python3.6 -m pip install -U pyqt5 pyinstaller &&\
+          python3.6 -m pip install . &&\
+          python3.6 freeze/freezeScript.py &&\
           rm -rf ./frozen/pyzo")
         docker start -ai $CID
         mkdir -p frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,16 @@ jobs:
       versionSpec: $(PY_VERSION)
       architecture: $(PY_ARCH)
   - task: Bash@3
+    displayName: Install Python 3.6 (on Linux)
+    condition: eq(variables['PY_VERSION'], 'native')
+    inputs:
+      targetType: inline
+      script: |
+        set -ex
+        add-apt-repository -y ppa:deadsnakes/ppa
+        apt-get update
+        apt-get install python3.6
+  - task: Bash@3
     displayName: Install development requirements
     inputs:
       targetType: inline
@@ -61,7 +71,7 @@ jobs:
         set -ex
         $(PY_EXE) -m pip install -U pip
         $(PY_EXE) -m pip install -U pyqt5
-        $(PY_EXE) -m pip install -U pytest pyinstaller==3.6
+        $(PY_EXE) -m pip install -U pytest black flake8 pyinstaller==3.6
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')
@@ -77,7 +87,6 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        $(PY_EXE) -m pip install -U black flake8
         black --check .
         flake8 .
   - task: Bash@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 variables:
   NAME: pyzo
   PY_ARCH: x64
-  PY_VERSION: 3.7
+  PY_VERSION: 3.8
 
 
 jobs:
@@ -20,24 +20,26 @@ jobs:
     matrix:
       Linux-tester:
         vmImage: ubuntu-16.04
-        SDIST: 1
         LINT: 1
         TEST: 1
       Linux-64:
         vmImage: ubuntu-16.04
-        ARCH: 64
         DOCKERIMAGE: manylinux2010_x86_64
+        FREEZE: 0 because freezing must only happen on container
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
         TEST: 1
+        FREEZE: 1
       Windows-64:
         vmImage: vs2017-win2016
         TEST: 1
+        FREEZE: 1
       Windows-32:
         vmImage: vs2017-win2016
         PY_ARCH: x86
         TEST: 1
+        FREEZE: 1
 
   pool:
     vmImage: $(vmImage)
@@ -45,19 +47,23 @@ jobs:
   steps:
   - task: Bash@3
     displayName: Docker build
-    condition: and(succeeded(), neq(variables['DOCKERIMAGE'], ''))
+    condition: and(succeeded(), ne(variables['DOCKERIMAGE'], ''))
     inputs:
       targetType: inline
       script: |
         set -ex
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
-          rm -rf ./frozen)
+          rm -rf ./frozen && \
+          /opt/python/cp38-cp38/bin/python -m pip install -U pip &&\
+          /opt/python/cp38-cp38/bin/python -m pip install -U pyqt5 pyinstaller &&\
+          /opt/python/cp38-cp38/bin/python -m pip install . &&\
+          /opt/python/cp38-cp38/bin/python freeze/freezeScript.py &&\
+          rm -rf ./frozen/pyzo)
         docker start -ai $CID
         mkdir -p frozen
         docker cp $CID:/tmp/pyzo/frozen/. ./frozen/.
         docker rm $CID
-        rm -rf ./frozen/pyzo
   - task: UsePythonVersion@0
     displayName: Select Python
     condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
@@ -123,7 +129,7 @@ jobs:
       testRunTitle: Test $(vmImage)
   - task: Bash@3
     displayName: Freeze
-    condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
+    condition: and(succeeded(), eq(variables['FREEZE'], '1'))
     inputs:
       targetType: inline
       script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
         TEST: 0
         FREEZE: 0
         PY_VERSION: native
-        #PY_EXE: python3
+        #PY_EXE: python
         DOCKERIMAGE: cdrx/pyinstaller-linux:python3
       MacOS-64:
         vmImage: macOS-10.14

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,10 @@ jobs:
         TEST: 1
       Linux-64:
         vmImage: ubuntu-16.04
-        #DOCKERIMAGE: manylinux2014_x86_64
-        #FREEZE: 0 because freezing must only happen on container
-        TEST: 1
-        FREEZE: 1
+        DOCKERIMAGE: manylinux2014_x86_64
+        FREEZE: 0 because freezing must only happen on container
+        #TEST: 1
+        #FREEZE: 1
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -58,7 +58,7 @@ jobs:
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
           /opt/python/cp37-cp37m/bin/python -m pip install -U pip &&\
-          /opt/python/cp37-cp37m/bin/python -m pip install -U pyqt5 pyinstaller &&\
+          /opt/python/cp37-cp37m/bin/python -m pip install -U pyqt5 pyinstaller==3.5 &&\
           /opt/python/cp37-cp37m/bin/python -m pip install . &&\
           /opt/python/cp37-cp37m/bin/python freeze/freezeScript.py &&\
           rm -rf ./frozen/pyzo")
@@ -80,7 +80,7 @@ jobs:
       script: |
         set -ex
         python -m pip install -U pip
-        pip install -U pyside2
+        pip install -U pyqt5
         pip install -U pytest black flake8 pyinstaller
   - task: Bash@3
     displayName: Install inno setup (on Windows)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,11 @@ jobs:
         TEST: 1
       Linux-64:
         vmImage: ubuntu-18.04
-        TEST: 1
-        FREEZE: 1
+        TEST: 0
+        FREEZE: 0
         PY_VERSION: native
-        PY_EXE: python3
+        #PY_EXE: python3
+        DOCKERIMAGE: cdrx/pyinstaller-linux:python3
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -47,6 +48,25 @@ jobs:
     vmImage: $(vmImage)
 
   steps:
+  - task: Bash@3
+    displayName: Docker build
+    condition: and(succeeded(), ne(variables['DOCKERIMAGE'], ''))
+    inputs:
+      targetType: inline
+      script: |
+        set -ex
+        CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
+          cp -r /tmp/src/. . && \
+          rm -rf ./frozen && \
+          python -m pip install -U pip &&\
+          python -m pip install -U pyqt5 pyinstaller &&\
+          python -m pip install . &&\
+          python freeze/freezeScript.py &&\
+          rm -rf ./frozen/pyzo")
+        docker start -ai $CID
+        mkdir -p frozen
+        docker cp $CID:/tmp/pyzo/frozen/. ./frozen/.
+        docker rm $CID
   - task: UsePythonVersion@0
     displayName: Select Python
     condition: ne(variables['PY_VERSION'], 'native')
@@ -120,7 +140,7 @@ jobs:
         rm -rf ./frozen/pyzo.app
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
-    condition: and(succeeded(), eq(variables['FREEZE'], '1'))
+    condition: and(succeeded(), or(ne(variables['DOCKERIMAGE'], ''), eq(variables['FREEZE'], '1')))
     inputs:
       pathtoPublish: frozen
       artifactName: frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,10 +57,10 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
-          /opt/python/cp37-cp37m/bin/python -m pip install -U pip &&\
-          /opt/python/cp37-cp37m/bin/python -m pip install -U pyqt5 pyinstaller==3.5 &&\
-          /opt/python/cp37-cp37m/bin/python -m pip install . &&\
-          /opt/python/cp37-cp37m/bin/python freeze/freezeScript.py &&\
+          /opt/python/cp36-cp36m/bin/python -m pip install -U pip &&\
+          /opt/python/cp36-cp36m/bin/python -m pip install -U pyqt5 pyinstaller &&\
+          /opt/python/cp36-cp36m/bin/python -m pip install . &&\
+          /opt/python/cp36-cp36m/bin/python freeze/freezeScript.py &&\
           rm -rf ./frozen/pyzo")
         docker start -ai $CID
         mkdir -p frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,8 @@ jobs:
         #PY_EXE: python
         DOCKERIMAGE:  python:3.7-stretch
       MacOS-64:
-        vmImage: macOS-10.12
-        MACOSX_DEPLOYMENT_TARGET: '10.12'
+        vmImage: macOS-10.13
+        MACOSX_DEPLOYMENT_TARGET: '10.13'
         TEST: 1
         FREEZE: 1
       Windows-64:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,10 +59,11 @@ jobs:
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
           apt-get update
+          apt-get install -y curl objdump
           apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
-          apt-get install -y python3.6 python3.6-dev curl
+          apt-get install -y python3.6 python3.6-dev
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3.6 get-pip.py
           python3.6 -m pip install -U pip &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,9 +58,9 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro $(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
-          sudo add-apt-repository -y ppa:deadsnakes/ppa
-          sudo apt-get update
-          sudo apt-get install python3.6 python3.6-dev
+          add-apt-repository -y ppa:deadsnakes/ppa
+          apt-get update
+          apt-get install python3.6 python3.6-dev
           python3.6 -m pip install -U pip &&\
           python3.6 -m pip install -U pyqt5 pyinstaller &&\
           python3.6 -m pip install . &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,8 @@ jobs:
         set -ex
         $(PY_EXE) -m pip install -U pip
         $(PY_EXE) -m pip install -U pyqt5
-        $(PY_EXE) -m pip install -U pytest black flake8 pyinstaller==3.6
+        $(PY_EXE) -m pip install -U pytest black flake8
+        $(PY_EXE) -m pip install https://github.com/pyinstaller/pyinstaller/tarball/develop
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
           /opt/python/cp38-cp38/bin/python -m pip install -U pyqt5 pyinstaller &&\
           /opt/python/cp38-cp38/bin/python -m pip install . &&\
           /opt/python/cp38-cp38/bin/python freeze/freezeScript.py &&\
-          rm -rf ./frozen/pyzo)
+          rm -rf ./frozen/pyzo")
         docker start -ai $CID
         mkdir -p frozen
         docker cp $CID:/tmp/pyzo/frozen/. ./frozen/.
@@ -138,6 +138,7 @@ jobs:
         rm -rf ./frozen/pyzo.app
   - task: PublishBuildArtifacts@1
     displayName: Publish distributions
+    condition: and(succeeded(), or(ne(variables['DOCKERIMAGE'], ''), eq(variables['FREEZE'], '1')))
     inputs:
       pathtoPublish: frozen
       artifactName: frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         FREEZE: 0
         PY_VERSION: native
         #PY_EXE: python
-        DOCKERIMAGE: ubuntu:16.04
+        DOCKERIMAGE:  python:3.7-stretch
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -58,18 +58,10 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro $(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
-          apt-get update
-          apt-get install -y curl binutils
-          apt-get install -y software-properties-common python-software-properties
-          add-apt-repository -y ppa:deadsnakes/ppa
-          apt-get update
-          apt-get install -y python3.6 python3.6-dev
-          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-          python3.6 get-pip.py
-          python3.6 -m pip install -U pip &&\
-          python3.6 -m pip install -U pyqt5 pyinstaller &&\
-          python3.6 -m pip install . &&\
-          python3.6 freeze/freezeScript.py &&\
+          python -m pip install -U pip &&\
+          python -m pip install -U pyqt5 pyinstaller &&\
+          python -m pip install . &&\
+          python freeze/freezeScript.py &&\
           rm -rf ./frozen/pyzo")
         docker start -ai $CID
         mkdir -p frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
         #PY_EXE: python
         DOCKERIMAGE:  python:3.7-stretch
       MacOS-64:
-        vmImage: macOS-10.13
+        vmImage: macOS-10.12
         MACOSX_DEPLOYMENT_TARGET: '10.12'
         TEST: 1
         FREEZE: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
           apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
-          apt-get install -y python3.6 python3.6-dev
+          apt-get install -y python3.6 python3.6-dev python3.6-pip
           python3.6 -m pip install -U pip &&\
           python3.6 -m pip install -U pyqt5 pyinstaller &&\
           python3.6 -m pip install . &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,10 +59,10 @@ jobs:
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
           apt-get update
-          apt-get install software-properties-common python-software-properties
+          apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
-          apt-get install python3.6 python3.6-dev
+          apt-get install -y python3.6 python3.6-dev
           python3.6 -m pip install -U pip &&\
           python3.6 -m pip install -U pyqt5 pyinstaller &&\
           python3.6 -m pip install . &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,32 +11,62 @@ variables:
   PY_ARCH: x64
   PY_VERSION: 3.7
 
+
 jobs:
+
 - job: Build
+
   strategy:
     matrix:
-      Linux:
+      Linux-tester:
         vmImage: ubuntu-16.04
         SDIST: 1
         LINT: 1
-      MacOS:
+        TEST: 1
+      Linux-64:
+        vmImage: ubuntu-16.04
+        ARCH: 64
+        DOCKERIMAGE: manylinux2010_x86_64
+      MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
-      Windows:
+        TEST: 1
+      Windows-64:
         vmImage: vs2017-win2016
+        TEST: 1
       Windows-32:
         vmImage: vs2017-win2016
         PY_ARCH: x86
+        TEST: 1
+
   pool:
     vmImage: $(vmImage)
+
   steps:
+  - task: Bash@3
+    displayName: Docker build
+    condition: and(succeeded(), neq(variables['DOCKERIMAGE'], ''))
+    inputs:
+      targetType: inline
+      script: |
+        set -ex
+        CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
+          cp -r /tmp/src/. . && \
+          rm -rf ./frozen)
+        docker start -ai $CID
+        mkdir -p frozen
+        docker cp $CID:/tmp/pyzo/frozen/. ./frozen/.
+        docker rm $CID
+        rm -rf ./frozen/pyzo
   - task: UsePythonVersion@0
     displayName: Select Python
+    condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
     inputs:
       versionSpec: $(PY_VERSION)
       architecture: $(PY_ARCH)
   - task: Bash@3
     displayName: Install development requirements
+    condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
     inputs:
       targetType: inline
       script: |
@@ -63,6 +93,7 @@ jobs:
         flake8 .
   - task: Bash@3
     displayName: Install sdist
+    condition: and(succeeded(), eq(variables['TEST'], '1'))
     inputs:
       targetType: inline
       script: |
@@ -71,6 +102,7 @@ jobs:
         pip install $(echo "$(Build.SourcesDirectory)" | sed -e 's/\\/\//g')/dist/*.tar.gz
   - task: Bash@3
     displayName: Test
+    condition: and(succeeded(), eq(variables['TEST'], '1'))
     inputs:
       targetType: inline
       script: |
@@ -83,6 +115,7 @@ jobs:
           exit 1
         fi
   - task: PublishTestResults@2
+    condition: and(succeeded(), eq(variables['TEST'], '1'))
     inputs:
       testResultsFiles: results.xml
       mergeTestResults: true
@@ -90,6 +123,7 @@ jobs:
       testRunTitle: Test $(vmImage)
   - task: Bash@3
     displayName: Freeze
+    condition: and(succeeded(), eq(variables['DOCKERIMAGE'], ''))
     inputs:
       targetType: inline
       script: |
@@ -102,11 +136,16 @@ jobs:
       pathtoPublish: frozen
       artifactName: frozen
 
+
 - job: Release
+
   dependsOn: Build
+
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
   pool:
     vmImage: ubuntu-16.04
+
   steps:
   - task: Bash@3
     displayName: git tag == git branch

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,11 +23,11 @@ jobs:
         LINT: 1
         TEST: 1
       Linux-64:
-        vmImage: ubuntu-16.04
-        DOCKERIMAGE: manylinux2014_x86_64
-        FREEZE: 0 because freezing must only happen on container
-        #TEST: 1
-        #FREEZE: 1
+        vmImage: ubuntu-14.04
+        # DOCKERIMAGE: manylinux2014_x86_64
+        # FREEZE: 0 because freezing must only happen on container
+        TEST: 1
+        FREEZE: 1
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
           apt-get update
-          apt-get install -y curl objdump
+          apt-get install -y curl binutils
           apt-get install -y software-properties-common python-software-properties
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
         TEST: 1
         FREEZE: 1
         PY_VERSION: native
-        PY_EXE: python3
+        PY_EXE: python3.6
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
-        CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
+        CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro $(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
           python -m pip install -U pip &&\

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
         set -ex
         python -m pip install -U pip
         pip install -U pyqt5
-        pip install -U pytest black flake8 pyinstaller==3.4
+        pip install -U pytest black flake8 pyinstaller==3.5
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 variables:
   NAME: pyzo
   PY_ARCH: x64
-  PY_VERSION: 3.8
+  PY_VERSION: 3.7
 
 
 jobs:
@@ -55,10 +55,10 @@ jobs:
         CID=$(docker create -t -w /tmp/pyzo -v $PWD:/tmp/src:ro quay.io/pypa/$(DOCKERIMAGE) bash -c "\
           cp -r /tmp/src/. . && \
           rm -rf ./frozen && \
-          /opt/python/cp38-cp38/bin/python -m pip install -U pip &&\
-          /opt/python/cp38-cp38/bin/python -m pip install -U pyqt5 pyinstaller &&\
-          /opt/python/cp38-cp38/bin/python -m pip install . &&\
-          /opt/python/cp38-cp38/bin/python freeze/freezeScript.py &&\
+          /opt/python/cp37-cp37m/bin/python -m pip install -U pip &&\
+          /opt/python/cp37-cp37m/bin/python -m pip install -U pyqt5 pyinstaller &&\
+          /opt/python/cp37-cp37m/bin/python -m pip install . &&\
+          /opt/python/cp37-cp37m/bin/python freeze/freezeScript.py &&\
           rm -rf ./frozen/pyzo")
         docker start -ai $CID
         mkdir -p frozen

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,10 @@ jobs:
         TEST: 1
       Linux-64:
         vmImage: ubuntu-16.04
-        DOCKERIMAGE: manylinux2014_x86_64
-        FREEZE: 0 because freezing must only happen on container
+        #DOCKERIMAGE: manylinux2014_x86_64
+        #FREEZE: 0 because freezing must only happen on container
+        TEST: 1
+        FREEZE: 1
       MacOS-64:
         vmImage: macOS-10.14
         MACOSX_DEPLOYMENT_TARGET: '10.13'
@@ -78,7 +80,7 @@ jobs:
       script: |
         set -ex
         python -m pip install -U pip
-        pip install -U pyqt5
+        pip install -U pyside2
         pip install -U pytest black flake8 pyinstaller
   - task: Bash@3
     displayName: Install inno setup (on Windows)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
         set -ex
         $(PY_EXE) -m pip install -U pip
         $(PY_EXE) -m pip install -U pyqt5
-        $(PY_EXE) -m pip install -U pytest black flake8 pyinstaller==3.6
+        $(PY_EXE) -m pip install -U pytest pyinstaller==3.6
   - task: Bash@3
     displayName: Install inno setup (on Windows)
     condition: eq(variables['Agent.OS'], 'Windows')
@@ -77,6 +77,7 @@ jobs:
       targetType: inline
       script: |
         set -ex
+        $(PY_EXE) -m pip install -U black flake8
         black --check .
         flake8 .
   - task: Bash@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
         set -ex
         sudo add-apt-repository -y ppa:deadsnakes/ppa
         sudo apt-get update
-        sudo apt-get install python3.6
+        sudo apt-get install python3.6 python3.6-dev
   - task: Bash@3
     displayName: Install development requirements
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
   steps:
   - task: Bash@3
     displayName: Docker build
-    condition: and(succeeded(), ne(variables['DOCKERIMAGE'], ''))
+    condition: ne(variables['DOCKERIMAGE'], '')
     inputs:
       targetType: inline
       script: |
@@ -75,6 +75,7 @@ jobs:
       architecture: $(PY_ARCH)
   - task: Bash@3
     displayName: Install development requirements
+    condition: or(eq(variables['TEST'], '1'), eq(variables['FREEZE'], '1'))
     inputs:
       targetType: inline
       script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,8 @@ jobs:
         #PY_EXE: python
         DOCKERIMAGE:  python:3.7-stretch
       MacOS-64:
-        vmImage: macOS-10.14
-        MACOSX_DEPLOYMENT_TARGET: '10.13'
+        vmImage: macOS-10.13
+        MACOSX_DEPLOYMENT_TARGET: '10.12'
         TEST: 1
         FREEZE: 1
       Windows-64:

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -120,6 +120,7 @@ if sys.platform.startswith("win"):
 elif sys.platform.startswith("darwin"):
     cmd.append("--windowed")  # makes a .app bundle
     cmd.extend(["--icon", iconFile[:-3] + "icns"])
+    cmd.extend(["--osx-bundle-identifier", "org.pyzo.pyzo4"])
 
 cmd.append(srcDir + "__main__.py")
 

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -125,7 +125,10 @@ cmd.append(srcDir + "__main__.py")
 
 PyInstaller.__main__.run(cmd)
 
-os.remove(os.path.join(thisDir, "pyzo.spec"))
+try:
+    os.remove(os.path.join(thisDir, "pyzo.spec"))
+except Exception:
+    pass
 
 
 ## Process source code and other resources

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -261,7 +261,8 @@ if sys.platform.startswith("win"):
                 zf.write(filename1, filename2)
 
 
-if sys.platform.startswith("win"):
+if sys.platform.startswith("win") and bitness == "64":
+    # Note: for some reason the 32bit installer is broken. Ah well, the zip works.
     print("Packing up into exe installer (via Inno Setup) ...")
 
     exes = [

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -125,7 +125,7 @@ cmd.append(srcDir + "__main__.py")
 
 PyInstaller.__main__.run(cmd)
 
-os.remove(baseDir + "pyzo.spec")
+os.remove(os.path.join(thisDir, "pyzo.spec"))
 
 
 ## Process source code and other resources
@@ -279,6 +279,8 @@ if sys.platform.startswith("win"):
     innoFile2 = os.path.join(thisDir, "installerBuilderScript2.iss")
     text = open(innoFile1, "rb").read().decode()
     text = text.replace("X.Y.Z", __version__).replace("64", bitness)
+    if bitness == "32":
+        text = text.replace("ArchitecturesInstallIn64BitMode = x64", "")
     with open(innoFile2, "wb") as f:
         f.write(text.encode())
     try:

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -32,7 +32,7 @@ sys.path.insert(0, baseDir)
 ## Includes and excludes
 
 # The Qt toolkit that we use
-QT_API = "PySide2"
+QT_API = "PyQt5"
 
 # All known Qt toolkits, mainly to exclude them
 qt_kits = {"PySide", "PySide2", "PyQt4", "PyQt5"}

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -32,7 +32,7 @@ sys.path.insert(0, baseDir)
 ## Includes and excludes
 
 # The Qt toolkit that we use
-QT_API = "PyQt5"
+QT_API = "PySide2"
 
 # All known Qt toolkits, mainly to exclude them
 qt_kits = {"PySide", "PySide2", "PyQt4", "PyQt5"}

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -133,6 +133,10 @@ except Exception:
 
 ## Process source code and other resources
 
+from pyzo import __version__
+
+bitness = "32" if sys.maxsize <= 2 ** 32 else "64"
+
 
 def copydir_smart(path1, path2):
     """ like shutil.copytree, but ...
@@ -227,11 +231,6 @@ if sys.platform.startswith("darwin"):
 # Linux: .tar.gz
 # Windows: zip and exe installer
 # MacOS: DMG
-
-
-from pyzo import __version__
-
-bitness = "32" if sys.maxsize <= 2 ** 32 else "64"
 
 
 if sys.platform.startswith("linux"):

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -6,6 +6,9 @@ Pyzo is frozen in such a way that it still uses the plain source code.
 This is achieved by putting the Pyzo package in a subdirectory called
 "source". This source directory is added to sys.path by __main__.py.
 
+In case we need better support for older MacOS:
+https://gist.github.com/phfaist/a5b8a895b003822df5397731f4673042
+
 """
 
 import os

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -218,7 +218,7 @@ if sys.platform.startswith("darwin"):
         line.strip() for line in extra_plist_info.splitlines()
     )
     extra_plist_info = extra_plist_info.replace("X.Y.Z", __version__)
-    plist_filename = os.path.join(distDir, "pyzo", "pyzo.app", "Contents", "Info.plist")
+    plist_filename = os.path.join(distDir, "pyzo.app", "Contents", "Info.plist")
     text = open(plist_filename, "rb").read().decode()
     i1 = text.index("<key>CFBundleShortVersionString</key")
     i2 = text.index("</string>", i1) + len("</string>")

--- a/freeze/freezeScript.py
+++ b/freeze/freezeScript.py
@@ -12,6 +12,7 @@ https://gist.github.com/phfaist/a5b8a895b003822df5397731f4673042
 """
 
 import os
+import re
 import sys
 import shutil
 import zipfile
@@ -137,7 +138,8 @@ except Exception:
 
 ## Process source code and other resources
 
-from pyzo import __version__
+with open(srcDir + "__init__.py") as fh:
+    __version__ = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
 
 bitness = "32" if sys.maxsize <= 2 ** 32 else "64"
 

--- a/freeze/installerBuilderScript.iss
+++ b/freeze/installerBuilderScript.iss
@@ -7,6 +7,7 @@ AppVerName = pyzo version X.Y.Z
 AppPublisher = The Pyzo team
 AppPublisherURL = https://pyzo.org
 
+ArchitecturesInstallIn64BitMode = x64
 DefaultDirName = {pf}\pyzo
 DefaultGroupName = pyzo
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     keywords="Python interactive IDE Qt science computing",
     platforms="any",
     provides=["pyzo"],
-    python_requires=">=3.6.0",
+    python_requires=">=3.5.0",
     install_requires=[],  # and 'PySide2' or 'PyQt5' (less sure about PySide/PyQt4)
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_dir={"pyzo": "pyzo"},

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     keywords="Python interactive IDE Qt science computing",
     platforms="any",
     provides=["pyzo"],
-    python_requires=">=3.5.0",
+    python_requires=">=3.6.0",
     install_requires=[],  # and 'PySide2' or 'PyQt5' (less sure about PySide/PyQt4)
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_dir={"pyzo": "pyzo"},


### PR DESCRIPTION
* Only build windows installer for 64bit (because the 32bit version seems to be broken).
* Make that 64bit installer install in `program files`, not `program file x86`.
* Try to fix #678 ... no luck so far. Ideas:
  * build the Linux version on Travis? (and then figure out how to push the artifact *sigh*)
  * build on another vm?
  * use the default python on the vm instead of using the `UsePythonVersion` task.