### PR TITLE
Compatibility Python 3.10

### DIFF
--- a/pyzo/yoton/channels/channels_base.py
+++ b/pyzo/yoton/channels/channels_base.py
@@ -257,7 +257,7 @@ class BaseChannel(object):
         if not value:
             self._send_condition.acquire()
             try:
-                if sys.version_info[0] < 3.10:
+                if sys.version_info < (2, 6):
                     self._send_condition.notifyAll()
                 else:
                     self._send_condition.notify_all()

--- a/pyzo/yoton/channels/channels_base.py
+++ b/pyzo/yoton/channels/channels_base.py
@@ -9,7 +9,7 @@
 Defines the base channel class and the MessageType class.
 
 """
-
+import sys
 import time
 import threading
 
@@ -257,7 +257,10 @@ class BaseChannel(object):
         if not value:
             self._send_condition.acquire()
             try:
-                self._send_condition.notifyAll()
+                if sys.version_info[0] < 3.10:
+                    condition.notifyAll()
+                else:
+                    condition.notify_all() 
             finally:
                 self._send_condition.release()
 

--- a/pyzo/yoton/channels/channels_base.py
+++ b/pyzo/yoton/channels/channels_base.py
@@ -258,9 +258,9 @@ class BaseChannel(object):
             self._send_condition.acquire()
             try:
                 if sys.version_info[0] < 3.10:
-                    condition.notifyAll()
+                    self._send_condition.notifyAll()
                 else:
-                    condition.notify_all() 
+                    self._send_condition.notify_all()
             finally:
                 self._send_condition.release()
 

--- a/pyzo/yoton/misc.py
+++ b/pyzo/yoton/misc.py
@@ -569,7 +569,7 @@ class TinyPackageQueue(PackageQueue):
 
             # Notify if this pop would reduce the length below the threshold
             if len(q) <= self._tinylen:
-                if sys.version_info[0] < 3.10:
+                if sys.version_info < (2, 6):
                     condition.notifyAll()  # wait() procedes
                 else:
                     condition.notify_all() 

--- a/pyzo/yoton/misc.py
+++ b/pyzo/yoton/misc.py
@@ -572,7 +572,7 @@ class TinyPackageQueue(PackageQueue):
                 if sys.version_info < (2, 6):
                     condition.notifyAll()  # wait() procedes
                 else:
-                    condition.notify_all() 
+                    condition.notify_all()
 
             # Return item
             return q.popleft()

--- a/pyzo/yoton/misc.py
+++ b/pyzo/yoton/misc.py
@@ -569,7 +569,10 @@ class TinyPackageQueue(PackageQueue):
 
             # Notify if this pop would reduce the length below the threshold
             if len(q) <= self._tinylen:
-                condition.notifyAll()  # wait() procedes
+                if sys.version_info[0] < 3.10:
+                    condition.notifyAll()  # wait() procedes
+                else:
+                    condition.notify_all() 
 
             # Return item
             return q.popleft()


### PR DESCRIPTION
notifyAll() deprecated and replaced with notify_all() in Python 3.10