### PR TITLE
fix shell prompt for debugging with stack frames

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -818,8 +818,9 @@ class BaseShell(BaseTextCtrl):
             self._cursor1.removeSelectedText()
             self._cursor2.setPosition(self._cursor1.position(), A_MOVE)
         elif prompt == 2:
-            # Insert text after prompt, inserted text becomes new prompt
-            self._cursor1.setPosition(self._cursor2.position(), A_MOVE)
+            # text becomes new prompt
+            self._cursor1.setPosition(self._cursor2.position(), A_KEEP)
+            self._cursor1.removeSelectedText()
             self._cursor1.setKeepPositionOnInsert(True)
             self._cursor2.setKeepPositionOnInsert(False)
             self._insertText(self._cursor1, text, format)
@@ -1432,6 +1433,7 @@ class PythonShell(BaseShell):
                 prompt = 1
             elif sub is self._strm_prompt:
                 prompt = 2
+                M = M[-1:]  # only use the newest prompt
             # Get color
             color = None
             if sub is self._strm_broker:

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -173,6 +173,7 @@ class PyzoInterpreter:
         # code is expected.
         self.more = 0
         self.newPrompt = True
+        self._oldPromptString = None
 
         # Code and script to run on first iteration
         self._codeToRunOnStartup = None
@@ -657,10 +658,14 @@ class PyzoInterpreter:
 
         # Set status and prompt?
         # Prompt is allowed to be an object with __str__ method
-        if self.newPrompt:
+        # We also compare prompt strings because stack frame changes
+        # caused by a breakpoint while running the gui event loop
+        # would get unnotified otherwise.
+        promptString = str(sys.ps2 if self.more else sys.ps1)
+        if self.newPrompt or promptString != self._oldPromptString:
             self.newPrompt = False
-            ps = [sys.ps1, sys.ps2][bool(self.more)]
-            self.context._strm_prompt.send(str(ps))
+            self._oldPromptString = promptString
+            self.context._strm_prompt.send(promptString)
 
         if True:
             # Determine state. The message is really only send


### PR DESCRIPTION
When running a script that makes use of the Qt event loop and also using breakpoints, the breakpoints could be triggered by either
- the normal linear execution (while the shell is busy), or
- code executed in the event loop.

In the latter case, i.e. setting a breakpoint in a callback function, the shell's prompt does not change to the stack frame when triggering the breakpoint. One has to debug-step or press the RETURN key to update to the correct prompt text. The same happens, when leaving the debug mode.

While fixing this, I encountered a bug that caused wrong formatting, and fixed it -- see #905.

For the sake of completeness, this is the code I used to reproduce the problem and test the new behaviour:
```
from PySide2 import QtGui, QtCore, QtWidgets

class Example(QtWidgets.QPushButton):
    def __init__(self):
        super().__init__()
        self.setFixedSize(300, 100)
        self.setText('click me')
        self.clicked.connect(self.callback_button)
        self.show()

    def callback_button(self):
        print('callback_button')
        func2()  # call another function just to have multiple stack frame levels


def func2():
    a = 1
    b = 2  # <-- set a breakpoint at this line
    c = 3
    d = 4


example = Example()
```
