### PR TITLE
have proper placeholder text for environ in shell config dialog

### DIFF
--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -106,7 +106,7 @@ class KernelInfo(ssdf.Struct):
         self.argv = ""
 
         # Additional environment variables
-        self.environ = "PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1"
+        self.environ = ""
 
         # Load info from ssdf struct. Make sure they are all strings
         if info:

--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -106,7 +106,7 @@ class KernelInfo(ssdf.Struct):
         self.argv = ""
 
         # Additional environment variables
-        self.environ = ""
+        self.environ = "PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1"
 
         # Load info from ssdf struct. Make sure they are all strings
         if info:

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -418,30 +418,24 @@ class ShellInfo_argv(ShellInfoLineEdit):
 
 
 class ShellInfo_environ(QtWidgets.QTextEdit):
-    EXAMPLE = "EXAMPLE_VAR1=value1\nPYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1"
+    EXAMPLE = "PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1\nEXAMPLE_VAR1=value1"
 
     def __init__(self, parent):
         QtWidgets.QTextEdit.__init__(self, parent)
         self.zoomOut(1)
-        self.setText(self.EXAMPLE)
+        self.setPlaceholderText(self.EXAMPLE)
 
     def _cleanText(self, txt):
         return "\n".join([line.strip() for line in txt.splitlines()])
 
     def setTheText(self, value):
         value = self._cleanText(value)
-        if value:
-            self.setText(value)
-        else:
-            self.setText(self.EXAMPLE)
+        self.setText(value)
 
     def getTheText(self):
         value = self.toPlainText()
         value = self._cleanText(value)
-        if value == self.EXAMPLE:
-            return ""
-        else:
-            return value
+        return value
 
 
 ## The dialog class and container with tabs


### PR DESCRIPTION
When editing or adding a shell configuration using the dialog, the text box "environ" shows the following text instead of an empty string (unless modified by the user):
```
EXAMPLE_VAR1=value1
PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1
```
But these variables never appear in os.environ -- the shell config ignores the text because it is a kind of placeholder text but implemented as normal text data. This has caused some confusion, as placeholder texts in other fields in the shell config dialog are implemented as proper placeholder texts (grayed out and vanishing when entering text).

This pull request changes the environ text field to have a proper placeholder text.
The old implementation allowed for easy inserting the useful environment variable `PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1` by just modifying the default entry. With the proper placeholder text, the user would have to type the whole line manually, because placeholder texts cannot be selected and copied to the clipboard.
To circumvent this, the default evironmental variable for a new shell config is changed to include this line.