### PR TITLE
reduce search dropbox margins

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -210,6 +210,8 @@ class FindReplaceWidget(QtWidgets.QFrame):
         # init layout
         layout = QtWidgets.QHBoxLayout(self)
         layout.setSpacing(0)
+        margin = 0
+        layout.setContentsMargins(margin, margin, margin, margin)
         self.setLayout(layout)
 
         # Create some widgets first to realize a correct tab order


### PR DESCRIPTION
In my opinion, the borders around the search dropbox are a waste of space.
With this PR, I can see ca. 1.5 text lines more in the editor when the search dropbox is visible.