### PR TITLE
Improve hidpi behavior

### DIFF
--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -96,6 +96,7 @@ from pyzo.util.qt import QtCore, QtGui, QtWidgets
 
 # Enable high-res displays
 try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(1)
     ctypes.windll.shcore.SetProcessDpiAwareness(2)
 except Exception:
     pass  # fail on non-windows


### PR DESCRIPTION
With #696 the behavior with high resolution monitors has much improved. But I recently found Pyzo in a state where half the application was in high-res mode, and some was not. It was as really odd: within the same list widget, some items where smaller than others. I should have made a screenshot. The error persisted even after restarting Pyzo.

My guess is that it is related to unplugging a high-res monitor and plugging in another, or something like this.

Anyway, I found that adding this lines fixes it:
```py
    ctypes.windll.shcore.SetProcessDpiAwareness(1)   # <-- added
    ctypes.windll.shcore.SetProcessDpiAwareness(2)
```
My suspicion is that with the first line it will pick up the global dpi setting, and then with the second line it will refine to the current monitor. Doing only the latter can apparently cause Qt to be in some sort of "floating" dpi state.