### PR TITLE
avoid crash in key mapping settings

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -186,6 +186,8 @@ class Menu(QtWidgets.QMenu):
 
     """
 
+    _dummyActionForHiddenEntryInKeyMapDialog = QtWidgets.QAction()
+
     def __init__(self, parent=None, name=None):
         QtWidgets.QMenu.__init__(self, parent)
 
@@ -851,6 +853,8 @@ class ZoomMenu(Menu):
 
 
 class FontMenu(Menu):
+    _hide_in_key_map_dialog = True
+
     def __init__(self, parent=None, name="Font", *args, **kwds):
         Menu.__init__(self, parent, name, *args, **kwds)
         self.aboutToShow.connect(self._updateFonts)
@@ -2625,6 +2629,9 @@ class KeyMapModel(QtCore.QAbstractItemModel):
         if pitem is self._root:
             return QtCore.QModelIndex()
         else:
+            if pitem is None:
+                # menu seems to be hidden for key mapping settings dialog
+                return QtCore.QModelIndex()
             L = pitem.parent().actions()
             row = 0
             if pitem in L:
@@ -2652,6 +2659,9 @@ class KeyMapModel(QtCore.QAbstractItemModel):
         childMenu = childAction.parent()
         if childMenu is not parentMenu and childMenu.actions():
             childAction = childMenu
+        if (isinstance(childMenu, Menu) and hasattr(childMenu, '_hide_in_key_map_dialog')
+                and childMenu._hide_in_key_map_dialog):
+            childAction = Menu._dummyActionForHiddenEntryInKeyMapDialog
         return self.createIndex(row, column, childAction)
         # This is the trick. The internal pointer is the way to establish
         # correspondence between ModelIndex and underlying data.


### PR DESCRIPTION
Warning! This is just a fix to avoid the crash. I have not tested it for secondary effects.

As described in #843, calling the key mapping settings dialog will crash pyzo when using a linux os, unless the font list was loaded before.

The segmentation fault happens in method `hasChildren` in class `KeyMapModel`, probably because of an invalid memory access in line `result = isinstance(index.internalPointer(), QtWidgets.QMenu)`.

It does not seem possible to avoid a crash when already inside `hasChildren`.
Changes have to be done to method `index` of the same class.
Inserting the lines
```
if isinstance(childMenu, FontMenu):
    childAction = QtWidgets.QAction()
```
before `return self.createIndex(row, column, childAction)` still leads to the same crash.
But, when giving the dummy action object a safe parent that keeps its memory ownership
```
if isinstance(childMenu, FontMenu):
    FontMenu.asdfasdf = QtWidgets.QAction()
    childAction = FontMenu.asdfasdf
```
the crash does not occur anymore and the menu entry is displayed like a separator in the key settings dialog.
So it seems that a `QAction` object got garbage collected and the later access in `hasChildren` caused the segmentation fault.

The proposed fix could be extended to also hide other menus by inserting line `_hide_in_key_map_dialog = True` in the class definition.