### PR TITLE
Introduce PYZO_DEFAULT_SHELL_PYTHON_EXE env-var

### DIFF
--- a/pyzo/core/commandline.py
+++ b/pyzo/core/commandline.py
@@ -12,7 +12,7 @@ is started to open the file.
 
 This module is used at the very early stages of starting pyzo, and also
 in main.py to apply any command line args for the current process, and
-to closse down the server when pyzo is closed.
+to close down the server when pyzo is closed.
 """
 
 import sys


### PR DESCRIPTION
Closes https://github.com/pyzo/pyzo/issues/814

Makes pyzo consider a user-defined python exe file without having to write it down manually in the file explorer.

This comes in handy for NixOS users because they'll be able to make pyzo automatically propose a specific python executable from the nix store, which is a better UX than having to directly deal with the hash-looking paths of the store...