### PR TITLE
Starting autocomplete after some chars

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -98,6 +98,12 @@ class AutoCompletion(object):
         """
         self.__popupSize = width, height
 
+    def setAutocompleteMinChars(self, n) :
+        """
+        Set the number of chars where we show the popup.
+        """
+        self.__autocompleteMinChars = n
+
     def autocompleteShow(self, offset=0, names=None):
         """
         Pop-up the autocompleter (if not already visible) and position it at current

--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -98,7 +98,7 @@ class AutoCompletion(object):
         """
         self.__popupSize = width, height
 
-    def setAutocompleteMinChars(self, n) :
+    def setAutocompleteMinChars(self, n):
         """
         Set the number of chars where we show the popup.
         """
@@ -226,11 +226,11 @@ class AutoCompletion(object):
         cursor.setPosition(self.__autocompleteStart.position(), cursor.KeepAnchor)
 
         prefix = cursor.selectedText()
-        if len(prefix) < self.__autocompleteMinChars :
+        if len(prefix) < self.__autocompleteMinChars:
             self.__completer.setCompletionPrefix("")
             self.autocompleteCancel()
             return False
-        else :
+        else:
             self.__completer.setCompletionPrefix(prefix)
             model = self.__completer.completionModel()
             if model.rowCount():
@@ -243,7 +243,9 @@ class AutoCompletion(object):
                 completions = [
                     (
                         row,
-                        model.data(model.index(row, 0), self.__completer.completionRole()),
+                        model.data(
+                            model.index(row, 0), self.__completer.completionRole()
+                        ),
                     )
                     for row in range(model.rowCount())
                 ]

--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -130,7 +130,11 @@ class AutoCompletion(object):
             # Popup the autocompleter. Don't use .complete() since we want to
             # position the popup manually
             self.__positionAutocompleter()
-            if self.__updateAutocompleterPrefix() and len (self.__completer.completionPrefix()) >= self.__autocompleteMinChars:
+            if (
+                self.__updateAutocompleterPrefix()
+                and len(self.__completer.completionPrefix())
+                >= self.__autocompleteMinChars
+            ):
                 self.__autocompleteVisible = True
                 self.__completer.popup().show()
             if self.__autocompleteDebug:

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -188,7 +188,7 @@ class BaseTextCtrl(codeeditor.CodeEditor):
     """ The base text control class.
     Inherited by the shell class and the Pyzo editor.
     The class implements autocompletion, calltips, and auto-help
-    
+
     Inherits from QsciScintilla. I tried to clean up the rather dirty api
     by using more sensible names. Hereby I apply the following rules:
     - if you set something, the method starts with "set"
@@ -240,6 +240,7 @@ class BaseTextCtrl(codeeditor.CodeEditor):
         self.setIndentUsingSpaces(pyzo.config.settings.defaultIndentUsingSpaces)
         self.setIndentWidth(pyzo.config.settings.defaultIndentWidth)
         self.setAutocompletPopupSize(*pyzo.config.view.autoComplete_popupSize)
+        self.setAutocompleteMinChars(pyzo.config.settings.autoComplete_minChars)
         self.setCancelCallback(self.restoreHelp)
 
     def setAutoCompletionAcceptKeysFromStr(self, keys):
@@ -297,19 +298,19 @@ class BaseTextCtrl(codeeditor.CodeEditor):
 
     def introspect(self, tryAutoComp=False, delay=True):
         """ introspect(tryAutoComp=False, delay=True)
-        
+
         The starting point for introspection (autocompletion and calltip).
         It will always try to produce a calltip. If tryAutoComp is True,
         will also try to produce an autocompletion list (which, on success,
         will hide the calltip).
-        
+
         This method will obtain the line and (re)start a timer that will
         call _introspectNow() after a short while. This way, if the
         user types a lot of characters, there is not a stream of useless
         introspection attempts; the introspection is only really started
         after he stops typing for, say 0.1 or 0.5 seconds (depending on
         pyzo.config.autoCompDelay).
-        
+
         The method _introspectNow() will parse the line to obtain
         information required to obtain the autocompletion and signature
         information. Then it calls processCallTip and processAutoComp
@@ -466,10 +467,10 @@ class BaseTextCtrl(codeeditor.CodeEditor):
 
     def event(self, event):
         """ event(event)
-        
+
         Overload main event handler so we can pass Ctrl-C Ctr-v etc, to the main
         window.
-        
+
         """
         if isinstance(event, QtGui.QKeyEvent):
             # Ignore CTRL+{A-Z} since those keys are handled through the menu

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -53,6 +53,7 @@ settings= dict:
     autoComplete_caseSensitive = 0
     autoComplete_fillups = '\n'
     autoComplete_acceptKeys = 'Tab'
+    autoComplete_minChars = 3
     justificationWidth = 70
     removeTrailingWhitespaceWhenSaving = 0
     changeDirOnFileExec = 0


### PR DESCRIPTION
Fixes #689 
Currently showing the popup after 3 chars. Seems to work.

**How to manage the setting ?** Should AutoCompletion refer directly to the value of pyzo setting, or should make the setting separate from AutoCompletion::__autocompleteMinChars ? This would require an update mechanism to propagate a new setting value.

Currently the interactive help still updates from the first char, which is odd. **Should the interactive help also "listen" to the pyzo setting ?** I think it would be to mundane to make a setting for the number of chars before the popup and another for updating the interactive help.