### PR TITLE
Making autodetection more automatic

### DIFF
--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -74,7 +74,7 @@ class KernelInfo(ssdf.Struct):
         self.gui = "Auto"
 
         # Use IPython if available
-        self.ipython = 'yes'
+        self.ipython = "yes"
 
         # The Python path. Paths should be separated by newlines.
         # '$PYTHONPATH' is replaced by environment variable by broker

--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -73,6 +73,9 @@ class KernelInfo(ssdf.Struct):
         # Instantiate with a value that is settable
         self.gui = "Auto"
 
+        # Use IPython if available
+        self.ipython = 'yes'
+
         # The Python path. Paths should be separated by newlines.
         # '$PYTHONPATH' is replaced by environment variable by broker
         self.pythonPath = ""

--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -113,9 +113,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Create new shell config if there is None
         if not pyzo.config.shellConfigs2:
-            from pyzo.core.kernelbroker import KernelInfo
-
-            pyzo.config.shellConfigs2.append(KernelInfo())
+            pyzo.config.shellConfigs2 = []
 
         # Focus on editor
         e = pyzo.editors.getCurrentEditor()

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -59,6 +59,7 @@ class ShellInfo_exe(QtWidgets.QComboBox):
     def setTheText(self, value):
 
         # Init
+        self.original_value = value
         self.clear()
         self.setEditable(True)
         self.setInsertPolicy(self.InsertAtTop)
@@ -558,6 +559,8 @@ class ShellInfoTab(QtWidgets.QScrollArea):
         try:
             for key, widget in self._shellInfoWidgets.items():
                 info[key] = widget.getTheText()
+            if info["exe"] != self._shellInfoWidgets["exe"].original_value :
+                info["wasAutodetected"] = False
 
         except Exception as why:
             print("Error getting info in shell config:", why)

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -559,7 +559,7 @@ class ShellInfoTab(QtWidgets.QScrollArea):
         try:
             for key, widget in self._shellInfoWidgets.items():
                 info[key] = widget.getTheText()
-            if info["exe"] != self._shellInfoWidgets["exe"].original_value :
+            if info["exe"] != self._shellInfoWidgets["exe"].original_value:
                 info["wasAutodetected"] = False
 
         except Exception as why:

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -622,13 +622,13 @@ class InterpreterHelper(QtWidgets.QWidget):
         self.setLayout(layout)
         layout.addWidget(self._label, 1)
 
-    def refresh(self, noRedetect = False):
+    def refresh(self):
         self._label.setText("Detecting interpreters ...")
         QtWidgets.qApp.flush()
         QtWidgets.qApp.processEvents()
-        self.detect(noRedetect)
+        self.detect()
 
-    def detect(self, noRedetect = False):
+    def detect(self):
 
         python_link = '<a href="https://www.python.org/">Python</a>'
         conda_link = '<a href="https://miniconda.pyzo.org">Miniconda</a>'
@@ -636,9 +636,8 @@ class InterpreterHelper(QtWidgets.QWidget):
         configs = pyzo.config.shellConfigs2
 
         # Hide now?
-        if (noRedetect or pyzo.config.settings.auto_useFound < 2) and configs and configs[0].exe:
-            self._label.setText("Happy coding!")
-            QtCore.QTimer.singleShot(1200, self.hide_this)
+        if pyzo.config.settings.auto_useFound < 2 and configs and configs[0].exe:
+            self.finish()
             return
 
         # Always sleep for a bit, so show that we've refreshed
@@ -697,7 +696,7 @@ class InterpreterHelper(QtWidgets.QWidget):
                 python_link,
                 conda_link,
             )
-        if pyzo.config.settings.auto_useFound > 0 and not noRedetect and self._the_exe :
+        if pyzo.config.settings.auto_useFound > 0 and self._the_exe :
             QtWidgets.qApp.flush()
             QtWidgets.qApp.processEvents()
             self.useFound()
@@ -746,9 +745,15 @@ class InterpreterHelper(QtWidgets.QWidget):
                 config_to_use.exe = self._the_exe
                 config_to_use.wasAutodetected = True
                 self.restart_shell(config_to_use)
-            self.refresh(True)
+            self.finish()
         else:
             self.refresh()
+
+    def finish(self) :
+        QtWidgets.qApp.flush()
+        QtWidgets.qApp.processEvents()
+        self._label.setText("Happy coding!")
+        QtCore.QTimer.singleShot(1200, self.hide_this)
 
     def hide_this(self):
         shells = self.parent()

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -696,7 +696,7 @@ class InterpreterHelper(QtWidgets.QWidget):
                 python_link,
                 conda_link,
             )
-        if pyzo.config.settings.auto_useFound > 0 and self._the_exe :
+        if pyzo.config.settings.auto_useFound > 0 and self._the_exe:
             QtCore.QTimer.singleShot(100, self.useFound)
 
         link_style = "font-weight: bold; color:#369; text-decoration:underline;"
@@ -730,16 +730,21 @@ class InterpreterHelper(QtWidgets.QWidget):
             # if there is no shell : create one and use it
             # if auto_useFound == 2 and there is an autodetected shell : update it
             # if auto_useFound == 2 and there is no autodetected shell : create one and use it
-            if pyzo.config.settings.auto_useFound == 2 :
-                for conf in configs :
-                    if getattr(conf, "wasAutodetected", False) :
+            if pyzo.config.settings.auto_useFound == 2:
+                for conf in configs:
+                    if getattr(conf, "wasAutodetected", False):
                         config_to_use = conf
                         break
-            if len(configs) == 0 or pyzo.config.settings.auto_useFound == 2 and config_to_use is None :
+            if (
+                len(configs) == 0
+                or pyzo.config.settings.auto_useFound == 2
+                and config_to_use is None
+            ):
                 from pyzo.core.kernelbroker import KernelInfo
+
                 configs.insert(0, KernelInfo())
                 config_to_use = configs[0]
-            if config_to_use is not None :
+            if config_to_use is not None:
                 config_to_use.exe = self._the_exe
                 config_to_use.wasAutodetected = True
                 self.restart_shell(config_to_use)
@@ -747,7 +752,7 @@ class InterpreterHelper(QtWidgets.QWidget):
         else:
             self.refresh()
 
-    def finish(self) :
+    def finish(self):
         QtWidgets.qApp.flush()
         QtWidgets.qApp.processEvents()
         self._label.setText("Happy coding!")
@@ -757,10 +762,10 @@ class InterpreterHelper(QtWidgets.QWidget):
         shells = self.parent()
         shells.showInterpreterHelper(False)
 
-    def restart_shell(self, config = None):
-        if config is None and len(pyzo.config.shellConfigs2) > 0 :
+    def restart_shell(self, config=None):
+        if config is None and len(pyzo.config.shellConfigs2) > 0:
             config = pyzo.config.shellConfigs2[0]
-        if config is None :
+        if config is None:
             return
         shells = self.parent()
         shell = shells.getCurrentShell()

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -697,9 +697,7 @@ class InterpreterHelper(QtWidgets.QWidget):
                 conda_link,
             )
         if pyzo.config.settings.auto_useFound > 0 and self._the_exe :
-            QtWidgets.qApp.flush()
-            QtWidgets.qApp.processEvents()
-            self.useFound()
+            QtCore.QTimer.singleShot(100, self.useFound)
 
         link_style = "font-weight: bold; color:#369; text-decoration:underline;"
         self._label.setText(text.replace("<a ", '<a style="%s" ' % link_style))

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -753,8 +753,6 @@ class InterpreterHelper(QtWidgets.QWidget):
             self.refresh()
 
     def finish(self):
-        QtWidgets.qApp.flush()
-        QtWidgets.qApp.processEvents()
         self._label.setText("Happy coding!")
         QtCore.QTimer.singleShot(1200, self.hide_this)
 

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -727,12 +727,23 @@ class InterpreterHelper(QtWidgets.QWidget):
         # Set newfound interpreter
         if self._the_exe:
             configs = pyzo.config.shellConfigs2
-            if not configs:
+            config_to_use = None
+            # if there is no shell : create one and use it
+            # if auto_useFound == 2 and there is an autodetected shell : update it
+            # if auto_useFound == 2 and there is no autodetected shell : create one and use it
+            if pyzo.config.settings.auto_useFound == 2 :
+                for conf in configs :
+                    if getattr(conf, "wasAutodetected", False) :
+                        config_to_use = conf
+                        break
+            if len(configs) == 0 or pyzo.config.settings.auto_useFound == 2 and config_to_use is None :
                 from pyzo.core.kernelbroker import KernelInfo
-
-                pyzo.config.shellConfigs2.append(KernelInfo())
-            configs[0].exe = self._the_exe
-            self.restart_shell()
+                configs.insert(0, KernelInfo())
+                config_to_use = configs[0]
+            if config_to_use :
+                config_to_use.exe = self._the_exe
+                config_to_use.wasAutodetected = True
+                self.restart_shell()
         self.refresh()
 
     def hide_this(self):

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -640,15 +640,15 @@ class InterpreterHelper(QtWidgets.QWidget):
             self.finish()
             return
 
-        # Always sleep for a bit, so show that we've refreshed
-        time.sleep(0.05)
-
         # Try to find an interpreter
         from pyzo.util.interpreters import get_interpreters
 
         interpreters = list(reversed(get_interpreters("2.4")))
         conda_interpreters = [i for i in interpreters if i.is_conda]
         conda_interpreters.sort(key=lambda x: len(x.path.replace("pyzo", "pyzo" * 10)))
+
+        # Always sleep for a bit, so show that we've refreshed
+        time.sleep(0.05)
 
         if conda_interpreters and conda_interpreters[0].version > "3":
             self._the_exe = conda_interpreters[0].path

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -636,7 +636,7 @@ class InterpreterHelper(QtWidgets.QWidget):
         configs = pyzo.config.shellConfigs2
 
         # Hide now?
-        if configs and configs[0].exe:
+        if pyzo.config.settings.auto_useFound < 2 and configs and configs[0].exe:
             self._label.setText("Happy coding!")
             QtCore.QTimer.singleShot(1200, self.hide_this)
             return

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -73,13 +73,13 @@ def shellTitle(shell, moreinfo=False):
 
 class ShellStackWidget(QtWidgets.QWidget):
     """ The shell stack widget provides a stack of shells.
-    
+
     It wrapps a QStackedWidget that contains the shell objects. This
     stack is used as a reference to synchronize the shell selection with.
     We keep track of what is the current selected shell and apply updates
     if necessary. Therefore, changing the current shell in the stack
     should be enough to invoke a full update.
-    
+
     """
 
     # When the current shell changes.
@@ -648,9 +648,6 @@ class InterpreterHelper(QtWidgets.QWidget):
         conda_interpreters = [i for i in interpreters if i.is_conda]
         conda_interpreters.sort(key=lambda x: len(x.path.replace("pyzo", "pyzo" * 10)))
 
-        # Always sleep for a bit, so show that we've refreshed
-        time.sleep(0.05)
-
         if conda_interpreters and conda_interpreters[0].version > "3":
             self._the_exe = conda_interpreters[0].path
             text = """Pyzo detected a conda environment in:
@@ -697,6 +694,11 @@ class InterpreterHelper(QtWidgets.QWidget):
                 python_link,
                 conda_link,
             )
+        if pyzo.config.settings.auto_useFound > 0 and self._the_exe :
+            self.useFound()
+        else :
+            # Always sleep for a bit, so show that we've refreshed
+            time.sleep(0.05)
 
         link_style = "font-weight: bold; color:#369; text-decoration:underline;"
         self._label.setText(text.replace("<a ", '<a style="%s" ' % link_style))

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -46,6 +46,7 @@ settings= dict:
     defaultIndentWidth = 4
     defaultIndentUsingSpaces = 1
     defaultLineEndings = '' # Set depending on OS
+    auto_useFound = 0      # 0 = old behaviour, 1 = no confirmation, 2 = no confirmation and reuse autodetect each time
     autoIndent = 1
     autoCallTip = 1
     autoComplete_keywords = 1


### PR DESCRIPTION
Fixes #688 

This adds a new setting auto_useFound :
- if 0, the current behaviour is retained,
- if 1, upon autodetecting a python interpreter, the confirmation step will be skipped, 
- if 2, autodetection will be performed even if there already exists a shell in the configuration.

To avoid spamming the shell config list with new shells in mode 2, when a shell config is created from autodetection, it is marked as such (wasAutodetected property set to 1). The useFound method will scan the existing shell configs to find a config with this property, and will update the exe in that config.

Incidentally, this sets the "use IPython if available" property to 1 by default for new shell configs.

This also changes the behaviour of pyzo when the starting config does not have a shellConfigs2 at all : instead of populating it with a spurious shell config with the empty string as exe, it creates an empty list. The previous behaviour prevented autodetection from working in such a case.

EDIT : this now works. Instead of calling useFound from detect, I set a 100 ms QTimer to do it. This seems to let everything that's needed be properly created.

The PR works as intended. In mode 2 in particular, additional shell configs that were manually created by the user remain untouched.

To avoid a problem where the user is in mode 2 but has modified the autodetected exe and it gets overwritten at next start, the shell config editor is tweaked to remove the wasAutodetected flag when a config exe is modified.

The shell config that gets started at the beginning is the config that was just created/updated with useFound, if any, or the first one in the config list, if useFound was not called.