### PR TITLE
Signing of the app for macos

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,10 +124,11 @@ jobs:
         # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
         echo "Notarize app"
         xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+        xcrun notarytool log c44df8eb-3087-4a3c-a5f4-9b72caceb083 --keychain-profile "notarytool-profile"
         # Finally, we need to "attach the staple" to our executable, which will allow our app to be
         # validated by macOS even when an internet connection is not available.
         echo "Attach staple"
-        xcrun stapler staple "freeze/dist/pyzo.app"
+        #xcrun stapler staple "freeze/dist/pyzo.app"
     - name: Package
       run: python freeze/pyzo_package.py
     - name: Test frozen

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,7 +112,7 @@ jobs:
       run: |
           python freeze/pyzo_freeze.py
           # cant get it to work //// codesign -s $MACOS_CERT_ID --force --all-architectures --timestamp --deep --options=runtime freeze/dist/pyzo.app -v
-          codesign -s --force --all-architectures --timestamp --deep freeze/dist/pyzo.app
+          codesign -s - --force --all-architectures --timestamp --deep freeze/dist/pyzo.app
     - name: Package
       run: python freeze/pyzo_package.py
     - name: Test frozen

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,7 +109,7 @@ jobs:
         security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
         # We finally codesign our app bundle, specifying the Hardened runtime option
-        /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime freeze/dist/pyzo.app -v
+        /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --all-architectures --timestamp --deep --options runtime freeze/dist/pyzo.app -v
     - name: "Notarize app bundle"
       # Extract the secrets we defined earlier as environment variables
       env:
@@ -124,11 +124,12 @@ jobs:
         # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
         echo "Notarize app"
         xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
-        xcrun notarytool log c44df8eb-3087-4a3c-a5f4-9b72caceb083 --keychain-profile "notarytool-profile"
+        # Debug
+        # xcrun notarytool log c44df8eb-3087-4a3c-a5f4-9b72caceb083 --keychain-profile "notarytool-profile"
         # Finally, we need to "attach the staple" to our executable, which will allow our app to be
         # validated by macOS even when an internet connection is not available.
         echo "Attach staple"
-        #xcrun stapler staple "freeze/dist/pyzo.app"
+        xcrun stapler staple "freeze/dist/pyzo.app"
     - name: Package
       run: python freeze/pyzo_package.py
     - name: Test frozen

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,7 +97,6 @@ jobs:
       env:
           MACOS_CERT: ${{ secrets.MACOS_CERT }}
           MACOS_CERT_PW: ${{ secrets.MACOS_CERT_PW }}
-          MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
           KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
       run: |
           echo $MACOS_CERT | base64 --decode > certificate.p12
@@ -108,6 +107,8 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PW build.keychain
           security find-identity -v
     - name: Freeze
+      env:
+          MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
       run: |
           python freeze/pyzo_freeze.py
           codesign -s $MACOS_CERT_ID --force --all-architectures --timestamp --deep --options=runtime freeze/dist/pyzo.app

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,7 +111,8 @@ jobs:
           MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
       run: |
           python freeze/pyzo_freeze.py
-          codesign -s $MACOS_CERT_ID --force --all-architectures --timestamp --deep --options=runtime freeze/dist/pyzo.app
+          # cant get it to work //// codesign -s $MACOS_CERT_ID --force --all-architectures --timestamp --deep --options=runtime freeze/dist/pyzo.app -v
+          codesign -s --force --all-architectures --timestamp --deep freeze/dist/pyzo.app
     - name: Package
       run: python freeze/pyzo_package.py
     - name: Test frozen

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,8 +93,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U pyside6 pyinstaller
           pip install -r freeze/frozen_libs.txt
+    - name: Setup Codesigning
+        env:
+          MACOS_CERT: ${{ secrets.MACOS_CERT }}
+          MACOS_CERT_PW: ${{ secrets.MACOS_CERT_PW }}
+          MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
+          KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
+        run: |
+          echo $MACOS_CERT | base64 —decode > certificate.p12
+          security create-keychain -p $KEYCHAIN_PW build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p $KEYCHAIN_PW build.keychain
+          security import certificate.p12 -k build.keychain -P $MACOS_CERT_PW -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PW build.keychain
+          security find-identity -v
     - name: Freeze
-      run: python freeze/pyzo_freeze.py
+      run: |
+          python freeze/pyzo_freeze.py
+          codesign -s $MACOS_CERT_ID --force --all-architectures --timestamp --deep --options=runtime freeze/dist/pyzo.app
     - name: Package
       run: python freeze/pyzo_package.py
     - name: Test frozen

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -100,7 +100,7 @@ jobs:
           MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
           KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
       run: |
-          echo $MACOS_CERT | base64 —decode > certificate.p12
+          echo $MACOS_CERT | base64 --decode > certificate.p12
           security create-keychain -p $KEYCHAIN_PW build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p $KEYCHAIN_PW build.keychain

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,26 +93,41 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U pyside6 pyinstaller
           pip install -r freeze/frozen_libs.txt
-    - name: Setup Codesigning
-      env:
-          MACOS_CERT: ${{ secrets.MACOS_CERT }}
-          MACOS_CERT_PW: ${{ secrets.MACOS_CERT_PW }}
-          KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
-      run: |
-          echo $MACOS_CERT | base64 --decode > certificate.p12
-          security create-keychain -p $KEYCHAIN_PW build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p $KEYCHAIN_PW build.keychain
-          security import certificate.p12 -k build.keychain -P $MACOS_CERT_PW -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PW build.keychain
-          security find-identity -v
     - name: Freeze
+      run: python freeze/pyzo_freeze.py
+    - name: Codesign app bundle
       env:
-          MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
+        MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+        MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+        MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
       run: |
-          python freeze/pyzo_freeze.py
-          # cant get it to work //// codesign -s $MACOS_CERT_ID --force --all-architectures --timestamp --deep --options=runtime freeze/dist/pyzo.app -v
-          codesign -s - --force --all-architectures --timestamp --deep freeze/dist/pyzo.app
+        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+        security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+        security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+        # We finally codesign our app bundle, specifying the Hardened runtime option
+        /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime freeze/dist/pyzo.app -v
+    - name: "Notarize app bundle"
+      # Extract the secrets we defined earlier as environment variables
+      env:
+        PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+        PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+        PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+      run: |
+        echo "Create keychain profile"
+        xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+        echo "Creating temp notarization archive"
+        ditto -c -k --keepParent "freeze/dist/pyzo.app" "notarization.zip"
+        # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+        echo "Notarize app"
+        xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+        # Finally, we need to "attach the staple" to our executable, which will allow our app to be
+        # validated by macOS even when an internet connection is not available.
+        echo "Attach staple"
+        xcrun stapler staple "freeze/dist/pyzo.app"
     - name: Package
       run: python freeze/pyzo_package.py
     - name: Test frozen

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -94,12 +94,12 @@ jobs:
           pip install -U pyside6 pyinstaller
           pip install -r freeze/frozen_libs.txt
     - name: Setup Codesigning
-        env:
+      env:
           MACOS_CERT: ${{ secrets.MACOS_CERT }}
           MACOS_CERT_PW: ${{ secrets.MACOS_CERT_PW }}
           MACOS_CERT_ID: ${{ secrets.MACOS_CERT_ID }}
           KEYCHAIN_PW: ${{ secrets.KEYCHAIN_PW }}
-        run: |
+      run: |
           echo $MACOS_CERT | base64 —decode > certificate.p12
           security create-keychain -p $KEYCHAIN_PW build.keychain
           security default-keychain -s build.keychain

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,7 +111,6 @@ jobs:
         # We finally codesign our app bundle, specifying the Hardened runtime option
         /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --all-architectures --timestamp --deep --options runtime freeze/dist/pyzo.app -v
     - name: "Notarize app bundle"
-      # Extract the secrets we defined earlier as environment variables
       env:
         PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
         PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
@@ -121,13 +120,11 @@ jobs:
         xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
         echo "Creating temp notarization archive"
         ditto -c -k --keepParent "freeze/dist/pyzo.app" "notarization.zip"
-        # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
         echo "Notarize app"
         xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
         # Debug
         # xcrun notarytool log c44df8eb-3087-4a3c-a5f4-9b72caceb083 --keychain-profile "notarytool-profile"
-        # Finally, we need to "attach the staple" to our executable, which will allow our app to be
-        # validated by macOS even when an internet connection is not available.
+        # Finally, we need to "attach the staple" allow our app to be validated without internet connection.
         echo "Attach staple"
         xcrun stapler staple "freeze/dist/pyzo.app"
     - name: Package

--- a/freeze/pyzo_freeze.py
+++ b/freeze/pyzo_freeze.py
@@ -278,3 +278,6 @@ for dir1, dir2 in data2.items():
         os.path.abspath(os.path.join(source_dir, dir2)),
     )
     print("Copied", dir1, "->", dir2)
+
+
+# In the GH Action we perform a sign again


### PR DESCRIPTION
## Ad-hoc code signing

In https://github.com/pyinstaller/pyinstaller/pull/7180#issuecomment-1415721750 a tip for the `codesign` syntax was given:
```
codesign -s - --force --all-architectures --timestamp --deep --entitlements /path/to/entitlements-file.plist /path/to/bundle.app
```

This works, and MacOS stops complaining about the app being broken or modified. But it still says it's untrusted, and requires right-clicking to open the app.

## Proper code signing

For proper code signing, you need to:
* Create an Apple developer account ($100 per year)
* Create a certificate with that account
* Setup Github Actions to sign with that certificate.
* Setup Github Actions to Notarization the app (verify that it's clean).

For detailed instructions, see https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/

## Trying to do proper code signing

So I gave this a go ... it was a tedious process with many hurdles. Every time it felt like I was close, but everytime it did not work for another reason ...

For one, I changed the `codesign` signature to include more options:
```
codesign --force -s "$MACOS_CERTIFICATE_NAME" --all-architectures --timestamp --deep --options runtime freeze/dist/pyzo.app -v
```

Also, my own certificate was marked "Certificate is not trusted", but I could fix that by checking what the issuer was, and then downloading and installing the corresponding certificate from [Apple PKI](https://www.apple.com/certificateauthority/), as explained [here](https://developer.apple.com/forums/thread/705473).

## The result

In the end, everything looks good, but I still get this:
<img width="254" alt="image" src="https://user-images.githubusercontent.com/3015475/217276421-ab957ecc-953c-4df4-a4d8-c1c7bef92f5f.png">

So people still need to right-click, select "open", and then click "open". Maybe I'll dive deeper another time.