### PR TITLE
fix breakpoint removal (Shell -> Clear all {x} breakpoints)

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -1226,9 +1226,10 @@ class BreakPoints(object):
         """A list of breakpoints for this editor."""
         return list(sorted(self._breakPoints))
 
-        self._breakPoints = {}
-        self.breakPointsChanged.emit(self)
-        self.__breakPointArea.update()
+    def clearBreakPoints(self):
+        """Remove all breakpoints for this editor."""
+        for linenr in self.breakPoints():
+            self.toggleBreakpoint(linenr)
 
     def toggleBreakpoint(self, linenr=None):
         """Turn breakpoint on/off for given linenr of current line."""


### PR DESCRIPTION
Apparently, the menu command "Shell -> Clear all {x} breakpoints" got broken at Pyzo v4.4.
This fix restores its function.
