### PR TITLE
In pipper: use bytes object instead list for pending stdout

### DIFF
--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -29,20 +29,20 @@ def subprocess_with_callback(callback, cmd, **kwargs):
         callback(str(err) + "\n")
         return -1
 
-    progressBarDash = [b"\xe2", b"\x94", b"\x81"]  # character "━"
-    pending = []
+    progressBarDash = b"\xe2\x94\x81"  # character "━"
+    pending = b""
     while p.poll() is None:
         time.sleep(0.001)
         # Read text and process
         c = p.stdout.read(1)
-        pending.append(c)
-        if c in b"-.\n" or pending[-len(progressBarDash) :] == progressBarDash:
-            callback(b"".join(pending).decode("utf-8", "ignore"))
-            pending = []
+        pending += c
+        if c in b"-.\n" or pending.endswith(progressBarDash):
+            callback(pending.decode("utf-8", "ignore"))
+            pending = b""
 
     # Process remaining text
-    pending.append(p.stdout.read())
-    callback(b"".join(pending).decode("utf-8", "ignore"))
+    pending += p.stdout.read()
+    callback(pending.decode("utf-8", "ignore"))
 
     # Done
     return p.returncode


### PR DESCRIPTION
Addendum to #919. Easier to just create a new PR for. cc @bdieterm 