### PR TITLE
fix debug focus double execution

### DIFF
--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -496,7 +496,7 @@ class DebugStack(QtWidgets.QToolButton):
         if not action._isCurrent:
             shell.executeCommand("DB FRAME {}\n".format(action._index))
         # Open file and select line
-        if True:
+        if False:  # debugFocus(...) is already called in setTrace(...)
             line = action.text().split(": ", 1)[1]
             self.debugFocus(line)
 


### PR DESCRIPTION
**Description of the problem**
When changing stack frames while debugging, function `debugFocus` is called twice from different functions. For frames that have an assigned valid source file path, this is no problem. But for frames like `<string>` that show an "Error loading file" message box, this is problem because the message box will be shown two times consecutively and both have to be confirmed by the user.

**Fix**
I disabled one of the two calls. Disabling the other call would also work.

**Reproducing the problem**
* create a normal python file, e.g. "/tmp/abc.py" and put a single line in it: `a = 1`
* open the file in the Pyzo editor and set a breakpoint at that single line
* create a new file in Pyzo and insert the following lines:
```
tt = """
fp = '/tmp/abc.py'
with open(fp, 'rt', encoding='utf-8') as fd:
    exec(compile(fd.read(), fp, 'exec'))
"""
exec(tt)
```
* run this new file (with the multiple lines) by pressing F5
* the debugger will stop in "/tmp/abc.py" at the breakpoint
* switch to the stack frame `<string>`
* the error message box will appear twice
