### PR TITLE
Prevent Pyzo from hanging when starting kernel fails

### DIFF
--- a/pyzo/yoton/events.py
+++ b/pyzo/yoton/events.py
@@ -101,7 +101,10 @@ class CallableObject(object):
         try:
             return func(*args, **kwargs)
         except Exception:
-            print("Exception while handling event:")
+            funcname = self._func
+            if hasattr(funcname, "__name__"):
+                funcname = funcname.__name__
+            print("Exception while handling event (in %s):" % (funcname,))
             print(getErrorMsg())
 
 


### PR DESCRIPTION
Closes #746 

When I manually mangle the command into something invalid, everything is fine, because the process starts but produces errors over stderr. However, in certain cases the `Popen`  call can raise an exception, and this situation was not adequately covered. 

When the selected Python was invalid (e.g. a firewall or antivirus prevening access) this can cause Pyzo to hang because it keeps trying.