### PR TITLE
allow multiple statements in shell startup code after gui initialization

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -633,7 +633,7 @@ class PyzoInterpreter:
         if self._codeToRunOnStartup:
             self.context._stat_interpreter.send("Busy")
             self._codeToRunOnStartup, tmp = None, self._codeToRunOnStartup
-            self.pushline(tmp)
+            self._runlines(tmp, filename="<startup_after_gui>", symbol="exec")
         if self._scriptToRunOnStartup:
             self.context._stat_interpreter.send("Busy")
             self._scriptToRunOnStartup, tmp = None, self._scriptToRunOnStartup


### PR DESCRIPTION
This PR will fix the following problem:

When using the following startup code in the shell configuration (startupScript -- Code to run at startup)
```
print(1)
print(2)
# AFTER_GUI - code below runs after integrating the GUI
print(3)
print(4)
````
and creating the shell, then the output is
```
1
2
Python 3.11.1 (main, Jan 16 2023, 22:41:20) on linux (64 bits).
This is the Pyzo interpreter with integrated event loop for PYQT6.
Type 'help' for help, type '?' for a list of *magic* commands.
  File "<console>", line 1
    print(3)
            ^
SyntaxError: multiple statements found while compiling a single statement
```