### PR TITLE
fix appconfig path on MS Windows and clean up code

### DIFF
--- a/pyzo/_start.py
+++ b/pyzo/_start.py
@@ -102,28 +102,6 @@ sys.excepthook = pyzo_excepthook
 
 # todo: move some stuff out of this module ...
 
-
-def getResourceDirs():
-    """getResourceDirs()
-    Get the directories to the resources: (pyzoDir, appDataDir, appConfigDir).
-    Also makes sure that the appDataDir has a "tools" directory and
-    a style file.
-    """
-
-    pyzoDir = os.path.abspath(os.path.dirname(__file__))
-    if ".zip" in pyzoDir:
-        raise RuntimeError("The Pyzo package cannot be run from a zipfile.")
-
-    # Get where the application data is stored (use old behavior on Mac)
-    appDataDir, appConfigDir = paths.appdata_dir("pyzo", roaming=True, macAsLinux=True)
-
-    # Create tooldir if necessary
-    toolDir = os.path.join(appDataDir, "tools")
-    os.makedirs(toolDir, exist_ok=True)
-
-    return pyzoDir, appDataDir, appConfigDir
-
-
 def resetConfig(preserveState=True):
     """resetConfig()
     Deletes the config file to revert to default and prevent Pyzo from storing
@@ -216,7 +194,7 @@ def loadConfig(defaultsOnly=False):
 
 def saveConfig():
     """saveConfig()
-    Save all configureations to file.
+    Save all configurations to file.
     """
 
     # Let the editorStack save its state
@@ -232,7 +210,6 @@ def saveConfig():
         ssdf.save(os.path.join(pyzo.appConfigDir, "config.ssdf"), pyzo.config)
 
 
-pyzo.getResourceDirs = getResourceDirs
 pyzo.resetConfig = resetConfig
 pyzo.loadThemes = loadThemes
 pyzo.saveConfig = saveConfig
@@ -301,7 +278,8 @@ pyzo.parser = None  # The source parser
 pyzo.status = None  # The statusbar (or None)
 
 # Get directories of interest
-pyzo.pyzoDir, pyzo.appDataDir, pyzo.appConfigDir = getResourceDirs()
+pyzo.appDataDir, pyzo.appConfigDir = paths.prepare_appdata_appconfig_dirs()
+pyzo.pyzoDir = os.path.abspath(os.path.dirname(__file__))
 
 # Whether the config file should be saved
 pyzo._saveConfigFile = True

--- a/pyzo/core/assistant.py
+++ b/pyzo/core/assistant.py
@@ -17,7 +17,6 @@ Copy the "docs" directory to the pyzo root!
 
 import pyzo
 from pyzo.qt import QtCore, QtGui, QtWidgets  # noqa
-from pyzo import getResourceDirs
 import os
 
 
@@ -144,10 +143,9 @@ class PyzoAssistant(QtWidgets.QWidget):
 
         super().__init__(parent)
         self.setWindowTitle("Help")
-        pyzoDir, appDataDir, appConfigDir = getResourceDirs()
         if collection_filename is None:
             # Collection file is stored in pyzo data dir:
-            collection_filename = os.path.join(appDataDir, "tools", "docs.qhc")
+            collection_filename = os.path.join(pyzo.appDataDir, "tools", "docs.qhc")
         self._engine = QtHelp.QHelpEngine(collection_filename)
 
         # Important, call setup data to load the files:
@@ -155,7 +153,7 @@ class PyzoAssistant(QtWidgets.QWidget):
 
         # If no files are loaded, register at least the pyzo docs:
         if len(self._engine.registeredDocumentations()) == 0:
-            doc_file = os.path.join(pyzoDir, "resources", "pyzo.qch")
+            doc_file = os.path.join(pyzo.pyzoDir, "resources", "pyzo.qch")
             self._engine.registerDocumentation(doc_file)
 
         # The main players:

--- a/pyzo/util/interpreters/__init__.py
+++ b/pyzo/util/interpreters/__init__.py
@@ -12,7 +12,6 @@ import os
 
 from .pythoninterpreter import EXE_DIR, PythonInterpreter, versionStringToTuple
 from .inwinreg import get_interpreters_in_reg
-from .. import paths
 
 
 def get_interpreters(minimumVersion=None):

--- a/pyzo/util/interpreters/__init__.py
+++ b/pyzo/util/interpreters/__init__.py
@@ -35,14 +35,11 @@ def get_interpreters(minimumVersion=None):
     # Get relative interpreters
     relative = set([PythonInterpreter(p) for p in _get_interpreters_relative()])
 
-    # Get Pyzo paths
-    pyzos = set([PythonInterpreter(p) for p in _get_interpreters_pyzo()])
-
     # Get pipenv paths
     pipenvs = set([PythonInterpreter(p) for p in _get_interpreters_pipenv()])
 
     # Almost done
-    interpreters = set.union(pythons, condas, relative, pyzos, pipenvs)
+    interpreters = set.union(pythons, condas, relative, pipenvs)
     minimumVersion = minimumVersion or "0"
     return _select_interpreters(interpreters, minimumVersion)
 
@@ -167,21 +164,6 @@ def _get_interpreters_posix():
 
     # Return as set (remove duplicates)
     return set(found)
-
-
-def _get_interpreters_pyzo():
-    """Get a list of known Pyzo interpreters."""
-    pythonname = "python" + ".exe" * sys.platform.startswith("win")
-    exes = []
-    for d in paths.pyzo_dirs():
-        for fname in [
-            os.path.join(d, "bin", pythonname + "3"),
-            os.path.join(d, pythonname),
-        ]:
-            if os.path.isfile(fname):
-                exes.append(fname)
-                break
-    return exes
 
 
 def _get_interpreters_conda():

--- a/pyzo/util/paths.py
+++ b/pyzo/util/paths.py
@@ -63,7 +63,7 @@ def prepare_appdata_appconfig_dirs():
                 python pyzolauncher.py --> 'pyzolauncher.py' or 'python'
                 via binary from frozen pyzo --> 'pyzo'
             """
-            if pyzo.qt.QtCore.QCoreApplication.applicationName() != "":
+            if QtCore.QCoreApplication.applicationName() != "":
                 data_path_base = os.path.split(data_path_base)[0]
                 config_path_base = os.path.split(config_path_base)[0]
             data_path = os.path.join(data_path_base, appname)

--- a/pyzo/util/paths.py
+++ b/pyzo/util/paths.py
@@ -3,35 +3,9 @@
 #
 # This file is distributed under the terms of the 2-Clause BSD License.
 
-""" Module paths
-
-Get paths to useful directories in a cross platform manner. The functions
-in this module are designed to be stand-alone, so that they can easily
-be copied and used in code that does not want pyzo as a dependency.
-
-This code was first part of pyzolib, and later moved to pyzo.
-
-"""
-
-# Notes:
-# * site.getusersitepackages() returns a dir in roaming userspace on Windows
-#   so better avoid that.
-# * site.getuserbase() returns appdata_dir('Python', True)
-# * See docstring: that's why the functions tend to not re-use each-other
-
+import os
 import sys
 from pyzo.qt import QtCore
-
-ISWIN = sys.platform.startswith("win")
-ISMAC = sys.platform.startswith("darwin")
-ISLINUX = sys.platform.startswith("linux")
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
-
-
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import sys
 
 
 def is_frozen():
@@ -41,295 +15,68 @@ def is_frozen():
     return bool(getattr(sys, "frozen", None))
 
 
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import os, sys, tempfile
-
-
-def temp_dir(appname=None, nospaces=False):
-    """temp_dir(appname=None, nospaces=False)
-    Get path to a temporary directory with write access.
-    If appname is given, a subdir is appended (and created if necessary).
-    If nospaces, will ensure that the path has no spaces.
+def prepare_appdata_appconfig_dirs():
+    """get the directories for Pyzo application data and configuration
+    folders are created if not present
     """
 
-    # Do it the Python way
-    path = tempfile.gettempdir()
-
-    # Try harder if we have to
-    if nospaces and " " in path:
-        if sys.platform.startswith("win"):
-            for path in ["c:\\TEMP", "c:\\TMP"]:
-                if os.path.isdir(path):
+    # check for a "settings" folder next to the Pyzo executable or one level above,
+    # which is typically used for portable applications
+    use_portable_settings = False
+    if is_frozen():
+        exec_dir = os.path.abspath(os.path.dirname(sys.executable))
+        for reldir in ("settings", "../settings"):
+            localpath = os.path.abspath(os.path.join(exec_dir, reldir))
+            if os.path.isdir(localpath):
+                try:
+                    open(os.path.join(localpath, "test.write"), "wb").close()
+                    os.remove(os.path.join(localpath, "test.write"))
+                except IOError:
+                    pass  # We cannot write in this directory
+                else:
+                    data_path = config_path = localpath
+                    use_portable_settings = True
                     break
-            os.makedirs(path, exist_ok=True)
+
+    if not use_portable_settings:
+        appname = "pyzo"
+        path_dot = os.path.expanduser("~/." + appname)  # leading dot means hidden directory
+        if sys.platform == "win32":
+            data_path = config_path = os.path.join(os.getenv("APPDATA"), appname)
+            # typically r"C:\Users\username\AppData\Roaming\pyzo"
+        elif os.path.isdir(path_dot):
+            # existing legacy data and config directory in Linux or macOS
+            data_path = config_path = path_dot
+        elif sys.platform == "linux":
+            # see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+            data_path_base = os.getenv("XDG_DATA_HOME", "") or "~/.local/share"
+            config_path_base = os.getenv("XDG_CONFIG_HOME", "") or "~/.config"
+            data_path = os.path.expanduser(os.path.join(data_path_base, appname))
+            config_path = os.path.expanduser(os.path.join(config_path_base, appname))
+        elif sys.platform == "darwin":
+            sp = QtCore.QStandardPaths
+            data_path_base = sp.writableLocation(sp.AppDataLocation)
+            config_path_base = sp.writableLocation(sp.ConfigLocation)
+            """
+            The AppName added by Qt depends on how pyzo was started, e.g.:
+                import pyzo; pyzo.start() --> ''
+                python pyzolauncher.py --> 'pyzolauncher.py' or 'python'
+                via binary from frozen pyzo --> 'pyzo'
+            """
+            if pyzo.qt.QtCore.QCoreApplication.applicationName() != "":
+                data_path_base = os.path.split(data_path_base)[0]
+                config_path_base = os.path.split(config_path_base)[0]
+            data_path = os.path.join(data_path_base, appname)
+            config_path = os.path.join(config_path_base, appname)
         else:
-            for path in [
-                "/tmp",
-                "/var/tmp",
-            ]:  # http://www.tuxfiles.org/linuxhelp/linuxdir.html
-                if os.path.isdir(path):
-                    break
-            else:
-                raise RuntimeError("Could not locate temporary directory.")
+            raise NotImplementedError("unsupported operating system: " + sys.platform)
 
-    # Get path specific for this app
-    if appname:
-        path = os.path.join(path, appname)
-        os.makedirs(path, exist_ok=True)
-
-    # Done
-    return path
-
-
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import os
-
-
-def user_dir():
-    """user_dir()
-    Get the path to the user directory. (e.g. "/home/jack", "c:/Users/jack")
-    """
-    return os.path.expanduser("~")
-
-
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import os, sys
-
-
-def appdata_dir(appname=None, roaming=False, macAsLinux=False):
-    """appdata_dir(appname=None, roaming=False,  macAsLinux=False)
-    Get the path to the application data and config directory, where applications are allowed
-    to write user specific files (e.g. configurations).
-    Applications should write their configurations files in the config folder,
-    and other data (e.g. history files) in the data folder.
-    For non-user specific data, consider using common_appdata_dir().
-    If appname is given, a subdir is appended (and created if necessary).
-    If roaming is True, will prefer a roaming directory (Windows Vista/7).
-    If macAsLinux is True, will return the Linux-like location on Mac.
-
-    The behaviour of this function changed, it now uses QStandardPaths to provide location
-    of data folder and config folder, but for retro-compatibility pyzo will use the old folder if it exists
-    """
-
-    # Define default user directory
-    userDir = os.path.expanduser("~")
-
-    # Get system app data dir
-    path = None
-    if sys.platform.startswith("win"):
-        path1, path2 = os.getenv("LOCALAPPDATA"), os.getenv("APPDATA")
-        path = (path2 or path1) if roaming else (path1 or path2)
-    elif sys.platform.startswith("darwin") and not macAsLinux:
-        path = os.path.join(userDir, "Library", "Application Support")
-    # On Linux and as fallback
-    if not (path and os.path.isdir(path)):
-        path = userDir
-
-    # Maybe we should store things local to the executable (in case of a
-    # portable distro or a frozen application that wants to be portable)
-    prefix = sys.prefix
-    if getattr(sys, "frozen", None):  # See application_dir() function
-        prefix = os.path.abspath(os.path.dirname(sys.executable))
-    for reldir in ("settings", "../settings"):
-        localpath = os.path.abspath(os.path.join(prefix, reldir))
-        if os.path.isdir(localpath):
-            try:
-                open(os.path.join(localpath, "test.write"), "wb").close()
-                os.remove(os.path.join(localpath, "test.write"))
-            except IOError:
-                pass  # We cannot write in this directory
-            else:
-                path = localpath
-                break
-    data_path, config_path = path, path
-
-    # Get path specific for this app
-    if appname:
-        if path == userDir:
-            appname = "." + appname.lstrip(".")  # Make it a hidden directory
-        path = os.path.join(path, appname)
-        data_path, config_path = path, path
-
-        if not os.path.isdir(path):
-            # Better way to get config/data folder especially on *nix system (see XDG_CONFIG_HOME standard),
-            # but this should work on any os.
-            # For retro-compatibility, check if old folder exist, and if not, use standard path.
-            try:
-                standard_data_path = QtCore.QStandardPaths.writableLocation(
-                    QtCore.QStandardPaths.AppDataLocation
-                )
-                standard_config_path = QtCore.QStandardPaths.writableLocation(
-                    QtCore.QStandardPaths.ConfigLocation
-                )
-            except AttributeError:
-                pass
-            else:
-                # Check if QStandardPaths succeeded to find the location, otherwise use old path
-                if standard_config_path:
-                    config_path = standard_config_path
-                if standard_data_path:
-                    data_path = standard_data_path
-                appname = appname.lstrip(".")
-                data_path = os.path.join(data_path, appname)
-                config_path = os.path.join(config_path, appname)
-
-            os.makedirs(data_path, exist_ok=True)
-            os.makedirs(config_path, exist_ok=True)
-
-    # Done
-    return data_path, config_path
-
-
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import os, sys
-
-
-def common_appdata_dir(appname=None):
-    """common_appdata_dir(appname=None)
-    Get the path to the common application directory. Applications are
-    allowed to write files here. For user specific data, consider using
-    appdata_dir().
-    If appname is given, a subdir is appended (and created if necessary).
-    """
-
-    # Try to get data_path
-    data_path = None
-    if sys.platform.startswith("win"):
-        data_path = os.getenv("ALLUSERSPROFILE", os.getenv("PROGRAMDATA"))
-    elif sys.platform.startswith("darwin"):
-        data_path = "/Library/Application Support"
-    else:
-        # Not sure what to use. Apps are only allowed to write to the home
-        # dir and tmp dir, right?
-        pass
-
-    # If no success, use appdata_dir() instead
-    if not (data_path and os.path.isdir(data_path)):
-        data_path = appdata_dir()[0]
-
-    # Get path specific for this app
-    if appname:
-        data_path = os.path.join(data_path, appname)
         os.makedirs(data_path, exist_ok=True)
+        os.makedirs(config_path, exist_ok=True)
 
-    # Done
-    return data_path
+    # Create tooldir if necessary
+    tool_dir = os.path.join(data_path, "tools")
+    os.makedirs(tool_dir, exist_ok=True)
 
-
-#  Other approaches that we considered, but which did not work for links,
-#  or are less reliable for other reasons are:
-#      * sys.executable: does not work for links
-#      * sys.prefix: dito
-#      * sys.exec_prefix: dito
-#      * os.__file__: does not work when frozen
-#      * __file__: only accessable from main module namespace, does not work when frozen
-
-# todo: get this included in Python sys or os module!
-
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import os, sys
-
-
-def application_dir():
-    """application_dir()
-    Get the directory in which the current application is located.
-    The "application" can be a Python script or a frozen application.
-    This function raises a RuntimeError if in interpreter mode.
-    """
-    if getattr(sys, "frozen", False):
-        # When frozen, use sys.executable
-        thepath = os.path.dirname(sys.executable)
-    else:
-        # Test if the current process can be considered an "application"
-        if not sys.path or not sys.path[0]:
-            raise RuntimeError(
-                "Cannot determine app path because sys.path[0] is empty!"
-            )
-        thepath = sys.path[0]
-    # Return absolute version, or symlinks may not work
-    return os.path.abspath(thepath)
-
-
-## Pyzo specific
-#
-# A Pyzo distribution maintains a file in the appdata dir that lists
-# the directory where it is intalled. Pyzo can in principle be installed
-# multiple times. In that case the file contains multiple entries.
-# This file is checked each time the pyzo executable is run. Therefore
-# a user can move the Pyzo directory and simply run the Pyzo executable
-# to update the registration.
-
-
-def pyzo_dirs(newdir=None, makelast=False):
-    """pyzo_dirs(newdir=None,  makelast=False)
-    Compatibility function. Like pyzo_dirs2, but returns a list of
-    directories and does not allow setting the version.
-    """
-    return [p[0] for p in pyzo_dirs2(newdir, makelast=makelast)]
-
-
-# From pyzolib/paths.py (https://bitbucket.org/pyzo/pyzolib/src/tip/paths.py)
-import os, sys
-
-
-def pyzo_dirs2(path=None, version="0", **kwargs):
-    """pyzo_dirs2(dir=None, version='0', makelast=False)
-    Get the locations of installed Pyzo directories. Returns a list of
-    tuples: (dirname, version). In future versions more information may
-    be added to the file, so please take larger tuples into account.
-    If path is a dir containing a python exe, it is added it to the
-    list. If the keyword arg 'makelast' is given and True, will ensure
-    that the given path is the last in the list (i.e. the default).
-    """
-    defaultPyzo = "", "0"  # To fill in values for shorter items
-    newPyzo = (str(path), str(version)) if path else None
-    # Get application dir
-    userDir = os.path.expanduser("~")
-    path = None
-    if sys.platform.startswith("win"):
-        path = os.getenv("LOCALAPPDATA", os.getenv("APPDATA"))
-    elif sys.platform.startswith("darwin"):
-        path = os.path.join(userDir, "Library", "Application Support")
-    # Get application dir for Pyzo
-    if path and os.path.isdir(path):
-        path = os.path.join(path, "pyzo")
-    else:
-        path = os.path.join(userDir, ".pyzo")  # On Linux and as fallback
-    if not os.path.isdir(path):
-        # Better way to get config folder especially on *nix system (see XDG_CONFIG_HOME standard),
-        # but this should work on any os.
-        # For retro-compatibility, check if old folder exist and use new path otherwise.
-        standard_path = QtCore.QStandardPaths.writableLocation(
-            QtCore.QStandardPaths.ConfigLocation
-        )
-        if (
-            standard_path != ""
-        ):  # Check if QStandardPaths succeeded to find the location, otherwise use old path
-            path = standard_path
-        path = os.path.join(path, "pyzo")
-        os.makedirs(path, exist_ok=True)
-    # Open file and parse
-    fname = os.path.join(path, "pyzodirs")
-    pyzos, npyzos = [], 0
-    if os.path.isfile(fname):
-        lines = open(fname, "rb").read().decode("utf-8").split("\n")
-        pyzos = [tuple(d.split(":::")) for d in [d.strip() for d in lines] if d]
-        npyzos = len(pyzos)
-    # Add dir if necessary
-    if newPyzo and os.path.isdir(newPyzo[0]):
-        if kwargs.get("makelast", False) or newPyzo not in pyzos:
-            npyzos = 0  # force save
-            pyzos = [p for p in pyzos if p[0] != newPyzo[0]]  # rm based on dir
-            pyzos.append(newPyzo)
-    # Check validity of all pyzos, write back if necessary, and return
-    pythonname = "python" + ".exe" * sys.platform.startswith("win")
-    pyzos = [p for p in pyzos if os.path.isfile(os.path.join(p[0], pythonname))]
-    if len(pyzos) != npyzos:
-        lines = [":::".join(p) for p in pyzos]
-        open(fname, "wb").write(("\n".join(lines)).encode("utf-8"))
-    return [p + defaultPyzo[len(p) :] for p in pyzos]
-
-
-## Windows specific
-
-# Maybe for directory of programs, pictures etc.
+    return data_path, config_path
+    


### PR DESCRIPTION
### Description of the problem
I encountered the following problem on different computers with MS Windows 10:
After installing and running Pyzo the first time, the user confirms the auto-detected pyzo interpreter or selects an individual one. But when closing Pyzo and starting it again, Pyzo does not remember the previous settings and the user has to configure everything again. After the second time, saving and loading the configuration works normally.
### Why does this happen?
When starting Pyzo for the first time (i.e. no previously saved configurations found), Pyzo selects the following paths for the appdata and config by executing function `appdata_dir` in `pyzo/util/paths.py`. The results are:
```
[Logger] >>> pyzo.appDataDir, pyzo.appConfigDir
('C:/Users/user/AppData/Roaming\\pyzo', 'C:/Users/user/AppData/Local\\pyzo')
```
When starting Pyzo the first time, the folder `C:\Users\user\AppData\Roaming\pyzo` (with `command_history.py`, etc.) is created, and when closing Pyzo the first time, settings are saved to file `C:\Users\user\AppData\Local\pyzo\config.ssdf`.

When starting Pyzo the second time (and every time after that), function `appdata_dir` behaves differently because folder `C:\Users\user\AppData\Roaming\pyzo` already exists:
```
[Logger] >>> pyzo.appDataDir, pyzo.appConfigDir
('C:\\Users\\user\\AppData\\Roaming\\pyzo', 'C:\\Users\\user\\AppData\\Roaming\\pyzo')
```
So, the second time (and later times) Pyzo is started, Pyzo will use the appdata path also as the config path. And therefore it ignores the file `C:\Users\user\AppData\Local\pyzo\config.ssdf` from the very first time that Pyzo was run. The config will be loaded and saved from/to `C:\Users\user\AppData\Roaming\pyzo\config.ssdf` instead from the second time on.

### Solution
I decided to keep the common directory for appdata and config (on MS Windows operating systems). This will keep the newest configuration on existing Pyzo installations after updating Pyzo. And I also cleaned up the code -- there were even remanents from the old times when Pyzo was a full Python distribution with normal Python interpreters that could be used by a shell/kernel in the Pyzo IDE.

I tested the changes on MS Windows 10 and Linux, and also the portable settings directory. But I do not have the equipment to check if Pyzo behaves still the same on macOS.



