### PR TITLE
activate breakpoint() only for Python >= v3.7

### DIFF
--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -19,7 +19,7 @@ class Debugger(bdb.Bdb):
         bdb.Bdb.__init__(self)
         self._debugmode = 0  # 0: no debug,  1: postmortem,  2: full debug
         self._files_with_offset = []
-        if sys.version_info >= (3, 7):
+        if hasattr(sys, "breakpointhook"):
             self._original_breakpointhook = sys.breakpointhook
             sys.breakpointhook = self.custom_breakpointhook
 

--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -19,8 +19,9 @@ class Debugger(bdb.Bdb):
         bdb.Bdb.__init__(self)
         self._debugmode = 0  # 0: no debug,  1: postmortem,  2: full debug
         self._files_with_offset = []
-        self._original_breakpointhook = sys.breakpointhook
-        sys.breakpointhook = self.custom_breakpointhook
+        if sys.version_info >= (3, 7):
+            self._original_breakpointhook = sys.breakpointhook
+            sys.breakpointhook = self.custom_breakpointhook
 
     def custom_breakpointhook(self, *args, **kwargs):
         """handle "breakpoint()" commands


### PR DESCRIPTION
When I added the support for the built-in function `breakpoint()` (see #908), I forgot to only activate this for newer Python versions. Consequently, shells with Python versions < 3.7 crashed during start-up because of the missing `breakpointhook` attribute in the `sys` module. This PR will fix the problem by only activating `breakpoint()` for newer Python versions.