### PR TITLE
Fix reload when file changed externally

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -385,10 +385,8 @@ class PyzoEditor(BaseTextCtrl):
 
     def focusInEvent(self, event):
         """Test whether the file has been changed 'behind our back'"""
-        # Act normally to the focus event
-        BaseTextCtrl.focusInEvent(self, event)
-        # Test file change
         self.testWhetherFileWasChanged()
+        return super().focusInEvent(event)
 
     def testWhetherFileWasChanged(self):
         """testWhetherFileWasChanged()
@@ -423,7 +421,7 @@ class PyzoEditor(BaseTextCtrl):
 
             # get result and act
             result = dlg.exec_()
-            if result == QtWidgets.QMessageBox.AcceptRole:
+            if result == QtWidgets.QMessageBox.AcceptRole.value:
                 self.reload()
             else:
                 pass  # when cancelled or explicitly said, do nothing

--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -421,7 +421,7 @@ class PyzoEditor(BaseTextCtrl):
 
             # get result and act
             result = dlg.exec_()
-            if result == QtWidgets.QMessageBox.AcceptRole.value:
+            if result == 0:  # in PySide6 AcceptRole != 0
                 self.reload()
             else:
                 pass  # when cancelled or explicitly said, do nothing


### PR DESCRIPTION
* Fix that the reload is done. It was ignored, because the working of enums changed in some Qt implementation :/
* Avoid bug where the editor had focus but also kinda did not? (could edit text but cursor was not blinking).