### PR TITLE
Allow <tmp 1> etc. as filename when double-clicking text

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -360,19 +360,20 @@ class BaseShell(BaseTextCtrl):
         after = line[pos:].split('"')[0]
         piece = before + after
 
-        # Check if it looks like a filename, quit if it does not
-        if len(piece) < 4:
-            return
-        elif not ("/" in piece or "\\" in piece):
-            return
-        #
-        if sys.platform.startswith("win"):
-            if piece[1] != ":":
+        if not re.fullmatch(r"<tmp \d+>", piece):
+            # Check if it looks like a filename, quit if it does not
+            if len(piece) < 4:
                 return
-        else:
-            if not piece.startswith("/"):
+            elif not ("/" in piece or "\\" in piece):
                 return
-        #
+
+            if sys.platform.startswith("win"):
+                if piece[1] != ":":
+                    return
+            else:
+                if not piece.startswith("/"):
+                    return
+
         filename = piece
 
         # Split in parts for getting line number


### PR DESCRIPTION
Double-clicking on a file name in the shell text, for example in the traceback message
`File "C:\temp\test.py", line 5, in <module>`
will open the file in an editor tab and move the cursor to the specified line number.
But for new, unsaved files with pseudo filenames "<tmp 1>" etc., this does not work.

The proposed change will make it possible to jump to lines of such new, unsaved files.



