### PR TITLE
fix breakpoints during cell execution on MS Windows

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -878,6 +878,10 @@ class PyzoInterpreter:
             if self._ipython:
                 self._ipython.execution_count += 1
 
+        # Bring fname to the canonical form so that pdb recognizes the breakpoints,
+        # otherwise filename r"C:\..." would be different from canonical form r"c:\..."
+        fname = self.debugger.canonic(fname)
+
         # Put the line number in the filename (if necessary)
         # Note that we could store the line offset in the _codeCollection,
         # but then we cannot retrieve it for syntax errors.


### PR DESCRIPTION
Problem:
On a Windows operating system, breakpoints do not work when executing a cell, as if they were not present. But when excuting the whole file or only the top cell, breakpoints work normally. And when executing any cell in a new, unsaved file ("<tmp 1>" etc.), breakpoints works normally as well.

Cause:
The python debugger pdb uses a filepath line-number combination as a key in its breakpoints data structure, where the filepath must be the canonical form. When setting the breakpoint, the debugger gets the correct canonical form of the filepath, but when executing a cell (or several selected lines), the code segment is compiled first with the normal form of the filepath, but not the canonical one. For example, filepath "C:\temp\test.py" will be different from its canonical form "c:\temp\test.py" (with the lowercase "c").

Fix:
Before compiling the code segment (and before appending the line offset), the filepath will be converted to its canonical form.
