### PR TITLE
re-scan tool directories when reloading tools

### DIFF
--- a/pyzo/tools/__init__.py
+++ b/pyzo/tools/__init__.py
@@ -351,6 +351,7 @@ class ToolManager(QtCore.QObject):
 
     def reloadTools(self):
         """Reload all tools."""
+        self.loadToolInfo()
         for id in self.getLoadedTools():
             self.loadTool(id)
 


### PR DESCRIPTION
When running "Tools -> Reload tools" in the menu, new tool py-files that were added after starting Pyzo were not detected. I changed the code to rescan both tool directories during reloading tools.