### PR TITLE
fix pipper utf-8 handling and progress bar update

### DIFF
--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -33,15 +33,15 @@ def subprocess_with_callback(callback, cmd, **kwargs):
     while p.poll() is None:
         time.sleep(0.001)
         # Read text and process
-        c = p.stdout.read(1).decode("utf-8", "ignore")
+        c = p.stdout.read(1)
         pending.append(c)
-        if c in ".\n":
-            callback("".join(pending))
+        if c in b".\n":
+            callback(b"".join(pending).decode("utf-8", "ignore"))
             pending = []
 
     # Process remaining text
-    pending.append(p.stdout.read().decode("utf-8"))
-    callback("".join(pending))
+    pending.append(p.stdout.read())
+    callback(b"".join(pending).decode("utf-8", "ignore"))
 
     # Done
     return p.returncode

--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -29,13 +29,14 @@ def subprocess_with_callback(callback, cmd, **kwargs):
         callback(str(err) + "\n")
         return -1
 
+    progressBarDash = [b"\xe2", b"\x94", b"\x81"]  # character "━"
     pending = []
     while p.poll() is None:
         time.sleep(0.001)
         # Read text and process
         c = p.stdout.read(1)
         pending.append(c)
-        if c in b".\n":
+        if c in b"-.\n" or pending[-len(progressBarDash) :] == progressBarDash:
             callback(b"".join(pending).decode("utf-8", "ignore"))
             pending = []
 


### PR DESCRIPTION
This PR will fix two problems with the magic command "pip":

First problem: 
```
>>> pip install --no-cache-dir pyserial
Collecting pyserial
  Downloading pyserial-3.5-py2.py3-none-any.whl (90 kB)
     Error in pip command:
'utf-8' codec can't decode byte 0x94 in position 0: invalid start byte
```
At least on Linux, the pip module uses a non-ascii character for rendering the progress bar while downloading the package:
(see line `bar = "-" if ascii else "━"` in the local Python installation, file "site-packages/pip/_vendor/rich/progress_bar.py")

When executing the magic pip command, Pyzo runs a subprocess, reads back single bytes and converts each single byte separately to utf-8. This fails with the non-ascii progress bar character.

Second problem:
The progress bar will only be printed after the bar is full because there are no dots printed as a progress indicator.
