### PR TITLE
add missing style entry for Syntax.illegal

### DIFF
--- a/pyzo/resources/themes/dark.theme
+++ b/pyzo/resources/themes/dark.theme
@@ -31,3 +31,4 @@ data = dict:
     syntax_c_multilinecomment='fore:#007f00, bold:no, underline:no, italic:no'
     syntax_c_char='fore:#7f007f, bold:no, underline:no, italic:no'
     editor_text='fore:#c5d9ff, back:#272822'
+    syntax_illegal = 'fore:#ff0000, back:#ffd7c7, bold:no, underline:no, italic:no'

--- a/pyzo/resources/themes/default.theme
+++ b/pyzo/resources/themes/default.theme
@@ -21,6 +21,7 @@ data = dict:
     syntax_comment = 'fore:#b58900, bold:no, underline:no, italic:no'
     syntax_functionname = 'fore:#073642, bold:yes, underline:no, italic:no'
     syntax_identifier = 'fore:#657b83, bold:no, underline:no, italic:no'
+    syntax_illegal = 'fore:#ff0000, back:#ffd7c7, bold:no, underline:no, italic:no'
     syntax_instance = 'fore:#657b83, bold:no, underline:no, italic:no'
     syntax_keyword = 'fore:#586e75, bold:yes, underline:no, italic:no'
     syntax_nonidentifier = 'fore:#586e75, bold:no, underline:no, italic:no'

--- a/pyzo/resources/themes/scintilla.theme
+++ b/pyzo/resources/themes/scintilla.theme
@@ -31,3 +31,4 @@ data = dict:
     syntax_python_multilinestring='fore:#7f0000, bold:no, underline:no, italic:no'
     syntax_python_cellcomment='fore:#007f00, bold:yes, underline:yes, italic:no'
     editor_text='fore:#000, back:#fff'
+    syntax_illegal = 'fore:#ff0000, back:#ffd7c7, bold:no, underline:no, italic:no'

--- a/pyzo/resources/themes/solarized_dark.theme
+++ b/pyzo/resources/themes/solarized_dark.theme
@@ -21,6 +21,7 @@ data = dict:
     syntax_comment = 'fore:#b58900, bold:no, underline:no, italic:no'
     syntax_functionname = 'fore:#eee8d5, bold:yes, underline:no, italic:no'
     syntax_identifier = 'fore:#839496, bold:no, underline:no, italic:no'
+    syntax_illegal = 'fore:#ff0000, back:#ffd7c7, bold:no, underline:no, italic:no'
     syntax_instance = 'fore:#839496, bold:no, underline:no, italic:no'
     syntax_keyword = 'fore:#93a1a1, bold:yes, underline:no, italic:no'
     syntax_nonidentifier = 'fore:#93a1a1, bold:no, underline:no, italic:no'

--- a/pyzo/resources/themes/solarized_light.theme
+++ b/pyzo/resources/themes/solarized_light.theme
@@ -21,6 +21,7 @@ data = dict:
     syntax_comment = 'fore:#b58900, bold:no, underline:no, italic:no'
     syntax_functionname = 'fore:#073642, bold:yes, underline:no, italic:no'
     syntax_identifier = 'fore:#657b83, bold:no, underline:no, italic:no'
+    syntax_illegal = 'fore:#ff0000, back:#ffd7c7, bold:no, underline:no, italic:no'
     syntax_instance = 'fore:#657b83, bold:no, underline:no, italic:no'
     syntax_keyword = 'fore:#586e75, bold:yes, underline:no, italic:no'
     syntax_nonidentifier = 'fore:#586e75, bold:no, underline:no, italic:no'


### PR DESCRIPTION
In the syntax/theme editor, style entry "Syntax.illegal" the color entry widgets are all empty for all themes (including the default theme), because in the *.theme files, the entry "syntax_illegal" was missing.

This missing entry has already been mentioned some time ago in #698.

This PR adds the missing lines in the themes files.