### PR TITLE
enable autocompletion for string literals

### DIFF
--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -97,7 +97,7 @@ def parseLine_autocomplete(tokens):
     for token in tokens[-2::-1]:
         if isinstance(token, Tokens.NonIdentifierToken) and str(token) == ".":
             needle = str(token) + needle
-        elif isinstance(token, (Tokens.IdentifierToken, Tokens.KeywordToken)):
+        elif isinstance(token, (Tokens.IdentifierToken, Tokens.StringToken)):
             needle = str(token) + needle
         else:
             break


### PR DESCRIPTION
This PR enables autocompletion when typing string literals (and similar objects), for example:
typing `' '.j` wll suggest `join`
typing `b'test'.d` wll suggest `decode`

And this PR also includes a minor code clean-up:
`isinstance(token, (Tokens.IdentifierToken, Tokens.KeywordToken))`
is the same as
`isinstance(token, Tokens.IdentifierToken)`
because `Tokens.KeywordToken` is a subclass of `Tokens.IdentifierToken`




