### PR TITLE
fix and clean regular expressions

### DIFF
--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -452,8 +452,8 @@ tokenProg = re.compile(
     + "[rR]?"  # Possibly bytes or unicode (py2.x)
     + "(\"\"\"|'''|\"|')"  # Possibly a raw string
     + ")|"  # String start (triple qoutes first, group 4)
-    + "(\(|\[|\{)|"  # End of string group
-    + "(\)|\]|\})|"  # Opening parenthesis (gr 5)
+    + r"(\(|\[|\{)|"  # End of string group
+    + r"(\)|\]|\})|"  # Opening parenthesis (gr 5)
     + "("  # Closing parenthesis (gr 6)
     + chr(160)
     + ")"  # non-breaking space (gr 7)

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -230,12 +230,12 @@ class Menu(QtWidgets.QMenu):
         e.g. Interrupt current shell -> interrupt_current_shell
         """
         # hide anything between brackets
-        name = re.sub("\(.*\)", "", name)
+        name = re.sub(r"\(.*\)", r"", name)
         # replace invalid chars
         name = name.replace(" ", "_")
         if name and name[0] in "0123456789_":
             name = "_" + name
-        name = re.sub("[^a-zA-z_0-9]", "", name)
+        name = re.sub(r"[^a-zA-z_0-9]", r"", name)
         return name.lower()
 
     def _addAction(self, text, icon, selected=None):

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -659,7 +659,9 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
                     name = objectName.split(".")[-1]
                     # Is the signature in the docstring?
                     docs = h_text.replace("\n", "|")
-                    tmp = re.search("[a-zA-z_\.]*?" + name + "\(.*?\)", docs)
+                    tmp = re.search(
+                        r"[a-zA-z_\.]*?" + re.escape(name) + r"\(.*?\)", docs
+                    )
                     if tmp and tmp.span(0)[0] < 5:
                         header = tmp.group(0)
                         h_text = h_text[len(header) :].lstrip(":").lstrip()
@@ -674,7 +676,7 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
 
                 # Parse the text as rest/numpy like docstring
                 h_text = self.smartFormat(h_text)
-                h_text = re.sub("``(.*?)``", r"<code>\1</code>", h_text)
+                h_text = re.sub(r"``(.*?)``", r"<code>\1</code>", h_text)
                 if header:
                     h_text = "<p style='color:#005;'><b>%s</b></p>\n%s" % (
                         header,

--- a/pyzo/util/zon.py
+++ b/pyzo/util/zon.py
@@ -252,7 +252,7 @@ class ReaderWriter(object):
                 indent = prev_indent
 
             # Split name and data using a regular expression
-            m = re.search("^\w+? *?=", line2)
+            m = re.search(r"^\w+? *?=", line2)
             if m:
                 i = m.end(0)
                 name = line2[: i - 1].strip()
@@ -391,7 +391,7 @@ class ReaderWriter(object):
         line = data.replace("\\\\", "0x07")  # temp
 
         # Find string using a regular expression
-        m = re.search("'.*?[^\\\\]'|''", line)
+        m = re.search(r"'.*?[^\\]'|''", line)
         if not m:
             print("ZON: string not ended correctly on line %i." % linenr)
             return None  # return not-a-string


### PR DESCRIPTION
When executing Pyzo from source with env variable `PYTHONWARNINGS=error` I got some errors about improper escaped strings in regular expressions. I fixed these and also cleaned up other re strings.