### PR TITLE
fix truncated version info string in pyzo logger welcome message

### DIFF
--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -74,9 +74,10 @@ class PyzoLoggerShell(BaseShell):
         self._interpreter = code.InteractiveConsole(locals, "<logger>")
 
         # Show welcome text
+        version = sys.version.split(None, 1)[0]
         moreBanner = "This is the Pyzo logger shell."
         self.write(
-            "Python %s on %s - %s\n\n" % (sys.version[:5], sys.platform, moreBanner)
+            "Python {} on {} - {}\n\n".format(version, sys.platform, moreBanner)
         )
         self.write(str(sys.ps1), 2)
 


### PR DESCRIPTION
Without this patch, the Pyzo Logger displays for example
`Python 3.11. on linux - This is the Pyzo logger shell.`
instead of
`Python 3.11.0 on linux - This is the Pyzo logger shell.`.