### PR TITLE
Disable button to terminate shell but leave it open

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1223,15 +1223,15 @@ class ShellMenu(Menu):
                 self._shellAction,
                 "restart",
             ),
-            self.addItem(
-                translate(
-                    "menu",
-                    "Terminate ::: Terminate the interpreter, leaving the shell open.",
-                ),
-                icons.application_delete,
-                self._shellAction,
-                "terminate",
-            ),
+            # self.addItem(
+            #     translate(
+            #         "menu",
+            #         "Terminate ::: Terminate the interpreter, leaving the shell open.",
+            #     ),
+            #     icons.application_delete,
+            #     self._shellAction,
+            #     "terminate",
+            # ),
             self.addItem(
                 translate(
                     "menu", "Close ::: Terminate the interpreter and close the shell."


### PR DESCRIPTION
Removes some clutter. The use-case for terminating a shell without closing it are very slim ...