### PR TITLE
fix QFontDatabase compatibility for PyQt6

### DIFF
--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -31,6 +31,11 @@ if PYQT6:
     if not hasattr(QtGui.QMouseEvent, "pos"):
         QtGui.QMouseEvent.pos = lambda self: self.position().toPoint()
     promote_enums(QtGui)
+
+    # in Qt6 use QtGui.QFontDatabase.families() instead of QtGui.QFontDatabase().families()
+    # https://doc.qt.io/qt-6/qfontdatabase-obsolete.html#QFontDatabase
+    QtGui.QFontDatabase.__new__ = lambda cls: cls
+
     del QtGui
     del inspect
 elif PYQT5:


### PR DESCRIPTION
When running Pyzo in PyQt6 the menu "View --> Font" did not work because PyQt6 does not allow `QtGui.QFontDatabase()` anymore (but PySide6 still does).
