### PR TITLE
fix missing cursor update when switching stack frames

### DIFF
--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -582,8 +582,6 @@ class DebugStack(QtWidgets.QToolButton):
             return "Stack frame is <console>."
         elif filename.startswith("<ipython-input-"):
             return "Stack frame is IPython input."
-        elif filename.startswith("<"):
-            return "Stack frame is special name"
         # Go there!
         result = pyzo.editors.loadFile(filename)
         if not result:


### PR DESCRIPTION
Problem:
After entering the debug mode and switching stack frames, the cursor does not jump to the proper line in the code editor when the code is in a new, unsaved file (e.g. "<tmp 1>").

Cause:
Function "debugFocus" in class "DebugStack" (shellStack.py) sees a filename starting with "<" as invalid and will not even try to look up the correct code editor tab. But when calling "pyzo.editors.loadFile(filename)", it is absolutely ok to pass "<tmp 1>" as filename, and this returns the correct editor tab.

Fix:
Removing the rule to ignore filenames starting with "<" solves the problem.
