### PR TITLE
fix themeEdit focussing for PySide2, PySide6 and PyQt6

### DIFF
--- a/pyzo/core/themeEdit.py
+++ b/pyzo/core/themeEdit.py
@@ -70,8 +70,8 @@ class TitledWidget(QtWidgets.QWidget):
 
         self.setLayout(layout)
 
-    def setFocus(self, val):
-        self.widget.setFocus(val)
+    def setFocus(self):
+        self.widget.setFocus()
 
 
 class ColorLineEdit(QtWidgets.QLineEdit):
@@ -220,8 +220,8 @@ class StyleEdit(QtWidgets.QWidget):
         for key, setter in self.setters.items():
             setter(style[key])
 
-    def setFocus(self, val):
-        self.layout.itemAt(0).widget().setFocus(True)
+    def setFocus(self):
+        self.layout.itemAt(0).widget().setFocus()
 
 
 class ThemeEditorWidget(QtWidgets.QWidget):
@@ -447,7 +447,7 @@ class ThemeEditorWidget(QtWidgets.QWidget):
             self.createTheme()
 
     def focusOnStyle(self, key):
-        self.styleEdits[key].setFocus(True)
+        self.styleEdits[key].setFocus()
         self.scrollArea.ensureWidgetVisible(self.styleEdits[key])
 
     def updatedStyle(self, style, text):


### PR DESCRIPTION
In the theme editor dialog ("Settings --> Edit syntax styles..."), clicking a code element in the preview text editor widget normally automatically puts the focus on the color input widget for the clicked syntax element type.
This did not work when running Pyzo with PySide2, PySide6 or PyQt6 (instead of PyQt5).

This patch will restore this focussing functionality for all four Qt wrappers.