### PR TITLE
fixes for PyQt6 and PySide6 support

### DIFF
--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -12,19 +12,24 @@ from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, PythonQtError
 
 
 if PYQT6:
-    from PyQt6 import QtGui
     from PyQt6.QtGui import *
 
     import inspect
-    QFontMetrics.width = inspect.getattr_static(QFontMetrics, 'horizontalAdvance')
+    QFontMetrics.width = inspect.getattr_static(QFontMetrics, "horizontalAdvance")
 
     # Map missing/renamed methods
-    QDrag.exec_ = inspect.getattr_static(QDrag, 'exec')
-    QGuiApplication.exec_ = inspect.getattr_static(QGuiApplication, 'exec')
-    QTextDocument.print_ = inspect.getattr_static(QTextDocument, 'print')
+    QDrag.exec_ = inspect.getattr_static(QDrag, "exec")
+    QGuiApplication.exec_ = inspect.getattr_static(QGuiApplication, "exec")
+    QTextDocument.print_ = inspect.getattr_static(QTextDocument, "print")
+    QTextDocument.FindFlags = lambda: QTextDocument.FindFlag(0)
 
     from .enums_compat import promote_enums
 
+    from PyQt6 import QtGui
+    QtGui.QMouseEvent.x = lambda self: int(self.position().x())
+    QtGui.QMouseEvent.y = lambda self: int(self.position().y())
+    if not hasattr(QtGui.QMouseEvent, "pos"):
+        QtGui.QMouseEvent.pos = lambda self: self.position().toPoint()
     promote_enums(QtGui)
     del QtGui
     del inspect

--- a/pyzo/qt/QtWidgets.py
+++ b/pyzo/qt/QtWidgets.py
@@ -12,23 +12,27 @@ from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, PythonQtError
 
 
 if PYQT6:
-    from PyQt6 import QtWidgets
     from PyQt6.QtWidgets import *
     from PyQt6.QtGui import QAction, QActionGroup, QShortcut, QFileSystemModel
     from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
     # Map missing/renamed methods
     import inspect
-    QTextEdit.setTabStopWidth = inspect.getattr_static(QTextEdit, 'setTabStopDistance')
-    QTextEdit.tabStopWidth = inspect.getattr_static(QTextEdit, 'tabStopDistance')
-    QTextEdit.print_ = inspect.getattr_static(QTextEdit, 'print')
-    QPlainTextEdit.setTabStopWidth = inspect.getattr_static(QPlainTextEdit, 'setTabStopDistance')
-    QPlainTextEdit.tabStopWidth = inspect.getattr_static(QPlainTextEdit, 'tabStopDistance')
-    QPlainTextEdit.print_ = inspect.getattr_static(QPlainTextEdit, 'print')
-    QApplication.exec_ = inspect.getattr_static(QApplication, 'exec')
-    QDialog.exec_ = inspect.getattr_static(QDialog, 'exec')
-    QMenu.exec_ = inspect.getattr_static(QMenu, 'exec')
+    QTextEdit.setTabStopWidth = inspect.getattr_static(QTextEdit, "setTabStopDistance")
+    QTextEdit.tabStopWidth = inspect.getattr_static(QTextEdit, "tabStopDistance")
+    QTextEdit.print_ = inspect.getattr_static(QTextEdit, "print")
+    QPlainTextEdit.setTabStopWidth = inspect.getattr_static(QPlainTextEdit, "setTabStopDistance")
+    QPlainTextEdit.tabStopWidth = inspect.getattr_static(QPlainTextEdit, "tabStopDistance")
+    QPlainTextEdit.print_ = inspect.getattr_static(QPlainTextEdit, "print")
 
+    if QApplication.__name__ != "QApplication_hijacked":
+        QApplication.exec_ = inspect.getattr_static(QApplication, "exec")
+    else:
+        print("Pyzo is executed inside another Pyzo instance")
+    QDialog.exec_ = inspect.getattr_static(QDialog, "exec")
+    QMenu.exec_ = inspect.getattr_static(QMenu, "exec")
+
+    from PyQt6 import QtWidgets
     from .enums_compat import promote_enums
     promote_enums(QtWidgets)
     del QtWidgets
@@ -36,7 +40,6 @@ if PYQT6:
 elif PYQT5:
     from PyQt5.QtWidgets import *
 elif PYSIDE6:
-    from PySide6 import QtWidgets
     from PySide6.QtWidgets import *
     from PySide6.QtGui import QAction, QActionGroup, QShortcut
     from PySide6.QtOpenGLWidgets import QOpenGLWidget
@@ -48,10 +51,14 @@ elif PYSIDE6:
     QPlainTextEdit.tabStopWidth = QPlainTextEdit.tabStopDistance
 
     # Map DeprecationWarning methods
-    QApplication.exec_ = QApplication.exec
+    if QApplication.__name__ != "QApplication_hijacked":
+        QApplication.exec_ = QApplication.exec
+    else:
+        print("Pyzo is executed inside another Pyzo instance")
     QDialog.exec_ = QDialog.exec
     QMenu.exec_ = QMenu.exec
 
+    from PySide6 import QtWidgets
     from .enums_compat import promote_enums
     promote_enums(QtWidgets)
     del QtWidgets

--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -674,7 +674,7 @@ class Tree(QtWidgets.QTreeWidget):
         QtWidgets.QTreeWidget.clear(self)
 
     def mouseDoubleClickEvent(self, event):
-        """Bypass expanding an item when double-cliking it.
+        """Bypass expanding an item when double-clicking it.
         Only activate the item.
         """
         item = self.itemAt(event.x(), event.y())


### PR DESCRIPTION
added some further fixes for PyQt6 support


and a hint for a special case in PySide6:

When wanting to use special PySide6 features "snake_case" and/or "true_property", then use PySide6 >= 6.4.2 because
```
from PySide6 import QtGui, QtCore, QtWidgets
from PySide6.QtWidgets import QApplication

backup_QApplication_hijacked = QApplication.__new__
from __feature__ import snake_case, true_property
assert backup_QApplication_hijacked is QApplication.__new__ # fails on PySide6 < 6.3.0
```
relevant fixes in the PySide6 project:
https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.3.0
     [PYSIDE-1702] snake_case handling now does explicitly not touch user defined classes.
https://code.qt.io/cgit/pyside/pyside-setup.git/tree/doc/changelogs/changes-6.4.2
    [PYSIDE-1019] A callback error when using true_property has been fixed.
 