### PR TITLE
fix introspection infinite iteration for special cases

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -254,7 +254,7 @@ class PyzoIntrospector(yoton.RepChannel):
                         hasattr(val, "__array__")
                         and hasattr(val, "dtype")
                         and hasattr(val, "shape")
-                        and not hasattr(val, "__this_object_is_definitely_not_an_array__")
+                        and not hasattr(val, "if_this_is_an_attribute_then_there_are_likely_inf_attributes")
                     ):
                         kind = "array"
                     elif isinstance(val, list):

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -254,6 +254,7 @@ class PyzoIntrospector(yoton.RepChannel):
                         hasattr(val, "__array__")
                         and hasattr(val, "dtype")
                         and hasattr(val, "shape")
+                        and not hasattr(val, "__this_object_is_definitely_not_an_array__")
                     ):
                         kind = "array"
                     elif isinstance(val, list):


### PR DESCRIPTION
As described in #816, some special cases will cause the Pyzo introspection to iterate infinitely for special class objects, and this can result in steadily rising memory usage.

The example in the issue can be broken down to the code
```
class Query:
    def __init__(self):
        print('__init__')

    def __getattr__(self, item):
        print('__getattr__', item)
        return self

    def __getitem__(self, item):
        print('__getitem__', item)
        # TODO: allocate memory
        return

Q = Query()
```
When running this code in Pyzo, pyzokernel/introspection.py will see a new global variable "Q" and run "dir2". Then "dir2" and "storeInfo" will execute `hasattr(val, "__array__")` etc. and come to the conclusion, that the object is an array -- because the Query class will have any attribute that is looked up (see `__getattr__`). Still in "storeInfo", the line `tmp = "x".join([str(s) for s in val.shape])` is executed to make a string that contains e.g. "2x3" for a 2 rows 3 columns array, but in this case, `val.shape` will be a `Query` object. And inside the list comprehension, `val.shape[0]`, `val.shape[1]`, `val.shape[2]`, etc. will be accessed in an infinite loop because `Query.__getitem__` never gets exhausted.

The proposed change fixes that special case by adding another criterion for checking if the object is an array.

