### PR TITLE
fix pyzo closing cancellation

### DIFF
--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -342,13 +342,6 @@ class MainWindow(QtWidgets.QMainWindow):
         # Are we restaring?
         restarting = time.time() - self._closeflag < 1.0  # noqa: F841
 
-        # Save settings
-        pyzo.saveConfig()
-        pyzo.command_history.save()
-
-        # Stop command server
-        commandline.stop_our_server()
-
         # Proceed with closing...
         result = pyzo.editors.closeAll()
         if not result:
@@ -358,6 +351,13 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             self._closeflag = True
             # event.accept()  # Had to comment on Windows+py3.3 to prevent error
+
+        # Save settings
+        pyzo.saveConfig()
+        pyzo.command_history.save()
+
+        # Stop command server
+        commandline.stop_our_server()
 
         # Proceed with closing shells
         pyzo.localKernelManager.terminateAll()


### PR DESCRIPTION
**Description of the problem**
The command server is stopped even when the user decides to not close Pyzo when asked for saving changes in editors.

**How to reproduce the problem**

- start Pyzo
- (optional: open the logger tool to see when the command server is stopped)
- create a new file and enter random characters --> editor tab icon turns red
- close Pyzo (e.g.: File -> Quit Pyzo)
- [Pyzo closes the command server, as indicated by output "Stopped our command server." in the logger widget]
- dialog pops up and asks to save modified file: Save | Discard | Cancel
- press Cancel
- command server is still stopped
- in MS Windows, opening a *.py file in the Windows Explorer will then start a new Pyzo instance instead of using the existing one

**Fix**
I changed the order in `closeEvent` so that the editor modifications are checked first.

By the way: variable `restarting` is not used anymore and could be removed

