### PR TITLE
Prevent warnings for qt on some macos's

### DIFF
--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -181,6 +181,7 @@ def getEnvFromKernelInfo(info):
     #
     env.pop("TK_LIBRARY", "")
     env.pop("TCL_LIBRARY", "")
+    env.pop("QT_MAC_WANTS_LAYER")
     env["PYTHONPATH"] = pythonPath
     # Jython does not use PYTHONPATH but JYTHONPATH
     env["JYTHONPATH"] = pyzo.pyzoDir + os.pathsep + os.environ.get("JYTHONPATH", "")


### PR DESCRIPTION
We set `QT_MAC_WANTS_LAYER` as an env variable to get the Pyzo IDE running correctly on MacOS with high-res displays. However, since the env var leaks into the kernel, and it's apparently not neccesary on modern qt versions, qt gives a warning, which is confusing for users.

This PR prevents the env var from leaking into the kernel.