### PR TITLE
use fontWeight enum names instead of integers

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -180,14 +180,14 @@ class ShellHighlighter(Highlighter):
                             # print(repr(nameToFormat(token.name)))
                             continue
                         # Set format
-                        # format.setFontWeight(75)
+                        # format.setFontWeight(QtGui.QFont.Bold)
                         if token.start >= pos2:
                             self.setFormat(token.start, token.end - token.start, format)
 
             # Set prompt to bold
             if atCurrentPrompt:
                 format = QtGui.QTextCharFormat()
-                format.setFontWeight(75)
+                format.setFontWeight(QtGui.QFont.Bold)
                 self.setFormat(pos1, pos2 - pos1, format)
 
         # Get the indentation setting of the editors
@@ -888,16 +888,16 @@ class BaseShell(BaseTextCtrl):
                 if param == 0:
                     format = QtGui.QTextCharFormat()
                 elif param == 1:
-                    format.setFontWeight(75)  # Bold
+                    format.setFontWeight(QtGui.QFont.Bold)
                 elif param == 2:
-                    format.setFontWeight(25)  # Faint
+                    format.setFontWeight(QtGui.QFont.Light)
                 elif param == 3:
                     format.setFontItalic(True)  # Italic
                 elif param == 4:
                     format.setFontUnderline(True)  # Underline
                 #
                 elif param == 22:
-                    format.setFontWeight(50)  # Not bold or faint
+                    format.setFontWeight(QtGui.QFont.Normal)  # Not bold or light
                 elif param == 23:
                     format.setFontItalic(False)  # Not italic
                 elif param == 24:

--- a/pyzo/qt/__init__.py
+++ b/pyzo/qt/__init__.py
@@ -52,6 +52,13 @@ PySide6
     >>> from qtpy import QtGui, QtWidgets, QtCore
     >>> print(QtWidgets.QWidget)
 
+
+General Hints
+=============
+Use enum names (e.g. QtGui.QFont.Bold) instead of integers for setFontWeight
+because integer values differ between Qt5 and Qt6.
+    see https://doc.qt.io/qt-5/qfont.html#Weight-enum
+    see https://doc.qt.io/qt-6/qfont.html#Weight-enum
 """
 
 from pyzo.util import parse_version_crudely as parse


### PR DESCRIPTION
From Qt5 to Qt6 the numeric values for `setFontWeight` changed:
Qt5 ... light: 25, normal: 50, bold: 75 ... see https://doc.qt.io/qt-5/qfont.html#Weight-enum
Qt6 ... light: 300, normal: 500, bold: 700 ... see https://doc.qt.io/qt-6/qfont.html#Weight-enum

To avoid Qt-version dependent value pairs I changed the code to use enum names (e.g. `QtGui.QFont.Bold`) instead of integers.