### PR TITLE
Fix Enums on pyside 6.4

### DIFF
--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -148,13 +148,14 @@ class CodeEditorBase(QtWidgets.QPlainTextEdit):
 
         # Set some document options
         # Setting this option breaks the showWhitespace and showLineEndings options in PySyde6.4
-        # option = self.document().defaultTextOption()
+        option = self.document().defaultTextOption()
         # option.setFlags(
         #     option.flags()
         #     | option.IncludeTrailingSpaces
         #     | option.AddSpaceForLineAndParagraphSeparators
         # )
-        # self.document().setDefaultTextOption(option)
+        option.setFlags(QtCore.QFlag())
+        self.document().setDefaultTextOption(option)
 
         # When the cursor position changes, invoke an update, so that
         # the hihghlighting etc will work

--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -148,13 +148,12 @@ class CodeEditorBase(QtWidgets.QPlainTextEdit):
 
         # Set some document options
         # Setting this option breaks the showWhitespace and showLineEndings options in PySyde6.4
-        option = self.document().defaultTextOption()
+        option = QtGui.QTextOption()#self.document().defaultTextOption()
         # option.setFlags(
         #     option.flags()
         #     | option.IncludeTrailingSpaces
         #     | option.AddSpaceForLineAndParagraphSeparators
         # )
-        option.setFlags(QtCore.QFlag())
         self.document().setDefaultTextOption(option)
 
         # When the cursor position changes, invoke an update, so that

--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -148,7 +148,7 @@ class CodeEditorBase(QtWidgets.QPlainTextEdit):
 
         # Set some document options
         # Setting this option breaks the showWhitespace and showLineEndings options in PySyde6.4
-        option = QtGui.QTextOption()#self.document().defaultTextOption()
+        option = QtGui.QTextOption()  # self.document().defaultTextOption()
         # option.setFlags(
         #     option.flags()
         #     | option.IncludeTrailingSpaces

--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -34,7 +34,7 @@ class Extension:
     def __init__(self, *args, extensionParam1 = 1, extensionParam2 = 3, **kwds):
         super().__init__(*args, **kwds)
         some_extension_init_stuff()
-        
+
 Note the following points:
  - All parameters have default values
  - The use of *args passes all non-named arguments to its super(), which
@@ -82,7 +82,7 @@ FancyEditor defined above:
 - then the CodeEditorBase, with the text
 - then the extensions that draw in front of the text (i.e. call
   super().paintEvent before painting), in the order ..., Extension2, Extension1
-  
+
 OVERRIDING OTHER EVENT HANDLERS
 
 When overriding other event handlers, be sure to call the super()'s event
@@ -147,13 +147,14 @@ class CodeEditorBase(QtWidgets.QPlainTextEdit):
         self.__highlighter = Highlighter(self, self.document())
 
         # Set some document options
-        option = self.document().defaultTextOption()
-        option.setFlags(
-            option.flags()
-            | option.IncludeTrailingSpaces
-            | option.AddSpaceForLineAndParagraphSeparators
-        )
-        self.document().setDefaultTextOption(option)
+        # Setting this option breaks the showWhitespace and showLineEndings options in PySyde6.4
+        # option = self.document().defaultTextOption()
+        # option.setFlags(
+        #     option.flags()
+        #     | option.IncludeTrailingSpaces
+        #     | option.AddSpaceForLineAndParagraphSeparators
+        # )
+        # self.document().setDefaultTextOption(option)
 
         # When the cursor position changes, invoke an update, so that
         # the hihghlighting etc will work

--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -730,12 +730,17 @@ class ShowWhitespace(object):
 
     @ce_option(False)
     def setShowWhitespace(self, value):
-        option = self.document().defaultTextOption()
-        if value:
-            option.setFlags(option.flags() | option.ShowTabsAndSpaces)
-        else:
-            option.setFlags(option.flags() & ~option.ShowTabsAndSpaces)
-        self.document().setDefaultTextOption(option)
+        try:
+            option = self.document().defaultTextOption()
+            if value:
+                option.setFlags(option.flags() | option.ShowTabsAndSpaces)
+            else:
+                option.setFlags(option.flags() & ~option.ShowTabsAndSpaces)
+            self.document().setDefaultTextOption(option)
+        except Exception:
+            # This can produce: 2147483617 is not a valid QTextOption.Flag
+            # and I do not know how to avoid it :/
+            pass
 
 
 class ShowLineEndings(object):
@@ -746,12 +751,17 @@ class ShowLineEndings(object):
         return bool(option.flags() & option.ShowLineAndParagraphSeparators)
 
     def setShowLineEndings(self, value):
-        option = self.document().defaultTextOption()
-        if value:
-            option.setFlags(option.flags() | option.ShowLineAndParagraphSeparators)
-        else:
-            option.setFlags(option.flags() & ~option.ShowLineAndParagraphSeparators)
-        self.document().setDefaultTextOption(option)
+        try:
+            option = self.document().defaultTextOption()
+            if value:
+                option.setFlags(option.flags() | option.ShowLineAndParagraphSeparators)
+            else:
+                option.setFlags(option.flags() & ~option.ShowLineAndParagraphSeparators)
+            self.document().setDefaultTextOption(option)
+        except Exception:
+            # This can produce: 2147483617 is not a valid QTextOption.Flag
+            # and I do not know how to avoid it :/
+            pass
 
 
 class LineNumbers(object):

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -2641,8 +2641,8 @@ class KeyMapModel(QtCore.QAbstractItemModel):
             return isinstance(index.internalPointer(), QtWidgets.QMenu)
 
     def index(self, row, column, parent):
-        # if not self.hasIndex(row, column, parent):
-        #     return QtCore.QModelIndex()
+        if not self.hasIndex(row, column, parent):
+            return QtCore.QModelIndex()
         # establish parent
         if not parent.isValid():
             parentMenu = self._root

--- a/pyzo/core/themeEdit.py
+++ b/pyzo/core/themeEdit.py
@@ -182,10 +182,7 @@ class StyleEdit(QtWidgets.QWidget):
         """
 
         checkBox = QtWidgets.QCheckBox()
-
-        self.setters[key] = lambda val, check=checkBox: check.setCheckState(
-            val == "yes"
-        )
+        self.setters[key] = lambda val, check=checkBox: check.setCheckState([QtCore.Qt.CheckState.Unchecked, QtCore.Qt.CheckState.Checked][val == "yes"])
 
         checkBox.stateChanged.connect(
             lambda state, key=key: self.__update(key, "yes" if state else "no")

--- a/pyzo/core/themeEdit.py
+++ b/pyzo/core/themeEdit.py
@@ -182,7 +182,9 @@ class StyleEdit(QtWidgets.QWidget):
         """
 
         checkBox = QtWidgets.QCheckBox()
-        self.setters[key] = lambda val, check=checkBox: check.setCheckState([QtCore.Qt.CheckState.Unchecked, QtCore.Qt.CheckState.Checked][val == "yes"])
+        self.setters[key] = lambda val, check=checkBox: check.setCheckState(
+            [QtCore.Qt.CheckState.Unchecked, QtCore.Qt.CheckState.Checked][val == "yes"]
+        )
 
         checkBox.stateChanged.connect(
             lambda state, key=key: self.__update(key, "yes" if state else "no")

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -254,7 +254,10 @@ class PyzoIntrospector(yoton.RepChannel):
                         hasattr(val, "__array__")
                         and hasattr(val, "dtype")
                         and hasattr(val, "shape")
-                        and not hasattr(val, "if_this_is_an_attribute_then_there_are_likely_inf_attributes")
+                        and not hasattr(
+                            val,
+                            "if_this_is_an_attribute_then_there_are_likely_inf_attributes",
+                        )
                     ):
                         kind = "array"
                     elif isinstance(val, list):

--- a/pyzo/qt/QtCore.py
+++ b/pyzo/qt/QtCore.py
@@ -86,3 +86,9 @@ elif PYSIDE2:
     __version__ = PySide2.QtCore.__version__
 else:
     raise PythonQtError("No Qt bindings could be found")
+
+from .enumfixer import fix_enums
+
+for ob in list(globals().values()):
+    if isinstance(ob, type) and ob.__name__.startswith("Q"):
+        fix_enums(ob)

--- a/pyzo/qt/QtCore.py
+++ b/pyzo/qt/QtCore.py
@@ -35,9 +35,7 @@ if PYQT6:
     # Those are imported from `import *`
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 
-    # Allow unscoped access for enums inside the QtCore module
     from .enums_compat import promote_enums
-
     promote_enums(QtCore)
     del QtCore
 elif PYQT5:
@@ -58,7 +56,8 @@ elif PYQT5:
 
 elif PYSIDE6:
     from PySide6.QtCore import *
-    import PySide6.QtCore
+    import PySide6
+    from PySide6 import QtCore
 
     __version__ = PySide6.QtCore.__version__
 
@@ -73,6 +72,10 @@ elif PYSIDE6:
     QThread.exec_ = QThread.exec
     QTextStreamManipulator.exec_ = QTextStreamManipulator.exec
 
+    from .enums_compat import promote_enums
+
+    promote_enums(QtCore)
+
 elif PYSIDE2:
     from PySide2.QtCore import *
 
@@ -86,9 +89,3 @@ elif PYSIDE2:
     __version__ = PySide2.QtCore.__version__
 else:
     raise PythonQtError("No Qt bindings could be found")
-
-from .enumfixer import fix_enums
-
-for ob in list(globals().values()):
-    if isinstance(ob, type) and ob.__name__.startswith("Q"):
-        fix_enums(ob)

--- a/pyzo/qt/QtCore.py
+++ b/pyzo/qt/QtCore.py
@@ -36,6 +36,7 @@ if PYQT6:
     del pyqtSignal, pyqtBoundSignal, pyqtSlot, pyqtProperty, QT_VERSION_STR
 
     from .enums_compat import promote_enums
+
     promote_enums(QtCore)
     del QtCore
 elif PYQT5:

--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -22,7 +22,6 @@ if PYQT6:
     QGuiApplication.exec_ = QGuiApplication.exec
     QTextDocument.print_ = QTextDocument.print
 
-    # Allow unscoped access for enums inside the QtGui module
     from .enums_compat import promote_enums
 
     promote_enums(QtGui)
@@ -32,6 +31,7 @@ elif PYQT5:
 elif PYSIDE2:
     from PySide2.QtGui import *
 elif PYSIDE6:
+    from PySide6 import QtGui
     from PySide6.QtGui import *
 
     QFontMetrics.width = QFontMetrics.horizontalAdvance
@@ -39,12 +39,9 @@ elif PYSIDE6:
     # Map DeprecationWarning methods
     QDrag.exec_ = QDrag.exec
     QGuiApplication.exec_ = QGuiApplication.exec
+
+    from .enums_compat import promote_enums
+
+    promote_enums(QtGui)
 else:
     raise PythonQtError("No Qt bindings could be found")
-
-
-from .enumfixer import fix_enums
-
-for ob in list(globals().values()):
-    if isinstance(ob, type) and ob.__name__.startswith("Q"):
-        fix_enums(ob)

--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -41,3 +41,10 @@ elif PYSIDE6:
     QGuiApplication.exec_ = QGuiApplication.exec
 else:
     raise PythonQtError("No Qt bindings could be found")
+
+
+from .enumfixer import fix_enums
+
+for ob in list(globals().values()):
+    if isinstance(ob, type) and ob.__name__.startswith("Q"):
+        fix_enums(ob)

--- a/pyzo/qt/QtHelp.py
+++ b/pyzo/qt/QtHelp.py
@@ -20,3 +20,10 @@ elif PYSIDE2:
     from PySide2.QtHelp import *
 else:
     raise PythonQtError("No Qt bindings could be found")
+
+
+from .enumfixer import fix_enums
+
+for ob in list(globals().values()):
+    if isinstance(ob, type) and ob.__name__.startswith("Q"):
+        fix_enums(ob)

--- a/pyzo/qt/QtHelp.py
+++ b/pyzo/qt/QtHelp.py
@@ -20,10 +20,3 @@ elif PYSIDE2:
     from PySide2.QtHelp import *
 else:
     raise PythonQtError("No Qt bindings could be found")
-
-
-from .enumfixer import fix_enums
-
-for ob in list(globals().values()):
-    if isinstance(ob, type) and ob.__name__.startswith("Q"):
-        fix_enums(ob)

--- a/pyzo/qt/QtWidgets.py
+++ b/pyzo/qt/QtWidgets.py
@@ -54,3 +54,10 @@ elif PYSIDE2:
     from PySide2.QtWidgets import *
 else:
     raise PythonQtError("No Qt bindings could be found")
+
+
+from .enumfixer import fix_enums
+
+for ob in list(globals().values()):
+    if isinstance(ob, type) and ob.__name__.startswith("Q"):
+        fix_enums(ob)

--- a/pyzo/qt/QtWidgets.py
+++ b/pyzo/qt/QtWidgets.py
@@ -28,7 +28,6 @@ if PYQT6:
     QDialog.exec_ = QDialog.exec
     QMenu.exec_ = QMenu.exec
 
-    # Allow unscoped access for enums inside the QtWidgets module
     from .enums_compat import promote_enums
 
     promote_enums(QtWidgets)
@@ -36,6 +35,7 @@ if PYQT6:
 elif PYQT5:
     from PyQt5.QtWidgets import *
 elif PYSIDE6:
+    from PySide6 import QtWidgets
     from PySide6.QtWidgets import *
     from PySide6.QtGui import QAction, QActionGroup, QShortcut
     from PySide6.QtOpenGLWidgets import QOpenGLWidget
@@ -50,14 +50,11 @@ elif PYSIDE6:
     QApplication.exec_ = QApplication.exec
     QDialog.exec_ = QDialog.exec
     QMenu.exec_ = QMenu.exec
+
+    from .enums_compat import promote_enums
+
+    promote_enums(QtWidgets)
 elif PYSIDE2:
     from PySide2.QtWidgets import *
 else:
     raise PythonQtError("No Qt bindings could be found")
-
-
-from .enumfixer import fix_enums
-
-for ob in list(globals().values()):
-    if isinstance(ob, type) and ob.__name__.startswith("Q"):
-        fix_enums(ob)


### PR DESCRIPTION
In Pyzo we access a lot of enum values via the object, but since pyside6.4 these are only available on the class, or via the enum field. Example:

* Given `option = QTextOption()`
* We have `QTextOption.Flag.ShowTabsAndSpaces`
* We have `option.Flag.ShowTabsAndSpaces`
* We have `QTextOption.ShowTabsAndSpaces`
* We no longer have `option.ShowTabsAndSpaces`

It's tedious and error-prone to update all cases, so we fix it at the core. Similar how this seems to be fixed for PyQt5 in qtpy.
