### PR TITLE
fix Pyzo restart in MS Windows with spaces in paths

### DIFF
--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -417,6 +417,12 @@ class MainWindow(QtWidgets.QMainWindow):
             ):
                 args = ["python.exe", "-m", "pyzo"]
 
+            if sys.platform == "win32":
+                # workaround for MSVCRT issue with spaces in arguments
+                #     https://bugs.python.org/issue436259
+                from subprocess import list2cmdline
+                args = [list2cmdline([s]) for s in args]
+
             # Replace the process!
             os.execv(sys.executable, args)
 


### PR DESCRIPTION
Restarting Pyzo in MS Windows, for example via "File --> Restart Pyzo", causes errors when there is a space in Pyzo's path or in the path of the python file to open.

An "Error loading file" message box appears because sys.argv is split.

Logger window in Pyzo before the restart:

```
>>> sys.argv
['C:\\Program Files\\pyzo\\pyzo.exe']
```
Logger window in Pyzo after the restart (without the patch):

```
>>> sys.argv
['C:\\Program', 'Files\\pyzo\\pyzo.exe']
```

The suggested workaround, consisting of quoting all argument list entries, is only required for MS Windows, but not for other operating systems.
