### PR TITLE
python 2.7 compatibility

### DIFF
--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -115,7 +115,7 @@ class App_nogui(App_base):
 
     def run(self, repl_callback):
         # Move at a slow pace - there is no gui to keep running
-        super().run(repl_callback, 0.1)
+        App_base.run(self, repl_callback, 0.1)
 
 
 # Experimental and WIP - not used at the moment


### PR DESCRIPTION
I just stumbled upon this:
Pyzo still supports Python 2.7 shells/kernels (after correcting one line with this PR).

@almarklein:
In my opinion we could drop Python 2.7 support (as well as Qt4 support) to modernize the codebase.
What do you think about that?
