### PR TITLE
replace version string parser with own implementation

### DIFF
--- a/freeze/frozen_libs.txt
+++ b/freeze/frozen_libs.txt
@@ -1,2 +1,1 @@
-packaging
 dialite

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -35,7 +35,6 @@ import traceback
 import keyword
 import inspect  # noqa - Must be in this namespace
 import bdb
-from distutils.version import LooseVersion as LV
 import linecache
 
 import yoton
@@ -354,10 +353,23 @@ class PyzoInterpreter:
 
         # Prevent app nap on OSX 9.2 and up
         # The _nope module is taken from MINRK's appnope package
-        if sys.platform == "darwin" and LV(platform.mac_ver()[0]) >= LV("10.9"):
-            from pyzokernel import _nope
+        if sys.platform == "darwin":
 
-            _nope.nope()
+            def parse_version_crudely(version_string):
+                """extracts the leading number parts of a version string to a tuple
+                e.g.: "123.45ew6.7x.dev8" --> (123, 45, 7)
+                """
+                import re
+
+                return tuple(
+                    int(s) for s in re.findall(r"\.(\d+)", "." + version_string)
+                )
+
+            parsev = parse_version_crudely
+            if parsev(platform.mac_ver()[0]) >= parsev("10.9"):
+                from pyzokernel import _nope
+
+                _nope.nope()
 
         # Setup post-mortem debugging via appropriately logged exceptions
         class PMHandler(logging.Handler):

--- a/pyzo/qt/__init__.py
+++ b/pyzo/qt/__init__.py
@@ -54,7 +54,7 @@ PySide6
 
 """
 
-from packaging.version import parse
+from pyzo.util import parse_version_crudely as parse
 import os
 import platform
 import sys

--- a/pyzo/util/__init__.py
+++ b/pyzo/util/__init__.py
@@ -1,0 +1,8 @@
+import re as _re
+
+
+def parse_version_crudely(version_string):
+    """extracts the leading number parts of a version string to a tuple
+    e.g.: "123.45ew6.7x.dev8" --> (123, 45, 7)
+    """
+    return tuple(int(s) for s in _re.findall(r"\.(\d+)", "." + version_string))

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,7 @@ setup(
     platforms="any",
     provides=["pyzo"],
     python_requires=">=3.5.0",
-    install_requires=[
-        "packaging"
-    ],  # and 'PySide2' or 'PyQt5' (less sure about PySide/PyQt4)
+    install_requires=[],  # and 'PySide2' or 'PyQt5' or 'PySide6' or 'PyQt6'
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_dir={"pyzo": "pyzo"},
     package_data={


### PR DESCRIPTION
Currently, there are two use cases for converting a string, like "123.45ew6.7x.dev8", to a comparable tuple, like (123, 45, 7).

1. `pyzo/pyzokernel/interpreter.py`
The version comparison is just to check if the macOS version is >= 10.9.
Before this PR, `distutils.version.LooseVersion` was used, but `distutils` is not available anymore in Python 3.12. See [PEP 632](https://peps.python.org/pep-0632/) and the [release notes](https://www.python.org/downloads/release/python-3120b2/) for details.

2. `pyzo/qt/__init__.py`
The version comparison is to check macOS and Qt versions.
Before this PR, the external package `packaging` was used for this (and only for this).

With the own implementation, pyzo has no more external dependencies, except `dialite` and a Qt binding.

The new function `parse_version_crudely` is implemented twice because in case (1) it is executed by the shell/kernel's Python interpreter and in case (2) by the Python interpreter that runs the Pyzo IDE. I think code duplication does not harm here because the function is merely one line of trivial code. And before this PR, two different packages (distutils and packaging) have been used for the same task. Using a common code file would be possible: this would require a new folder such as "kernel_and_ide" to have a clean separation. Currently all files in directory `pyzo/yoton` are the only code files that are used by both the kernel and the IDE.
