### PR TITLE
fix unremoved old highlighter after setting a new one

### DIFF
--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -254,6 +254,9 @@ class CodeEditorBase(QtWidgets.QPlainTextEdit):
         return cursor.selectedText().translate(self._plainTextTrans)
 
     def _setHighlighter(self, highlighterClass):
+        # PySide 2 and 6 do not remove the previous highlighter automatically
+        self.__highlighter.setDocument(None)
+
         self.__highlighter = highlighterClass(self, self.document())
 
     ## Options


### PR DESCRIPTION
When working on improving the shell prompt I got some weird issues with text formatting.
The problem only occured with PySide 2 and PySide 6 but not with PyQt5/6.

It turned out that with PySide there were two different highlighter objects running at the same time instead of just the newer one of the derived class.

The object of `class CodeEditorBase(QtWidgets.QPlainTextEdit)` sets the default highlighter `Highlighter` (see pyzo/codeeditor/highlighter.py) during initialization.
The object of the derived `class BaseShell(BaseTextCtrl)` sets its custom highlighter `ShellHighlighter` (see pyzo/core/shell.py) to override the original highlighter.
Using PySide, the new highlighter is called additionally to the old one, and in some (reproducable) special cases, the new highlighter does not get called with the same line arguments.

I changed the code to set the referring document of the old highlighter object to an invalid document before installing the new highlighter. That solved the problem.
