### PR TITLE
save "Auto hide" value in editor search dropbox

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1525,6 +1525,7 @@ class EditorTabs(QtWidgets.QWidget):
         pyzo.config.state.find_matchCase = fr._caseCheck.isChecked()
         pyzo.config.state.find_regExp = fr._regExp.isChecked()
         pyzo.config.state.find_wholeWord = fr._wholeWord.isChecked()
+        pyzo.config.state.find_autoHide = fr._autoHide.isChecked()
         pyzo.config.state.find_show = fr.isVisible()
         #
         pyzo.config.state.editorState2 = self._getCurrentOpenFilesAsSsdfList()


### PR DESCRIPTION
The value for the "Auto hide" checkbox is read from the config file but was never saved back to it unlike the other checkboxes.
With this PR, the state of the "Auto hide" checkbox will be saved.