### PR TITLE
add optional non-native file dialogs

### DIFF
--- a/pyzo/core/assistant.py
+++ b/pyzo/core/assistant.py
@@ -15,6 +15,7 @@ Copy the "docs" directory to the pyzo root!
 
 """
 
+import pyzo
 from pyzo.qt import QtCore, QtGui, QtWidgets  # noqa
 from pyzo import getResourceDirs
 import os
@@ -72,10 +73,14 @@ class Settings(QtWidgets.QWidget):
         del_button.clicked.connect(self.del_doc)
 
     def add_doc(self):
+        options = QtWidgets.QFileDialog.Option(0)
+        if not pyzo.config.advanced.useNativeFileDialogs:
+            options |= QtWidgets.QFileDialog.Option.DontUseNativeDialog
         doc_file = QtWidgets.QFileDialog.getOpenFileName(
             self,
             "Select a compressed help file",
             filter="Qt compressed help files (*.qch)",
+            options=options
         )
         if isinstance(doc_file, tuple):
             doc_file = doc_file[0]

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1171,8 +1171,8 @@ class EditorTabs(QtWidgets.QWidget):
             # Example how to preselect files, can be used when the users
             # opens a file in a project to select all files currently not
             # loaded.
-            d = QtWidgets.QFileDialog(self, msg, startdir, filter,
-                options=self._fileDialogOptions
+            d = QtWidgets.QFileDialog(
+                self, msg, startdir, filter, options=self._fileDialogOptions
             )
             d.setFileMode(d.ExistingFiles)
             d.selectFile('"codeparser.py" "editorStack.py"')
@@ -1204,8 +1204,8 @@ class EditorTabs(QtWidgets.QWidget):
 
         # show dialog
         msg = "Select a directory to open"
-        dirname = QtWidgets.QFileDialog.getExistingDirectory(self, msg,
-            startdir, options=self._fileDialogOptions
+        dirname = QtWidgets.QFileDialog.getExistingDirectory(
+            self, msg, startdir, options=self._fileDialogOptions
         )
 
         # was a dir selected?
@@ -1340,8 +1340,8 @@ class EditorTabs(QtWidgets.QWidget):
         filter += "C (*.c *.h *.cpp);;"
         # filter += "Py+Cy+C (*.py *.pyw *.pyi *.pyx *.pxd *.c *.h *.cpp);;"
         filter += "All (*.*)"
-        filename = QtWidgets.QFileDialog.getSaveFileName(self, msg, startdir,
-            filter, options=self._fileDialogOptions
+        filename = QtWidgets.QFileDialog.getSaveFileName(
+            self, msg, startdir, filter, options=self._fileDialogOptions
         )
         if isinstance(filename, tuple):  # PySide
             filename = filename[0]

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1006,6 +1006,13 @@ class EditorTabs(QtWidgets.QWidget):
         # the widgets are properly sized.
         pyzo.callLater(self.restoreEditorState)
 
+    @property
+    def _fileDialogOptions(self):
+        options = QtWidgets.QFileDialog.Option(0)
+        if not pyzo.config.advanced.useNativeFileDialogs:
+            options |= QtWidgets.QFileDialog.Option.DontUseNativeDialog
+        return options
+
     def addContextMenu(self):
         """Adds a context menu to the tab bar"""
 
@@ -1156,7 +1163,7 @@ class EditorTabs(QtWidgets.QWidget):
         filter += "All (*)"
         if True:
             filenames = QtWidgets.QFileDialog.getOpenFileNames(
-                self, msg, startdir, filter
+                self, msg, startdir, filter, options=self._fileDialogOptions
             )
             if isinstance(filenames, tuple):  # PySide
                 filenames = filenames[0]
@@ -1164,7 +1171,9 @@ class EditorTabs(QtWidgets.QWidget):
             # Example how to preselect files, can be used when the users
             # opens a file in a project to select all files currently not
             # loaded.
-            d = QtWidgets.QFileDialog(self, msg, startdir, filter)
+            d = QtWidgets.QFileDialog(self, msg, startdir, filter,
+                options=self._fileDialogOptions
+            )
             d.setFileMode(d.ExistingFiles)
             d.selectFile('"codeparser.py" "editorStack.py"')
             d.exec_()
@@ -1195,7 +1204,9 @@ class EditorTabs(QtWidgets.QWidget):
 
         # show dialog
         msg = "Select a directory to open"
-        dirname = QtWidgets.QFileDialog.getExistingDirectory(self, msg, startdir)
+        dirname = QtWidgets.QFileDialog.getExistingDirectory(self, msg,
+            startdir, options=self._fileDialogOptions
+        )
 
         # was a dir selected?
         if not dirname:
@@ -1329,7 +1340,9 @@ class EditorTabs(QtWidgets.QWidget):
         filter += "C (*.c *.h *.cpp);;"
         # filter += "Py+Cy+C (*.py *.pyw *.pyi *.pyx *.pxd *.c *.h *.cpp);;"
         filter += "All (*.*)"
-        filename = QtWidgets.QFileDialog.getSaveFileName(self, msg, startdir, filter)
+        filename = QtWidgets.QFileDialog.getSaveFileName(self, msg, startdir,
+            filter, options=self._fileDialogOptions
+        )
         if isinstance(filename, tuple):  # PySide
             filename = filename[0]
 

--- a/pyzo/core/pdfExport.py
+++ b/pyzo/core/pdfExport.py
@@ -147,8 +147,12 @@ class PdfExport(QtWidgets.QDialog):
 
     def _exportPdf(self):
         """Exports the code as pdf, and opens file manager"""
+        options = QtWidgets.QFileDialog.Option(0)
+        if not pyzo.config.advanced.useNativeFileDialogs:
+            options |= QtWidgets.QFileDialog.Option.DontUseNativeDialog
         filename = QtWidgets.QFileDialog.getSaveFileName(
-            None, "Export PDF", os.path.expanduser("~"), "*.pdf"
+            None, "Export PDF", os.path.expanduser("~"), "*.pdf",
+            options=options
         )
         if isinstance(filename, tuple):  # PySide
             filename = filename[0]

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -71,6 +71,7 @@ advanced = dict:
     titleText = '{fileName} ({fullPath}) - Interactive Editor for Python'
     homeAndEndWorkOnDisplayedLine = 0
     find_autoHide_timeout = 10
+    useNativeFileDialogs = 1
 
 tools = dict:
     pyzologger = dict:

--- a/pyzo/tools/pyzoFileBrowser/importwizard.py
+++ b/pyzo/tools/pyzoFileBrowser/importwizard.py
@@ -5,13 +5,13 @@ numpy array. The wizard containst three pages:
 
 SelectFilePage:
     - The user selects a file and previews its contents (or, the beginning of it)
-    
+
 SetParametersPage:
     - The user selects delimiters, etc. and selects which columns to import
     - A preview of the data in tabualar form is shown, with colors indicating
       how the file is parsed: yellow for header rows, green for the comments
       column and red for values that could not be parsed
-      
+
 ResultPage:
     - The wizard shows the generated code that is to be used to import the file
       according to the settings
@@ -24,6 +24,7 @@ ResultPage:
 import unicodedata
 import os.path as op
 
+import pyzo
 import pyzo.codeeditor
 from . import QtCore, QtGui, QtWidgets
 from pyzo import translate
@@ -122,10 +123,14 @@ class SelectFilePage(QtWidgets.QWizardPage):
         self._isComplete = False
 
     def onBrowseClicked(self):
+        options = QtWidgets.QFileDialog.Option(0)
+        if not pyzo.config.advanced.useNativeFileDialogs:
+            options |= QtWidgets.QFileDialog.Option.DontUseNativeDialog
         # Difference between PyQt4 and PySide: PySide returns filename, filter
         # while PyQt4 returns only the filename
         filename = QtWidgets.QFileDialog.getOpenFileName(
-            filter="Text files (*.txt *.csv);;All files (*.*)"
+            filter="Text files (*.txt *.csv);;All files (*.*)",
+            options=options
         )
         if isinstance(filename, tuple):
             filename = filename[0]


### PR DESCRIPTION
This PR will allow for using non-native file dialogs (Qt widgets based) instead of the operating system provided ones.
To enable these non-native file dialogs, users have to change the "advanced -> useNativeFileDialogs" setting in the "Advanced Settings" dialog from default value 1 to 0.

One of the use cases is to avoid specific errors on MS Windows -- I will write an issue for that later and mention it in this PR.
