### PR TITLE
Make hidpi work for multiple monitors

### DIFF
--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -96,7 +96,7 @@ from pyzo.util.qt import QtCore, QtGui, QtWidgets
 
 # Enable high-res displays
 try:
-    ctypes.windll.shcore.SetProcessDpiAwareness(True)
+    ctypes.windll.shcore.SetProcessDpiAwareness(2)
 except Exception:
     pass  # fail on non-windows
 try:


### PR DESCRIPTION
Use-case: When I connect my 4K monitor and set it up to be the only monitor, the GUI is scaled correctly and fonts look crisp.  (The 16x16 icons look fuzzy, but that's a problem for another day.) When I set the monitor up as an additional display, everything looks a bit fuzzy. What matters is the situation when Pyzo starts up. Using one monitor, then starting Pyzo, then switching to two monitors, will keep Pyzo in a good state.

The problem is that Pyzo is currently setup to be system-level aware. Search for "dpiawareness" on https://doc.qt.io/qt-5/highdpi.html. This PR fixes that.

