### PR TITLE
build on 39

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 variables:
   NAME: pyzo
   PY_ARCH: x64
-  PY_VERSION: 3.7
+  PY_VERSION: 3.9
   PY_EXE: python
 
 jobs:

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -41,7 +41,7 @@ and workspace.
 """
 
 # Set version number
-__version__ = "4.11.0"
+__version__ = "4.11.1"
 
 import os
 import sys

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -69,6 +69,9 @@ if getattr(sys, "frozen", False):
 if "QT_AUTO_SCREEN_SCALE_FACTOR" not in os.environ:
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 
+# Fix Qt now showing a window on MacOS Big Sur
+os.environ["QT_MAC_WANTS_LAYER"] = "1"
+
 # Import yoton as an absolute package
 from pyzo import yotonloader  # noqa
 from pyzo.util import paths


### PR DESCRIPTION
This makes the CI/CD builds run on Python 3.9 and sets the `QT_MAC_WANTS_LAYER` environment variable to make Qt (and thus  Pyzo) work on MacOS Big Sur. Also bumps the version number, because I provided the MacOS build artifact for testing, and giving it a different version number helps differentiate between versions.