### PR TITLE
fix PySide6 deprecation warnings

### DIFF
--- a/pyzo/qt/QtCore.py
+++ b/pyzo/qt/QtCore.py
@@ -70,6 +70,7 @@ elif PYSIDE6:
     QEventLoop.exec_ = QEventLoop.exec
     QThread.exec_ = QThread.exec
     QTextStreamManipulator.exec_ = QTextStreamManipulator.exec
+    QLibraryInfo.location = QLibraryInfo.path
 
     from .enums_compat import promote_enums
 

--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -53,6 +53,9 @@ elif PYSIDE6:
     # Map DeprecationWarning methods
     QDrag.exec_ = QDrag.exec
     QGuiApplication.exec_ = QGuiApplication.exec
+    QtGui.QMouseEvent.x = lambda self: int(self.position().x())
+    QtGui.QMouseEvent.y = lambda self: int(self.position().y())
+    QtGui.QMouseEvent.pos = lambda self: self.position().toPoint()
 
     from .enums_compat import promote_enums
 


### PR DESCRIPTION
This will fix some deprecation warnings when running Pyzo with PySide6.