### PR TITLE
prevent error message box when running a second Pyzo instance to open a file

### DIFF
--- a/freeze/boot.py
+++ b/freeze/boot.py
@@ -68,8 +68,10 @@ class BootAction:
 
     def __exit__(self, cls, err, tb):
         if err:
-            error_handler(cls, err, tb, self._action)
-            sys.exit(1)
+            if not isinstance(err, SystemExit) or err.code:
+                error_handler(cls, err, tb, self._action)
+                if not isinstance(err, SystemExit):
+                    sys.exit(1)
 
 
 # %% Boot

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -52,13 +52,6 @@ if sys.version_info < (3, 6):
 
 def start():
     """Start Pyzo."""
-    try:
-        from ._start import start
-    except SystemExit as e:
-        if e.code == 0 or e.code is None:
-            # prevent SystemExit exception from showing an error message box
-            # in MS Windows when sys.exit(0) or sys.exit() is called
-            return
-        raise e
+    from ._start import start
 
     start()

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -52,6 +52,13 @@ if sys.version_info < (3, 6):
 
 def start():
     """Start Pyzo."""
-    from ._start import start
+    try:
+        from ._start import start
+    except SystemExit as e:
+        if e.code == 0 or e.code is None:
+            # prevent SystemExit exception from showing an error message box
+            # in MS Windows when sys.exit(0) or sys.exit() is called
+            return
+        raise e
 
     start()


### PR DESCRIPTION
As described in #859, starting a second instance of Pyzo to open a file will show a cmd console window and an error message box in MS Windows.
The console window and the error message box seem to be opened because an exception is raised after successfully opening the file. This exception is of type `SystemExit` and caused by the command
https://github.com/pyzo/pyzo/blob/ebb7df8922af8e15eac102e8fa4a35bfa143869a/pyzo/_start.py#L77
which is just called to gracefully close the second Pyzo instance.