### PR TITLE
use context manager for file access

### DIFF
--- a/freeze/pyzo_freeze.py
+++ b/freeze/pyzo_freeze.py
@@ -117,8 +117,8 @@ excludes = []
 includes += get_stdlib_modules()
 
 # Include a few 3d party packages, e.g. deps of qtpy
-with open(os.path.join(this_dir, "frozen_libs.txt"), "rt") as fd:
-    includes += fd.read().split()
+with open(os.path.join(this_dir, "frozen_libs.txt"), "rb") as fd:
+    includes += fd.read().decode().split()
 
 # Include a subset of Qt modules
 qt_includes = [

--- a/freeze/pyzo_freeze.py
+++ b/freeze/pyzo_freeze.py
@@ -30,7 +30,9 @@ def get_pyzo_version():
     """Get Pyzo's version."""
     filename = os.path.join(dist_dir, "..", "..", "pyzo", "__init__.py")
     NS = {}
-    for line in open(filename, "rb").read().decode().splitlines():
+    with open(filename, "rb").read() as fd:
+        data = fd.read()
+    for line in data.decode().splitlines():
         if line.startswith("__version__"):
             exec(line.strip(), NS, NS)
     if not NS.get("__version__", 0):
@@ -115,7 +117,8 @@ excludes = []
 includes += get_stdlib_modules()
 
 # Include a few 3d party packages, e.g. deps of qtpy
-includes += open(os.path.join(this_dir, "frozen_libs.txt"), "rt").read().split()
+with open(os.path.join(this_dir, "frozen_libs.txt"), "rt") as fd:
+    includes += fd.read().split()
 
 # Include a subset of Qt modules
 qt_includes = [

--- a/freeze/pyzo_package.py
+++ b/freeze/pyzo_package.py
@@ -11,7 +11,9 @@ this_dir = os.path.abspath(os.path.dirname(__file__)) + "/"
 dist_dir = this_dir + "dist/"
 
 
-with open(os.path.join(this_dir, "..", "pyzo", "__init__.py")) as fh:
+with open(
+    os.path.join(this_dir, "..", "pyzo", "__init__.py"), "rt", encoding="utf-8"
+) as fh:
     __version__ = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
 
 bitness = "32" if sys.maxsize <= 2**32 else "64"
@@ -40,8 +42,7 @@ def package_tar_gz():
     oridir = os.getcwd()
     os.chdir(dist_dir)
     try:
-        tf = tarfile.open(basename + ".tar.gz", "w|gz")
-        with tf:
+        with tarfile.open(basename + ".tar.gz", "w|gz") as tf:
             tf.add("pyzo", arcname="pyzo")
     finally:
         os.chdir(oridir)
@@ -81,7 +82,8 @@ def package_inno_installer():
     # Set inno file
     innoFile1 = os.path.join(this_dir, "installerBuilderScript.iss")
     innoFile2 = os.path.join(this_dir, "installerBuilderScript2.iss")
-    text = open(innoFile1, "rb").read().decode()
+    with open(innoFile1, "rb") as f:
+        text = f.read().decode()
     text = text.replace("X.Y.Z", __version__).replace("64", bitness)
     if bitness == "32":
         text = text.replace("ArchitecturesInstallIn64BitMode = x64", "")

--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -532,11 +532,8 @@ class PyzoEditor(BaseTextCtrl):
         bb = text.encode(self.encoding)
 
         # Store
-        f = open(filename, "wb")
-        try:
+        with open(filename, "wb") as f:
             f.write(bb)
-        finally:
-            f.close()
 
         # Update stats
         self._filename = normalizePath(filename)

--- a/pyzo/core/history.py
+++ b/pyzo/core/history.py
@@ -38,7 +38,8 @@ class CommandHistory(QtCore.QObject):
                     pass
 
             # Load lines and add to commands
-            lines = open(filename, "r", encoding="utf-8").read().splitlines()
+            with open(filename, "rt", encoding="utf-8") as fd:
+                lines = fd.read().splitlines()
             self._commands.extend(
                 [line.rstrip() for line in lines[-self.max_commands :]]
             )

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -922,9 +922,10 @@ class PyzoInterpreter:
 
         # Get text (make sure it ends with a newline)
         try:
-            bb = open(fname, "rb").read()
+            with open(fname, "rb") as fd:
+                bb = fd.read()
             encoding = "UTF-8"
-            firstline = bb.split("\n".encode(), 1)[0].decode("ascii", "ignore")
+            firstline = bb.split(b"\n", 1)[0].decode("ascii", "ignore")
             if firstline.startswith("#") and "coding" in firstline:
                 encoding = firstline.split("coding", 1)[-1].strip(" \t\r\n:=-*")
             source = bb.decode(encoding)

--- a/pyzo/qt/uic.py
+++ b/pyzo/qt/uic.py
@@ -251,7 +251,7 @@ else:
         widget_class = ui.find("widget").get("class")
         form_class = ui.find("class").text
 
-        with open(uifile, encoding="utf-8") as fd:
+        with open(uifile, "rt", encoding="utf-8") as fd:
             code_stream = StringIO()
             frame = {}
 

--- a/pyzo/tools/__init__.py
+++ b/pyzo/tools/__init__.py
@@ -195,26 +195,27 @@ class ToolManager(QtCore.QObject):
             toolSummary = ""
             # read file to find name or summary
             linecount = 0
-            for line in open(file, encoding="utf-8"):
-                linecount += 1
-                if linecount > 50:
-                    break
-                if line.startswith("tool_name"):
-                    i = line.find("=")
-                    if i < 0:
-                        continue
-                    line = line.rstrip("\n").rstrip("\r")
-                    line = line[i + 1 :].strip(" ")
-                    toolName = eval(line)  # applies translation
-                elif line.startswith("tool_summary"):
-                    i = line.find("=")
-                    if i < 0:
-                        continue
-                    line = line.rstrip("\n").rstrip("\r")
-                    line = line[i + 1 :].strip(" ")
-                    toolSummary = line.strip("'").strip('"')
-                else:
-                    pass
+            with open(file, "rt", encoding="utf-8") as fd:
+                for line in fd:
+                    linecount += 1
+                    if linecount > 50:
+                        break
+                    if line.startswith("tool_name"):
+                        i = line.find("=")
+                        if i < 0:
+                            continue
+                        line = line.rstrip("\n").rstrip("\r")
+                        line = line[i + 1 :].strip(" ")
+                        toolName = eval(line)  # applies translation
+                    elif line.startswith("tool_summary"):
+                        i = line.find("=")
+                        if i < 0:
+                            continue
+                        line = line.rstrip("\n").rstrip("\r")
+                        line = line[i + 1 :].strip(" ")
+                        toolSummary = line.strip("'").strip('"')
+                    else:
+                        pass
 
             # Add stuff
             tmp = ToolDescription(modulePath, toolName, toolSummary)

--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -417,8 +417,7 @@ class NativeFSProxy(BaseFSProxy):
     def read(self, path):
         if op.isfile(path):
             with open(path, "rb") as f:
-                data = f.read()
-            return data
+                return f.read()
 
     def write(self, path, bb):
         with open(path, "wb") as f:

--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -416,7 +416,9 @@ class NativeFSProxy(BaseFSProxy):
 
     def read(self, path):
         if op.isfile(path):
-            return open(path, "rb").read()
+            with open(path, "rb") as f:
+                data = f.read()
+            return data
 
     def write(self, path, bb):
         with open(path, "wb") as f:

--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -349,8 +349,8 @@ class FileItem(BrowserItem):
         if not op.isfile(dummy_filename):
             if not isdir(op.dirname(dummy_filename)):
                 os.makedirs(op.dirname(dummy_filename))
-            f = open(dummy_filename, "wb")
-            f.close()
+            with open(dummy_filename, "wb"):
+                pass
         # Use that file
         if sys.platform.startswith("linux") and not QtCore.__file__.startswith("/usr/"):
             icon = iconprovider.icon(iconprovider.File)

--- a/pyzo/util/bootstrapconda.py
+++ b/pyzo/util/bootstrapconda.py
@@ -447,11 +447,8 @@ def _fetch_file(url, file_name, progress=None):
         response = urllib.request.urlopen(url, timeout=5.0)
         # file_size = int(response.headers['Content-Length'].strip())
         # Downloading data (can be extended to resume if need be)
-        local_file = open(temp_file_name, "wb")
-        _chunk_read(response, local_file, initial_size=initial_size, progress=progress)
-        # temp file must be closed prior to the move
-        if not local_file.closed:
-            local_file.close()
+        with open(temp_file_name, "wb") as fd:
+            _chunk_read(response, fd, initial_size=initial_size, progress=progress)
         shutil.move(temp_file_name, file_name)
     except Exception as e:
         raise RuntimeError(

--- a/pyzo/util/interpreters/__init__.py
+++ b/pyzo/util/interpreters/__init__.py
@@ -175,7 +175,7 @@ def _get_interpreters_conda():
     exes = []
     filename = os.path.expanduser("~/.conda/environments.txt")
     if os.path.isfile(filename):
-        with open(filename, "rt") as fd:
+        with open(filename, "rt", encoding="utf-8") as fd:
             for line in fd.readlines():
                 line = line.strip()
                 exe_filename = os.path.join(line, pythonname)

--- a/pyzo/util/interpreters/__init__.py
+++ b/pyzo/util/interpreters/__init__.py
@@ -175,11 +175,12 @@ def _get_interpreters_conda():
     exes = []
     filename = os.path.expanduser("~/.conda/environments.txt")
     if os.path.isfile(filename):
-        for line in open(filename, "rt").readlines():
-            line = line.strip()
-            exe_filename = os.path.join(line, pythonname)
-            if line and os.path.isfile(exe_filename):
-                exes.append(exe_filename)
+        with open(filename, "rt") as fd:
+            for line in fd.readlines():
+                line = line.strip()
+                exe_filename = os.path.join(line, pythonname)
+                if line and os.path.isfile(exe_filename):
+                    exes.append(exe_filename)
     return exes
 
 

--- a/pyzo/util/zon.py
+++ b/pyzo/util/zon.py
@@ -185,9 +185,11 @@ def load(file):
     Load a Dict from the given file or filename.
     """
     if isinstance(file, string_types):
-        file = open(file, "rb")
-    text = file.read().decode("utf-8")
-    return loads(text)
+        with open(file, "rb") as fd:
+            data = fd.read()
+    else:
+        data = file.read()
+    return loads(data.decode("utf-8"))
 
 
 def saves(d):

--- a/pyzo/yoton/tests/count_lines_of_code.py
+++ b/pyzo/yoton/tests/count_lines_of_code.py
@@ -3,7 +3,8 @@ import os
 
 def count_lines(filename):
     # Get text
-    text = open(filename, "r").read()
+    with open(filename, "rt", encoding="utf-8") as fd:
+        text = fd.read()
 
     # Init counts: code, docstring, comments, whitespace
     count1, count2, count3, count4 = 0, 0, 0, 0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ except ImportError:
 def get_version_and_doc(filename):
     NS = dict(__version__="", __doc__="")
     docStatus = 0  # Not started, in progress, done
-    for line in open(filename, "rb").read().decode().splitlines():
+    with open(filename, "rb") as fd:
+        data = fd.read()
+    for line in data.decode().splitlines():
         if line.startswith("__version__"):
             exec(line.strip(), NS, NS)
         elif line.startswith('"""'):
@@ -110,8 +112,10 @@ if sys.platform.startswith("linux") and sys.prefix.startswith("/usr"):
         filename1 = os.path.join(os.path.dirname(__file__), fname)
         filename2 = os.path.join("/usr/share/metainfo", fname)
         try:
-            bb = open(filename1, "rb").read()
-            open(filename2, "wb").write(bb)
+            with open(filename1, "rb") as fd:
+                bb = fd.read()
+            with open(filename2, "wb") as fd:
+                fd.write(bb)
         except PermissionError:
             pass  # No sudo, no need to warn
         except Exception as err:


### PR DESCRIPTION
When executing Pyzo from source with env variable `PYTHONWARNINGS=error` I got many warnings because of files that were not closed (immediately). I changed the code to use the context manager whereever suitable, and I also cleaned up some mode and encoding arguments.