### PR TITLE
improve PDF export

### DIFF
--- a/pyzo/core/pdfExport.py
+++ b/pyzo/core/pdfExport.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pyzo
 from pyzo import translate
 from pyzo.qt import QtCore, QtGui, QtWidgets, QtPrintSupport
@@ -185,8 +186,10 @@ class PdfExport(QtWidgets.QDialog):
             orientation = [base.Portrait, base.Landscape][index]
 
             self._preview.setOrientation(orientation)
-            self._preview.setOrientation(orientation)  # calling this a second time is a
-            # workaround, otherwise the preview in Qt6 is wrong when switching orientation
+            if sys.platform == "win32":
+                self._preview.setOrientation(orientation)  # calling this a second time is a
+                # workaround, otherwise the preview in Qt6 is wrong when switching orientation
+                # on Windows 10 with Qt 6.5.0
 
             layout = QtGui.QPageLayout()
             layout.setOrientation(orientation)

--- a/pyzo/core/pdfExport.py
+++ b/pyzo/core/pdfExport.py
@@ -65,7 +65,6 @@ class PdfExport(QtWidgets.QDialog):
         self._btnDone = QtWidgets.QPushButton("Done", self)
         self._btnDone.clicked.connect(self.close)
 
-
         self._mainLayout = QtWidgets.QHBoxLayout()
         self.setLayout(self._mainLayout)
         self._rightLayout = QtWidgets.QVBoxLayout()
@@ -86,7 +85,6 @@ class PdfExport(QtWidgets.QDialog):
         self._bottomLayout.addWidget(self._btnUpdatePreview)
         self._bottomLayout.addWidget(self._btnExport)
         self._bottomLayout.addWidget(self._btnDone)
-
 
         self._preview.paintRequested.connect(self._editor.print_)
 
@@ -131,8 +129,9 @@ class PdfExport(QtWidgets.QDialog):
             fmt = QtGui.QTextCharFormat()
             fmt.setBackground(QtGui.QColor(240, 240, 240))
             cursor.movePosition(cursor.Start, cursor.MoveAnchor)
-            notAtLastBlock = cursor.movePosition(cursor.NextBlock, cursor.MoveAnchor,
-                len(headerLines))
+            notAtLastBlock = cursor.movePosition(
+                cursor.NextBlock, cursor.MoveAnchor, len(headerLines)
+            )
             while notAtLastBlock:
                 cursor.movePosition(cursor.Right, cursor.KeepAnchor, numDigits)
                 cursor.setCharFormat(fmt)

--- a/pyzo/core/pdfExport.py
+++ b/pyzo/core/pdfExport.py
@@ -1,267 +1,194 @@
-from pyzo.qt import QtCore, QtGui, QtWidgets
-from pyzo import translate
-import pyzo
 import os
-from pyzo.codeeditor import Manager
+import pyzo
+from pyzo import translate
+from pyzo.qt import QtCore, QtGui, QtWidgets, QtPrintSupport
 
 
 class PdfExport(QtWidgets.QDialog):
     """
     This class is used to export an editor to a pdf.
     The content of the editor is copied in another editor,
-    and then the options chosen are applied by _print()
+    and then the options chosen are applied by _updateTemporaryEditor()
     """
 
     def __init__(self):
         super().__init__()
 
-        from pyzo.qt import QtPrintSupport
-
-        self.printer = QtPrintSupport.QPrinter(
-            QtPrintSupport.QPrinter.HighResolution,
-        )
-
-        # To allow pdf export with color
-        self.printer.setColorMode(QtPrintSupport.QPrinter.Color)
-
-        # Default settings
-        self.show_line_number = True
-        self._enable_syntax_highlighting = True
-
-        # Set title
         self.setWindowTitle(translate("menu dialog", "Pdf Export"))
 
-        # Set dialog size
-        size = 1000, 600
-        offset = 0
-        size2 = size[0], size[1] + offset
-        self.resize(*size2)
-        # self.setMinimumSize(*size2)
+        self.resize(1000, 600)
 
-        # Button to export to pdf
-        self.validation_button = QtWidgets.QPushButton("Export")
-        self.validation_button.clicked.connect(self._export_pdf)
+        self._printer = QtPrintSupport.QPrinter(QtPrintSupport.QPrinter.HighResolution)
+        self._printer.setColorMode(QtPrintSupport.QPrinter.Color)
 
-        # Button to update the preview
-        self.button_update_preview = QtWidgets.QPushButton("Update preview", self)
-        self.button_update_preview.clicked.connect(self._update_preview)
-
-        # Preview widget
-        self.preview = QtPrintSupport.QPrintPreviewWidget(self.printer)
-
-        # Lines numbers option
-        self.checkbox_line_number = QtWidgets.QCheckBox(
-            "Print line number", self, checked=self.show_line_number
-        )
-
-        self.checkbox_line_number.stateChanged.connect(self._get_show_line_number)
-
-        # Make of copy of the editor
-        self.current_editor = pyzo.editors.getCurrentEditor()
-        self.editor_name = self.current_editor.name
-        self.editor_filename = self.current_editor.filename
-        self.editor = pyzo.core.editor.PyzoEditor(
-            pyzo.editors.getCurrentEditor().toPlainText()
-        )
-
-        # Zoom
-        # The default zoom is the current zoom used by the editor
-        self.original_zoom = pyzo.config.view.zoom
-        self.zoom_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
-        self.zoom_slider.setMinimum(-10)  # Maybe too much ?
-        self.zoom_slider.setMaximum(10)
-        self.zoom_slider.setTickInterval(1)
-        self.zoom_selected = self.original_zoom
-        self.zoom_slider.setValue(self.zoom_selected)
-        self.zoom_value_label = QtWidgets.QLabel()
-        self._zoom_value_changed()
-        self.zoom_slider.valueChanged.connect(self._zoom_value_changed)
-
-        # Option for syntax highlighting
-        self.checkbox_syntax_highlighting = QtWidgets.QCheckBox(
-            "Enable syntax highlighting", self, checked=self._enable_syntax_highlighting
-        )
-
-        self.checkbox_syntax_highlighting.stateChanged.connect(
-            self._change_syntax_highlighting_option
-        )
-
-        self.combobox_file_name = QtWidgets.QComboBox(self)
-        self.combobox_file_name.addItem("Do not print the file name", 0)
-        self.combobox_file_name.addItem("Print with file name", 1)
-        self.combobox_file_name.addItem("Print with file name and absolute path", 2)
-        self.combobox_file_name.setCurrentIndex(1)
-        self.combobox_file_name.setToolTip("The title at the top of the document")
-
-        # Orientation
-        self.combobox_orientation = QtWidgets.QComboBox(self)
-        self.combobox_orientation.addItem("Portrait", 0)
-        self.combobox_orientation.addItem("Landscape", 1)
-        self.combobox_orientation.setToolTip("Orientation of the document")
-
-        # Layout
-        self.main_layout = QtWidgets.QHBoxLayout()
-        self.setLayout(self.main_layout)
-        self.preview.setSizePolicy(
+        self._preview = QtPrintSupport.QPrintPreviewWidget(self._printer)
+        self._preview.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
         )
-        self.right_layout = QtWidgets.QVBoxLayout()
-        self.option_layout = QtWidgets.QFormLayout()
-        self.main_layout.addWidget(self.preview)
 
-        self.main_layout.addLayout(self.right_layout)
-        self.right_layout.addLayout(self.option_layout)
-        self.option_layout.addRow(self.combobox_file_name)
-        self.option_layout.addRow(self.checkbox_line_number)
-        self.option_layout.addRow(self.checkbox_syntax_highlighting)
-        self.option_layout.addRow(self.zoom_value_label, self.zoom_slider)
-        self.option_layout.addRow(self.combobox_orientation)
-        self.bottom_layout = QtWidgets.QHBoxLayout()
-        self.right_layout.addLayout(self.bottom_layout)
-        self.bottom_layout.addStretch()
-        self.bottom_layout.addWidget(self.button_update_preview)
-        self.bottom_layout.addWidget(self.validation_button)
+        self._chkLineNumbers = QtWidgets.QCheckBox(
+            "Print line number", self, checked=True
+        )
 
-        self._update_preview()
+        self._currentEditor = pyzo.editors.getCurrentEditor()
+        self._editor = pyzo.core.editor.PyzoEditor("")
 
-    def _print(self):
-        """Generate the pdf for preview and export"""
+        self._sliderZoom = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self._sliderZoom.setMinimum(-10)
+        self._sliderZoom.setMaximum(10)
+        self._sliderZoom.setTickInterval(1)
+        self._sliderZoom.setValue(pyzo.config.view.zoom)
+        self._lblZoom = QtWidgets.QLabel()
+        self._updateZoomLabel()
+        self._sliderZoom.valueChanged.connect(self._updateZoomLabel)
 
-        if self.editor is not None:
-            cursor = self.editor.textCursor()
-            cursor.movePosition(cursor.Start)
-            cursor.movePosition(cursor.End, cursor.KeepAnchor)
+        self._chkSyntaxHighlighting = QtWidgets.QCheckBox(
+            "Enable syntax highlighting", self, checked=True
+        )
 
-            cursor.insertText(pyzo.editors.getCurrentEditor().toPlainText())
-            self._set_zoom(self.zoom_selected)
+        self._cmbFileName = QtWidgets.QComboBox(self)
+        self._cmbFileName.addItem("Do not print the file name", 0)
+        self._cmbFileName.addItem("Print with file name", 1)
+        self._cmbFileName.addItem("Print with file name and absolute path", 2)
+        self._cmbFileName.setCurrentIndex(1)
+        self._cmbFileName.setToolTip("The title at the top of the document")
 
-            # Print with line numbers
-            lines = self.editor.toPlainText().splitlines()
-            nzeros = len(str(len(lines)))
+        self._cmbPageOrientation = QtWidgets.QComboBox(self)
+        self._cmbPageOrientation.addItem("Portrait", 0)
+        self._cmbPageOrientation.addItem("Landscape", 1)
+        self._cmbPageOrientation.setToolTip("Orientation of the document")
 
-            self._apply_syntax_highlighting()
-            starting_line = 0
+        self._btnUpdatePreview = QtWidgets.QPushButton("Update preview", self)
+        self._btnUpdatePreview.clicked.connect(self._updatePreview)
+        self._btnExport = QtWidgets.QPushButton("Export")
+        self._btnExport.clicked.connect(self._exportPdf)
+        self._btnDone = QtWidgets.QPushButton("Done", self)
+        self._btnDone.clicked.connect(self.close)
 
-            self._change_orientation()
 
-            # Print name or filename in the editor
-            if self.combobox_file_name.currentIndex():
-                starting_line = 1
-                if self.combobox_file_name.currentIndex() == 1:
-                    lines.insert(0, "# " + self.editor_name + "\n")
-                elif self.combobox_file_name.currentIndex() == 2:
-                    lines.insert(0, "# " + self.editor_filename + "\n")
+        self._mainLayout = QtWidgets.QHBoxLayout()
+        self.setLayout(self._mainLayout)
+        self._rightLayout = QtWidgets.QVBoxLayout()
+        self._mainLayout.addWidget(self._preview)
+        self._mainLayout.addLayout(self._rightLayout)
 
-            # Print line numbers in the editor
-            if self.show_line_number:
-                for i in range(starting_line, len(lines)):
-                    lines[i] = (
-                        str(i + 1 - starting_line).rjust(nzeros, "0") + "| " + lines[i]
-                    )
+        self._optionLayout = QtWidgets.QFormLayout()
+        self._rightLayout.addLayout(self._optionLayout)
+        self._optionLayout.addRow(self._cmbFileName)
+        self._optionLayout.addRow(self._chkLineNumbers)
+        self._optionLayout.addRow(self._chkSyntaxHighlighting)
+        self._optionLayout.addRow(self._lblZoom, self._sliderZoom)
+        self._optionLayout.addRow(self._cmbPageOrientation)
 
-            cursor = self.editor.textCursor()
-            cursor.movePosition(cursor.Start)
-            cursor.movePosition(cursor.End, cursor.KeepAnchor)
-            cursor.insertText("\n".join(lines))
+        self._bottomLayout = QtWidgets.QHBoxLayout()
+        self._rightLayout.addLayout(self._bottomLayout)
+        self._bottomLayout.addStretch()
+        self._bottomLayout.addWidget(self._btnUpdatePreview)
+        self._bottomLayout.addWidget(self._btnExport)
+        self._bottomLayout.addWidget(self._btnDone)
 
-            # Highlight line numbers
-            if self.show_line_number:
-                cursor.movePosition(cursor.Start, cursor.MoveAnchor)
-                # Move the cursor down 2 lines if a title is printed
-                if starting_line != 0:
-                    cursor.movePosition(cursor.NextBlock, cursor.MoveAnchor, 2)
-                # Apply background for lines numbers
-                for i in range(len(lines)):
-                    fmt = QtGui.QTextCharFormat()
-                    fmt.setBackground(QtGui.QColor(240, 240, 240))
-                    cursor.movePosition(cursor.Right, cursor.KeepAnchor, nzeros)
-                    cursor.setCharFormat(fmt)
-                    cursor.movePosition(cursor.NextBlock, cursor.MoveAnchor)
-                    cursor.movePosition(cursor.StartOfBlock, cursor.MoveAnchor)
 
-    def _update_preview(self):
+        self._preview.paintRequested.connect(self._editor.print_)
+
+        self._updatePreview()
+
+    def _updateTemporaryEditor(self):
+        """update the temporary editor for preview and export"""
+
+        self._editor.setZoom(pyzo.config.view.zoom + self._sliderZoom.value())
+
+        if self._chkSyntaxHighlighting.isChecked():
+            parser = self._currentEditor.parser().name()
+        else:
+            parser = None
+        self._editor.setParser(parser)
+
+        self._updateOrientation()
+
+        # Print name or filename in the editor
+        headerLines = []
+        if self._cmbFileName.currentIndex() == 1:
+            headerLines = ["# " + self._currentEditor.name, ""]
+        elif self._cmbFileName.currentIndex() == 2:
+            headerLines = ["# " + self._currentEditor.filename, ""]
+
+        editorLines = self._currentEditor.toPlainText().splitlines()
+
+        # Print line numbers in the editor
+        showLineNumbers = self._chkLineNumbers.isChecked()
+        if showLineNumbers:
+            numDigits = len(str(len(editorLines)))
+            for i, s in enumerate(editorLines):
+                editorLines[i] = str(i + 1).rjust(numDigits, "0") + "| " + s
+
+        self._editor.clear()
+        cursor = self._editor.textCursor()
+        cursor.beginEditBlock()
+        cursor.insertText("\n".join(headerLines + editorLines))
+
+        # Highlight line numbers
+        if showLineNumbers:
+            fmt = QtGui.QTextCharFormat()
+            fmt.setBackground(QtGui.QColor(240, 240, 240))
+            cursor.movePosition(cursor.Start, cursor.MoveAnchor)
+            notAtLastBlock = cursor.movePosition(cursor.NextBlock, cursor.MoveAnchor,
+                len(headerLines))
+            while notAtLastBlock:
+                cursor.movePosition(cursor.Right, cursor.KeepAnchor, numDigits)
+                cursor.setCharFormat(fmt)
+                notAtLastBlock = cursor.movePosition(cursor.NextBlock, cursor.MoveAnchor)
+
+        cursor.endEditBlock()
+
+    def _updatePreview(self):
         """Update the widget preview"""
+        self._updateTemporaryEditor()
+        self._preview.updatePreview()
 
-        self._print()
-        self.preview.paintRequested.connect(self.editor.print_)
-        self.preview.updatePreview()
-        self._set_zoom(self.original_zoom)
-
-    def _export_pdf(self):
+    def _exportPdf(self):
         """Exports the code as pdf, and opens file manager"""
-        if self.editor is not None:
-            if True:
-                filename = QtWidgets.QFileDialog.getSaveFileName(
-                    None, "Export PDF", os.path.expanduser("~"), "*.pdf"
-                )
-                if isinstance(filename, tuple):  # PySide
-                    filename = filename[0]
-                if not filename:
-                    return
-                self.printer.setOutputFileName(filename)
-            else:
-                d = QtWidgets.QPrintDialog(self.printer)
-                d.setWindowTitle("Print code")
-                d.setOption(d.PrintSelection, self.editor.textCursor().hasSelection())
-                d.setOption(d.PrintToFile, True)
-                ok = d.exec_()
-                if ok != d.Accepted:
-                    return
+        filename = QtWidgets.QFileDialog.getSaveFileName(
+            None, "Export PDF", os.path.expanduser("~"), "*.pdf"
+        )
+        if isinstance(filename, tuple):  # PySide
+            filename = filename[0]
+        if not filename:
+            return
 
-        try:
-            self._print()
-            self.editor.print_(self.printer)
+        self._printer.setOutputFileName(filename)
+        self._updateTemporaryEditor()
+        self._editor.print_(self._printer)
 
-        except Exception as print_error:
-            print(print_error)
+        if self._printer.printerState() == self._printer.Error:
+            # Notify in logger
+            msg = 'could not export PDF file to "{}"'.format(filename)
+            print(msg)
+            # Make sure the user knows
+            m = QtWidgets.QMessageBox(self)
+            m.setWindowTitle("Error exporting PDF file")
+            m.setText(msg)
+            m.setIcon(m.Warning)
+            m.exec_()
 
-    def _get_show_line_number(self, state):
-        """Change the show_line_number according to the checkbox"""
-        if state == QtCore.Qt.Checked:
-            self.show_line_number = True
-        else:
-            self.show_line_number = False
+    def _updateZoomLabel(self):
+        self._lblZoom.setText("Zoom level: {}".format(self._sliderZoom.value()))
 
-    def _set_zoom(self, value):
-        """Apply zoom setting only to the editor used to generate the pdf
-        (and the preview)"""
-        self.editor.setZoom(pyzo.config.view.zoom + value)
-
-    def _zoom_value_changed(self):
-        """Triggered when the zoom slider is changed"""
-        self.zoom_selected = self.zoom_slider.value()
-        zoom_level = self.zoom_selected - self.zoom_slider.minimum()
-        self.zoom_value_label.setText("Zoom level : {}".format(zoom_level))
-
-    def _change_syntax_highlighting_option(self, state):
-        """Used for the syntax highlight checkbox when its state change
-        to change the option value"""
-        if state == QtCore.Qt.Checked:
-            self._enable_syntax_highlighting = True
-        else:
-            self._enable_syntax_highlighting = False
-
-    def _apply_syntax_highlighting(self):
-        """Apply the syntax setting when _print() is used"""
-        if self._enable_syntax_highlighting:
-            text = pyzo.editors.getCurrentEditor().toPlainText()
-            ext = os.path.splitext(pyzo.editors.getCurrentEditor()._filename)[1]
-            parser = Manager.suggestParser(ext, text)
-            self.editor.setParser(parser)
-        else:
-            self.editor.setParser(None)
-
-    def _change_orientation(self):
+    def _updateOrientation(self):
         """Set document in portrait or landscape orientation"""
-        if hasattr(self.printer, "setOrientation"):  # PySide5, PyQt5
-            base = pyzo.qt.QtPrintSupport.QPrinter
+        index = self._cmbPageOrientation.currentIndex()
+        if hasattr(self._printer, "setOrientation"):  # PySide5, PyQt5
+            base = QtPrintSupport.QPrinter
             orientation = [base.Portrait, base.Landscape][index]
-            self.preview.setOrientation(orientation)
-            self.printer.setOrientation(orientation)
+            self._preview.setOrientation(orientation)
+            self._printer.setOrientation(orientation)
         else:  # PySide6, PyQt6
             base = QtGui.QPageLayout
             orientation = [base.Portrait, base.Landscape][index]
-            self.preview.setOrientation(orientation)
+
+            self._preview.setOrientation(orientation)
+            self._preview.setOrientation(orientation)  # calling this a second time is a
+            # workaround, otherwise the preview in Qt6 is wrong when switching orientation
+
             layout = QtGui.QPageLayout()
             layout.setOrientation(orientation)
-            self.printer.setPageLayout(layout)
+            self._printer.setPageLayout(layout)


### PR DESCRIPTION
Features of the new version:
* significant speed improvements for preview/export of larger documents (e.g. 6500 lines with line numbers is down from 130 seconds to a few seconds)
* parser for syntax highlighting is now the same as in the editor window (instead of Manager.suggestParser)
* added missing line that I accidentally deleted in my last pull request
* added "Done" button in the dialog window
* added proper error message box when the PDF could not be saved
* zoom level slider offset removed (0 is normal, negative values are smaller font sizes)
* added workaround for wrong preview in Qt6 when changing from portrait to landscape
* updated code style to better match the rest of the code base, and cleaned up the code a bit
