### PR TITLE
remove QtOpenGLWidgets

### DIFF
--- a/freeze/pyzo_freeze.py
+++ b/freeze/pyzo_freeze.py
@@ -124,7 +124,6 @@ qt_includes = [
     "QtWidgets",  # Standard
     "QtHelp",  # For docs
     "QtPrintSupport",  # For PDF export
-    "QtOpenGLWidgets",  # Because qtpy imports QOpenGLQWidget into QtWidgets
 ]
 includes += [f"{qt_api}.{sub}" for sub in qt_includes]
 
@@ -140,6 +139,7 @@ excludes += list(other_qt_kits)
 qt_excludes = [
     "QtNetwork",
     "QtOpenGL",
+    "QtOpenGLWidgets",
     "QtXml",
     "QtTest",
     "QtSql",

--- a/pyzo/qt/QtWidgets.py
+++ b/pyzo/qt/QtWidgets.py
@@ -14,7 +14,6 @@ from . import PYQT5, PYQT6, PYSIDE2, PYSIDE6, PythonQtError
 if PYQT6:
     from PyQt6.QtWidgets import *
     from PyQt6.QtGui import QAction, QActionGroup, QShortcut, QFileSystemModel
-    from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
     # Map missing/renamed methods
     import inspect
@@ -42,7 +41,6 @@ elif PYQT5:
 elif PYSIDE6:
     from PySide6.QtWidgets import *
     from PySide6.QtGui import QAction, QActionGroup, QShortcut
-    from PySide6.QtOpenGLWidgets import QOpenGLWidget
 
     # Map missing/renamed methods
     QTextEdit.setTabStopWidth = QTextEdit.setTabStopDistance


### PR DESCRIPTION
As far as I can tell, Pyzo does not use and does not need the QtOpenGLWidgets.