### PR TITLE
fix duplicate line operation in editor for last line

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -605,9 +605,12 @@ class PyzoEditor(BaseTextCtrl):
         cursor.setPosition(start)
         cursor.movePosition(cursor.StartOfBlock)
         cursor.setPosition(end, cursor.KeepAnchor)
-        cursor.movePosition(cursor.NextBlock, cursor.KeepAnchor)
-
-        text = cursor.selectedText()
+        notAtLastBlock = cursor.movePosition(cursor.NextBlock, cursor.KeepAnchor)
+        if notAtLastBlock:
+            text = cursor.selectedText()
+        else:
+            cursor.movePosition(cursor.End, cursor.KeepAnchor)
+            text = cursor.selectedText() + "\u2029"
         cursor.setPosition(start)
         cursor.movePosition(cursor.StartOfBlock)
         cursor.insertText(text)


### PR DESCRIPTION
The operation "Edit -> Duplicate line" from Pyzo's menu normally duplicates the current line or the selected multiple lines in the code editor. But when having the cursor in the last line resp. when having multiple lines selected including the last line, the duplicated text was missing a part after the cursor/selection and also missing a new-line control character.

I fixed that with this PR.