### PR TITLE
improve shell printing performance for longer texts

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -920,8 +920,10 @@ class BaseShell(BaseTextCtrl):
             # Process very long text more efficiently.
             # Insert per line (very long lines are split in smaller ones)
             if len(text) > 1024:
+                cursor.beginEditBlock()
                 for line in self._splitLinesForPrinting(text):
                     cursor.insertText(line, format)
+                cursor.endEditBlock()
             else:
                 cursor.insertText(text, format)
 


### PR DESCRIPTION
This PR improves the performance of printing text in the shell.
Especially when printing many short lines, e.g. 10 characters per line, this results in a 5x speed-up.
```
import timeit
t = timeit.timeit("print(('a'*10 + '\\n')*20000)", number=10)
```
As a positive side-effect I also observed that the editor has a much better responsiveness. While the code that prints the text is (still) running, quickly typed characters do not show up immediately without this patch.
