### PR TITLE
More reliable way to use argv

### DIFF
--- a/pyzo/_start.py
+++ b/pyzo/_start.py
@@ -69,8 +69,7 @@ class MyApp(QtWidgets.QApplication):
         if isinstance(event, QtGui.QFileOpenEvent):
             fname = str(event.file())
             if fname and fname != "pyzo":
-                sys.argv[1:] = []
-                sys.argv.append(fname)
+                sys.argv[-1:] = [fname]
                 res = commandline.handle_cmd_args()
                 if not commandline.is_our_server_running():
                     print(res)

--- a/pyzo/pyzokernel/start.py
+++ b/pyzo/pyzokernel/start.py
@@ -73,7 +73,7 @@ ct._stat_breakpoints = yoton.StateChannel(ct, "stat-breakpoints", yoton.OBJECT)
 # Connect (port number given as command line argument)
 # Important to do this *before* replacing the stdout etc, because if an
 # error occurs here, it will be printed in the shell.
-port = int(sys.argv[1])
+port = int(sys.argv[-1])
 ct.connect("localhost:" + str(port), timeout=1.0)
 
 # Create file objects for stdin, stdout, stderr


### PR DESCRIPTION
Triggered by https://github.com/pyzo/pyzo/issues/901#issuecomment-1743858498, I checked the usage of `sys.argv` and made it such that if an OS would for some reason introduce args, Pyzo would be less likely to error on it.