### PR TITLE
fix matching selection highlighter for line-wrapped occurrences

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -90,23 +90,20 @@ class HighlightMatchingOccurrences(object):
             if heightDiff == 0:
                 painter.drawRect(startRect.left(), startRect.top(), width, cursorHeight)
             elif heightDiff > 0:
-                cursorSub = QtGui.QTextCursor(cursor)
-                startLineY = startRect.top()
-                cursorSub.movePosition(cursorSub.EndOfLine)
-                secondLineY = self.cursorRect(cursorSub).top()
+                cursor.movePosition(cursor.EndOfLine)
+                secondLineY = self.cursorRect(cursor).top()
                 endLineY = endRect.top()
                 fullLineStartX = 0
                 fullLineEndX = self.width()
-                numFullLines = (endLineY - secondLineY) // (secondLineY - startLineY)
 
                 # first partial line
                 width = fullLineEndX - startRect.left()
                 painter.drawRect(startRect.left(), startRect.top(), width, cursorHeight)
 
                 # full lines in between
-                if numFullLines > 0:
+                if endLineY > secondLineY:
                     width = fullLineEndX - fullLineStartX
-                    height = (secondLineY - startLineY) * numFullLines
+                    height = endLineY - secondLineY
                     painter.drawRect(fullLineStartX, secondLineY, width, height)
 
                 # last partial line

--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -53,6 +53,7 @@ class HighlightMatchingOccurrences(object):
     def _doHighlight(self, text):
         # make cursor at the beginning of the first visible block
         cursor = self.cursorForPosition(QtCore.QPoint(0, 0))
+        cursor.movePosition(cursor.StartOfWord)
         doc = self.document()
 
         color = self.getStyleElementFormat("editor.highlightMatchingOccurrences").back
@@ -75,16 +76,43 @@ class HighlightMatchingOccurrences(object):
                 continue
 
             endRect = self.cursorRect(cursor)
-            if endRect.bottom() > self.height():
+            cursor.setPosition(min(cursor.position(), cursor.anchor()))
+            startRect = self.cursorRect(cursor)
+
+            if startRect.top() > self.height():
                 # rest of document is not visible, don't bother highlighting
                 break
 
-            cursor.setPosition(min(cursor.position(), cursor.anchor()))
-            startRect = self.cursorRect(cursor)
             width = endRect.left() - startRect.left()
-            painter.drawRect(
-                startRect.left(), startRect.top(), width, startRect.height()
-            )
+            cursorHeight = startRect.height()
+
+            heightDiff = endRect.top() - startRect.top()
+            if heightDiff == 0:
+                painter.drawRect(startRect.left(), startRect.top(), width, cursorHeight)
+            elif heightDiff > 0:
+                cursorSub = QtGui.QTextCursor(cursor)
+                startLineY = startRect.top()
+                cursorSub.movePosition(cursorSub.EndOfLine)
+                secondLineY = self.cursorRect(cursorSub).top()
+                endLineY = endRect.top()
+                fullLineStartX = 0
+                fullLineEndX = self.width()
+                numFullLines = (endLineY - secondLineY) // (secondLineY - startLineY)
+
+                # first partial line
+                width = fullLineEndX - startRect.left()
+                painter.drawRect(startRect.left(), startRect.top(), width, cursorHeight)
+
+                # full lines in between
+                if numFullLines > 0:
+                    width = fullLineEndX - fullLineStartX
+                    height = cursorHeight * numFullLines
+                    painter.drawRect(fullLineStartX, secondLineY, width, height)
+
+                # last partial line
+                width = endRect.left() - fullLineStartX
+                if width > 0:
+                    painter.drawRect(fullLineStartX, endLineY, width, cursorHeight)
 
             # move to end of word again, otherwise we never advance in the doc
             cursor.movePosition(cursor.EndOfWord)

--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -106,7 +106,7 @@ class HighlightMatchingOccurrences(object):
                 # full lines in between
                 if numFullLines > 0:
                     width = fullLineEndX - fullLineStartX
-                    height = cursorHeight * numFullLines
+                    height = (secondLineY - startLineY) * numFullLines
                     painter.drawRect(fullLineStartX, secondLineY, width, height)
 
                 # last partial line


### PR DESCRIPTION
The new code will properly highlight the matches of the selected text even when they are line-wrapped.

before applying the patch:
![old](https://github.com/pyzo/pyzo/assets/119257544/75847095-b673-4f48-8599-68714f468d45)

after applying the patch:
![new](https://github.com/pyzo/pyzo/assets/119257544/8bdd1275-250e-4b98-90d3-099c369b978a)
