### PR TITLE
disable custom text colors for editor tabs

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -931,13 +931,16 @@ class FileTabWidget(CompactTabWidget):
             else:
                 tabBar.setTabToolTip(i, item.filename)
 
-            # Determine text color. Is main file? Is current?
-            if self._mainFile == item.id:
-                tabBar.setTabTextColor(i, QtGui.QColor("#008"))
-            elif i == self.currentIndex():
-                tabBar.setTabTextColor(i, QtGui.QColor("#000"))
-            else:
-                tabBar.setTabTextColor(i, QtGui.QColor("#444"))
+            if False:
+                # TODO: once there is a proper solution for dark mode, text colors
+                # TODO: ... in the editor tab widget could be re-enabled
+                # Determine text color. Is main file? Is current?
+                if self._mainFile == item.id:
+                    tabBar.setTabTextColor(i, QtGui.QColor("#008"))
+                elif i == self.currentIndex():
+                    tabBar.setTabTextColor(i, QtGui.QColor("#000"))
+                else:
+                    tabBar.setTabTextColor(i, QtGui.QColor("#444"))
 
             # Get number of blocks
             nBlocks = item.editor.blockCount()


### PR DESCRIPTION
As described in #915, the dark text in the editor tabs is barely readable in Qt 6.5 dark mode.

I actually had to look twice to realize that Pyzo sets different text colors for the active editor tab and for the main file editor tab. Therefore I suggest just disabling these custom text colors until a proper dark mode handling is implemented.
The main file tab is annotated with a star symbol anyways, an the active tab also has a different shape, so the differentiation is still possible.

After this fix, the editor tab texts will have a proper text color, i.e. black text in light mode an white text in dark mode.

