### PR TITLE
replace deprecated isAlive() per is_alive()

### DIFF
--- a/pyzo/core/commandline.py
+++ b/pyzo/core/commandline.py
@@ -147,7 +147,7 @@ def is_our_server_running():
     not running, this is probably not the first Pyzo, but there might
     also be problem with starting the server.
     """
-    return server and server.isAlive()
+    return server and server.is_alive()
 
 
 def is_pyzo_server_running():

--- a/pyzo/yoton/channels/channels_reqrep.py
+++ b/pyzo/yoton/channels/channels_reqrep.py
@@ -700,7 +700,7 @@ class RepChannel(BaseChannel):
             self._timer.start()
         elif mode in [2, "thread", "thread-driven"]:
             self._run_mode = 2
-            if not self._thread.isAlive():
+            if not self._thread.is_alive():
                 self._thread.start()
         else:
             raise ValueError("Invalid mode for ReqChannel instance.")


### PR DESCRIPTION
deprecated isAlive() has been removed in Python-3.9

solves https://github.com/pyzo/pyzo/issues/713