### PR TITLE
add debugger integration for Python built-in breakpoint() function

### DIFF
--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -19,6 +19,20 @@ class Debugger(bdb.Bdb):
         bdb.Bdb.__init__(self)
         self._debugmode = 0  # 0: no debug,  1: postmortem,  2: full debug
         self._files_with_offset = []
+        self._original_breakpointhook = sys.breakpointhook
+        sys.breakpointhook = self.custom_breakpointhook
+
+    def custom_breakpointhook(self, *args, **kwargs):
+        """handle "breakpoint()" commands
+        see https://docs.python.org/3/library/sys.html#sys.breakpointhook
+        """
+        s = os.environ.get("PYTHONBREAKPOINT", None)
+        if s == "0":
+            pass  # deactivated
+        elif s is None or s == "":
+            self.set_trace()
+        else:
+            self._original_breakpointhook(*args, **kwargs)
 
     def clear_all_breaks(self):
         bdb.Bdb.clear_all_breaks(self)


### PR DESCRIPTION
Since Python 3.7 there is a built-in function `breakpoint()` that opens a text based debugger at the place it was called.
Executing this command in the Pyzo shell also brings up the text based debugger.

I changed the code so that the `breakpoint()` command will use the debugger toolbar of the Pyzo GUI, the same way as breakpoints do, i.e. without the text based pdb interface. In this custom implementation, the `PYTHONBREAKPOINT` environment variable has the same effects as in Python's default implementation.

As far as I have seen, using the `breakpoint()` command has the advantage of not slowing down the execution of the whole script, unlike when using Pyzo's graphical breakpoints. On the other hand, a `breakpoint()` command cannot be added or removed easily on the fly, e.g. in callback functions of a GUI's event loop, but with Pyzo's graphical breakpoints that is easy.

Further reading:
https://docs.python.org/3/library/functions.html#breakpoint
https://docs.python.org/3/library/sys.html#sys.breakpointhook