### PR TITLE
update required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     keywords="Python interactive IDE Qt science computing",
     platforms="any",
     provides=["pyzo"],
-    python_requires=">=3.5.0",
+    python_requires=">=3.6.0",
     install_requires=[
         "packaging"
     ],  # and 'PySide2' or 'PyQt5' (less sure about PySide/PyQt4)
@@ -89,10 +89,12 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
According to `pyzo/__init__.py`, the minimum required Python version is 3.6.