### PR TITLE
Tweaks to make Pyzo consume less power when idle

### DIFF
--- a/pyzo/core/icons.py
+++ b/pyzo/core/icons.py
@@ -564,7 +564,7 @@ class ShellIconMaker:
 
         # Create timer
         self._timer = QtCore.QTimer(None)
-        self._timer.setInterval(150)
+        self._timer.setInterval(200)
         self._timer.setSingleShot(False)
         self._timer.timeout.connect(self.onTimer)
 

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -39,7 +39,7 @@ from pyzo.core.menu import ShellContextMenu
 
 # Interval for polling messages. Timer for each kernel. I found
 # that this one does not affect performance much
-POLL_TIMER_INTERVAL = 30  # 30 ms 33Hz
+POLL_TIMER_INTERVAL = 100  # 100ms 10Hz
 
 # Maximum number of lines in the shell
 MAXBLOCKCOUNT = pyzo.config.advanced.shellMaxLines

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -313,7 +313,7 @@ class ShellControl(QtWidgets.QToolButton):
 
         # Create timer
         self._elapsedTimesTimer = QtCore.QTimer(self)
-        self._elapsedTimesTimer.setInterval(200)
+        self._elapsedTimesTimer.setInterval(1000)
         self._elapsedTimesTimer.setSingleShot(False)
         self._elapsedTimesTimer.timeout.connect(self.onElapsedTimesTimer)
 

--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -577,7 +577,7 @@ class App_qt(App_base):
         # Create timer
         timer = self._timer = self._QtCore.QTimer()
         timer.setSingleShot(False)
-        timer.setInterval(int(0.05 * 1000))  # ms
+        timer.setInterval(int(0.1 * 1000))  # ms
         timer.timeout.connect(repl_callback)
         timer.start()
 

--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -66,11 +66,15 @@ class App_base:
             interpreter.more = 0
             interpreter.newPrompt = True
 
-    def run(self, repl_callback, sleeptime=0.01):
+    def run(self, repl_callback, sleep_time=0.01):
         """Very simple mainloop. Subclasses can overload this to use
-        the native event loop. Attempt to process GUI events at least
-        every sleeptime seconds.
+        the native event loop. Attempt to process GUI events every so often.
         """
+
+        # The sleep_time is 100Hz by default, which seems like an ok balance
+        # between CPU strain and smooth animations. Ideally we'd run a
+        # real event loop though, that is fast when needed and just sleeps
+        # when the gui is idle, saving battery life.
 
         if hasattr(time, "perf_counter"):
             perf_counter = time.perf_counter
@@ -78,7 +82,8 @@ class App_base:
             perf_counter = time.time
         perf_counter
 
-        _sleeptime = sleeptime
+        repl_time = 0.099
+        next_repl = perf_counter() + repl_time
 
         # The toplevel while-loop is just to catch Keyboard interrupts
         # and then proceed. The inner while-loop is the actual event loop.
@@ -86,9 +91,11 @@ class App_base:
             try:
 
                 while True:
-                    time.sleep(_sleeptime)
-                    repl_callback()
+                    time.sleep(sleep_time)
                     self.process_events()
+                    if perf_counter() > next_repl:
+                        next_repl = perf_counter() + repl_time
+                        repl_callback()
 
             except KeyboardInterrupt:
                 self._keyboard_interrupt()
@@ -104,6 +111,14 @@ class App_base:
         raise SystemExit()
 
 
+class App_nogui(App_base):
+    """The app for when there is no GUI."""
+
+    def run(self, repl_callback):
+        # Move at a slow pace - there is no gui to keep running
+        super().run(repl_callback, 0.1)
+
+
 # Experimental and WIP - not used at the moment
 class App_asyncio_new(App_base):
     """Based on asyncio (standard Python) event loop.
@@ -117,24 +132,16 @@ class App_asyncio_new(App_base):
         asyncio.integrate_with_ide = self.enable
         self._loop = None
 
-    def run(self, repl_callback, sleeptime=0.01):
+    def run(self, repl_callback):
         import asyncio
 
         self._repl_callback = repl_callback
-        self._sleeptime = sleeptime
+        self._sleeptime = 0.1
 
         loop = asyncio.get_event_loop()
         self.enable(loop, True)
 
     def enable(self, loop, run=False):
-
-        # If using qasync, create a tiny window to prevent closing. Naah ugly
-        # if hasattr(loop, "_QEventLoop__app"):
-        #     mod = sys.modules[loop._QEventLoop__app.__module__]
-        #     self._w = mod.QWidget(None)
-        #     self._w.resize(1, 1)
-        #     self._w.show()
-
         self.swap_loops_when_new_one_starts(self._loop, loop)
 
         loop.call_later(self._sleeptime, self._ping_repl_callback)
@@ -408,7 +415,7 @@ class App_tornado(App_base):
             self._warned_about_process_events = True
         # self.app.run_sync(lambda x=None: None)
 
-    def run(self, repl_callback, sleeptime=None):
+    def run(self, repl_callback):
         from tornado.ioloop import PeriodicCallback
 
         # Create timer
@@ -565,7 +572,7 @@ class App_qt(App_base):
         self.app.sendPostedEvents()
         self.app.processEvents()
 
-    def run(self, repl_callback, sleeptime=None):
+    def run(self, repl_callback):
         # Create timer
         timer = self._timer = self._QtCore.QTimer()
         timer.setSingleShot(False)

--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -136,15 +136,15 @@ class App_asyncio_new(App_base):
         import asyncio
 
         self._repl_callback = repl_callback
-        self._sleeptime = 0.1
+        self._sleep_time = 0.1
 
         loop = asyncio.get_event_loop()
         self.enable(loop, True)
 
     def enable(self, loop, run=False):
-        self.swap_loops_when_new_one_starts(self._loop, loop)
-
-        loop.call_later(self._sleeptime, self._ping_repl_callback)
+        if loop is not self._loop:
+            self.swap_loops_when_new_one_starts(self._loop, loop)
+            loop.call_later(self._sleep_time, self._ping_repl_callback)
         if run:
             loop.run_forever()
 
@@ -153,7 +153,8 @@ class App_asyncio_new(App_base):
             if old_loop and old_loop.is_running():
                 old_loop.stop()
             self._loop = new_loop
-            new_loop.original_run_forever(*args, **kwargs)
+            if not new_loop.is_running():
+                new_loop.original_run_forever(*args, **kwargs)
 
         if not hasattr(new_loop, "original_run_forever"):
             new_loop.original_run_forever = new_loop.run_forever
@@ -172,7 +173,7 @@ class App_asyncio_new(App_base):
 
         # If its the same as our current loop, we want to be called again
         if loop:
-            self._loop.call_later(self._sleeptime, self._ping_repl_callback)
+            self._loop.call_later(self._sleep_time, self._ping_repl_callback)
 
     def quit(self):
         if self._loop:

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -118,7 +118,6 @@ class PyzoInterpreter:
       * introspector: the introspector instance (a subclassed yoton.RepChannel)
       * magician: the object that handles the magic commands
       * guiApp: a wrapper for the integrated GUI application
-      * sleeptime: the amount of time (in seconds) to sleep at each iteration
 
     """
 
@@ -158,10 +157,6 @@ class PyzoInterpreter:
 
         # Init buffer to deal with multi-line command in the shell
         self._buffer = []
-
-        # Init sleep time. 0.001 result in 0% CPU usage at my laptop (Windows),
-        # but 8% CPU usage at my older laptop (on Linux).
-        self.sleeptime = 0.01  # 100 Hz
 
         # Create compiler
         if sys.platform.startswith("java"):
@@ -221,7 +216,7 @@ class PyzoInterpreter:
 
         # Enter main
         try:
-            self.guiApp.run(self.process_commands, self.sleeptime)
+            self.guiApp.run(self.process_commands)
         except SystemExit:
             # Set self._exitException if it is not set yet
             type, value, tb = sys.exc_info()
@@ -488,7 +483,7 @@ class PyzoInterpreter:
         event loop).
         """
 
-        self.guiApp = guiintegration.App_base()
+        self.guiApp = guiintegration.App_nogui()
         self.guiName = guiName = startup_info["gui"].upper()
         guiError = ""
 

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -499,7 +499,7 @@ class PyzoInterpreter:
                     ("PYSIDE", guiintegration.App_pyside),
                     ("PYQT4", guiintegration.App_pyqt4),
                     # ('WX', guiintegration.App_wx),
-                    ("ASYNCIO", guiintegration.App_asyncio),
+                    ("ASYNCIO", guiintegration.App_asyncio_new),
                     ("TK", guiintegration.App_tk),
                 ]:
                     try:
@@ -511,7 +511,7 @@ class PyzoInterpreter:
                 else:
                     guiName = ""
             elif guiName == "ASYNCIO":
-                self.guiApp = guiintegration.App_asyncio()
+                self.guiApp = guiintegration.App_asyncio_new()
             elif guiName == "TK":
                 self.guiApp = guiintegration.App_tk()
             elif guiName == "WX":

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,9 @@ setup(
     platforms="any",
     provides=["pyzo"],
     python_requires=">=3.5.0",
-    install_requires=["packaging"],  # and 'PySide2' or 'PyQt5' (less sure about PySide/PyQt4)
+    install_requires=[
+        "packaging"
+    ],  # and 'PySide2' or 'PyQt5' (less sure about PySide/PyQt4)
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_dir={"pyzo": "pyzo"},
     package_data={


### PR DESCRIPTION
MacOS's activity monitor also shows the "energy impact", and it showed that Pyzo in idle mode is more hungry than other applications. These measures reduce that quite a bit. The kernel (with no GUI or asyncio GUI) seem to be about 8x leaner, and the IDE itself about 2x.

This also uses the new asyncio gui integration, which I worked on earlier, but never applied yet.