### PR TITLE
Displaying signatures in interactive help

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -392,8 +392,9 @@ class PyzoIntrospector(yoton.RepChannel):
 
             # get and correct signature
             h_fun, kind = self._getSignature(objectName)
-            if kind == "builtin" or not h_fun:
-                h_fun = ""  # signature already in docstring or not available
+
+            if not h_fun:
+                h_fun = ""  # signature not available
 
             # cut repr if too long
             if len(h_repr) > 200:

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -670,9 +670,8 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
                         header, sep, docs = h_text.partition("\n")
                         # h_text = header + '\n\n' + docs
                         h_text = docs
-                    elif h_fun is not None and h_fun != "" :
+                    elif h_fun is not None and h_fun != "":
                         header = h_fun
-
 
                 # Parse the text as rest/numpy like docstring
                 h_text = self.smartFormat(h_text)
@@ -689,14 +688,14 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
 
             # Compile rich text
             text += get_title_text(objectName, h_class, h_repr)
-            if not self._config.smartNewlines and h_fun is not None and h_fun != "" :
+            if not self._config.smartNewlines and h_fun is not None and h_fun != "":
                 text += "<p><b>Signature:</b> {}</p>".format(h_fun)
             text += "{}<br />".format(h_text)
 
         except Exception:
             try:
                 text += get_title_text(objectName, h_class, h_repr)
-                if h_fun is not None and h_fun != "" :
+                if h_fun is not None and h_fun != "":
                     text += "<p><b>Signature:</b> {}</p>".format(h_fun)
                 text += h_text
             except Exception:

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -670,6 +670,9 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
                         header, sep, docs = h_text.partition("\n")
                         # h_text = header + '\n\n' + docs
                         h_text = docs
+                    elif h_fun is not None and h_fun != "" :
+                        header = h_fun
+
 
                 # Parse the text as rest/numpy like docstring
                 h_text = self.smartFormat(h_text)
@@ -686,7 +689,7 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
 
             # Compile rich text
             text += get_title_text(objectName, h_class, h_repr)
-            if h_fun is not None and h_fun != "" :
+            if not self._config.smartNewlines and h_fun is not None and h_fun != "" :
                 text += "<p><b>Signature:</b> {}</p>".format(h_fun)
             text += "{}<br />".format(h_text)
 

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -686,11 +686,15 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
 
             # Compile rich text
             text += get_title_text(objectName, h_class, h_repr)
+            if h_fun is not None and h_fun != "" :
+                text += "<p><b>Signature:</b> {}</p>".format(h_fun)
             text += "{}<br />".format(h_text)
 
         except Exception:
             try:
                 text += get_title_text(objectName, h_class, h_repr)
+                if h_fun is not None and h_fun != "" :
+                    text += "<p><b>Signature:</b> {}</p>".format(h_fun)
                 text += h_text
             except Exception:
                 text = response


### PR DESCRIPTION
Contrary to the shell's ``help`` builtin, Pyzo's interactive help will not display the signatures of functions.
This is due to :

- the interactive help not doing anything with the signature when it gets one ;
- the introspection module erasing the signature from its response on builtin functions.

According to the comments, the latter is done on the assumption that builtin functions have their signature at the beginning of their docstring. This is true for eg. ``numpy.zeros`` but false for ``open``.

There is some code in the help tool to detect the signature in the docstring and displaying it nicely ; I added a fallback code where we just use the signature given by the introspection.