### PR TITLE
require minimum version of pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
-          pip install -U pytest
+          pip install -U pytest>=7.0.1
           pip install -U ${{ matrix.qtlib }}
     - name: Install in development mode
       run: |


### PR DESCRIPTION
As described in #902, the pip dependency resolver suddenly decided to use a much older version 4.5.0 instead of the normally used 7.x.y, and this caused one build to fail. I changed the version to be at least 7.0.1 because that version was the minimum version used for the newest release and that version is also the highest version that still supports Python 3.6.