### PR TITLE
fix daemon threads

### DIFF
--- a/pyzo/core/codeparser.py
+++ b/pyzo/core/codeparser.py
@@ -82,7 +82,7 @@ class Parser(threading.Thread):
         # Lock to enable save threading
         self._lock = threading.RLock()
 
-        # Set deamon
+        # Set daemon
         self.daemon = True
         self._exit = False
 

--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -743,7 +743,7 @@ class StreamReader(threading.Thread):
         self._process = process
         self._strm_raw = strm_raw
         self._strm_broker = strm_broker
-        self.deamon = True
+        self.daemon = True
         self._exit = False
 
     def stop(self, timeout=1.0):

--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -257,7 +257,7 @@ class BaseFSProxy(threading.Thread):
 
     def __init__(self):
         threading.Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
         #
         self._interrupt = False
         self._exit = False

--- a/pyzo/util/bootstrapconda.py
+++ b/pyzo/util/bootstrapconda.py
@@ -470,7 +470,7 @@ class StreamCatcher(threading.Thread):
         self._lines = []
         self._line = ""
         threading.Thread.__init__(self)
-        self.setDaemon(True)  # do not let this thread hold up Python shutdown
+        self.daemon = True  # do not let this thread hold up Python shutdown
         self.start()
 
     def run(self):

--- a/pyzo/yoton/channels/channels_reqrep.py
+++ b/pyzo/yoton/channels/channels_reqrep.py
@@ -10,6 +10,7 @@ Defines the channel classes for the req/rep pattern.
 
 """
 
+import sys
 import time
 import threading
 
@@ -867,8 +868,11 @@ class ThreadForReqChannel(threading.Thread):
         # Store channel
         self._channel = channel
 
-        # Make deamon
-        self.setDaemon(True)
+        # Make daemon
+        if sys.version_info < (2, 6):
+            self.setDaemon(True)
+        else:
+            self.daemon = True
 
     def run(self):
         """run()

--- a/pyzo/yoton/clientserver.py
+++ b/pyzo/yoton/clientserver.py
@@ -33,6 +33,7 @@ servers in a single process, that listen on different ports.
 
 """
 
+import sys
 import time
 import socket
 import threading
@@ -105,8 +106,11 @@ class RequestServer(threading.Thread):
         # To stop serving
         self._stop_me = False
 
-        # Make deamon
-        self.setDaemon(True)
+        # Make daemon
+        if sys.version_info < (2, 6):
+            self.setDaemon(True)
+        else:
+            self.daemon = True
 
     def start(self):
         """start()

--- a/pyzo/yoton/connection_tcp.py
+++ b/pyzo/yoton/connection_tcp.py
@@ -296,8 +296,11 @@ class HostThread(threading.Thread):
         self._context_connection = context_connection
         self._bsd_host_socket = bsd_socket
 
-        # Make deamon
-        self.setDaemon(True)
+        # Make daemon
+        if sys.version_info < (2, 6):
+            self.setDaemon(True)
+        else:
+            self.daemon = True
 
     def run(self):
         """run()
@@ -480,7 +483,10 @@ class BaseIOThread(threading.Thread):
         threading.Thread.__init__(self)
 
         # Thread will "destruct" when the interpreter shuts down
-        self.setDaemon(True)
+        if sys.version_info < (2, 6):
+            self.setDaemon(True)
+        else:
+            self.daemon = True
 
         # Store (temporarily) the ref to the context connection
         # Also of bsd_socket, because it might be removed before the

--- a/pyzo/yoton/events.py
+++ b/pyzo/yoton/events.py
@@ -21,6 +21,7 @@ more information. Note that signals only work if events are processed.
 
 """
 
+import sys
 import time
 import threading
 import weakref
@@ -253,7 +254,10 @@ class TheTimerThread(threading.Thread):
 
     def __init__(self):
         threading.Thread.__init__(self)
-        self.setDaemon(True)
+        if sys.version_info < (2, 6):
+            self.setDaemon(True)
+        else:
+            self.daemon = True
         self._exit = False
         self._timers = []
         self._somethingChanged = False


### PR DESCRIPTION
Changes:

- in kernelbroker.py there was a spelling mistake in `daemon` that created an unused attribute instead of setting the property
- `setDaemon()` is deprecated and therefore replaced by setting the property `daemon` depending on the interpreter version