### PR TITLE
Filebrowser improvements

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -26,7 +26,7 @@ The config consists of three fields:
       * str path, the directory that is starred
       * str name, the name of the project (op.basename(path) by default)
       * bool addToPythonpath
-  * searchMatchCase, searchRegExp, searchSubDirs
+  * searchMatchCase, searchRegExp, searchSubDirs, searchExcludeBinary
   * nameFilter
 
 """

--- a/pyzo/tools/pyzoFileBrowser/browser.py
+++ b/pyzo/tools/pyzoFileBrowser/browser.py
@@ -110,6 +110,7 @@ class Browser(QtWidgets.QWidget):
             "matchCase": self.config.searchMatchCase,
             "regExp": self.config.searchRegExp,
             "subDirs": self.config.searchSubDirs,
+            "excludeBinary": self.config.searchExcludeBinary,
         }
 
     @property
@@ -650,6 +651,7 @@ class SearchFilter(LineEditWithToolButtons):
             ("searchMatchCase", False, translate("filebrowser", "Match case")),
             ("searchRegExp", False, translate("filebrowser", "RegExp")),
             ("searchSubDirs", True, translate("filebrowser", "Search in subdirs")),
+            ("searchExcludeBinary", True, translate("filebrowser", "Exclude binary")),
         ]
 
         # Fill menu

--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -414,10 +414,11 @@ class NativeFSProxy(BaseFSProxy):
         if op.isfile(path):
             return op.getsize(path)
 
-    def read(self, path):
+    def read(self, path, size=None):
+        size = size or -1
         if op.isfile(path):
             with open(path, "rb") as f:
-                return f.read()
+                return f.read(size)
 
     def write(self, path, bb):
         with open(path, "wb") as f:

--- a/pyzo/tools/pyzoFileBrowser/tasks.py
+++ b/pyzo/tools/pyzoFileBrowser/tasks.py
@@ -14,13 +14,21 @@ from . import proxies
 class SearchTask(proxies.Task):
     __slots__ = []
 
-    def process(self, proxy, pattern=None, matchCase=False, regExp=False, **rest):
+    def process(
+        self,
+        proxy,
+        pattern=None,
+        matchCase=False,
+        regExp=False,
+        excludeBinary=True,
+        **rest
+    ):
         # Quick test
         if not pattern:
             return
 
         # Get text
-        text = self._getText(proxy)
+        text = self._getText(proxy, excludeBinary)
         if not text:
             return
 
@@ -42,7 +50,7 @@ class SearchTask(proxies.Task):
         else:
             return []
 
-    def _getText(self, proxy):
+    def _getText(self, proxy, excludeBinary=True):
         # Init
         path = proxy.path()
         fsProxy = proxy._fsProxy
@@ -53,12 +61,11 @@ class SearchTask(proxies.Task):
         # except NotImplementedError:
         #     size = 0
 
-        # Search all Python files. Other files need to look like text.
-        check_preamble_for_zeros = True
+        # Always search Python files.
         if path.lower().endswith(".py"):
-            check_preamble_for_zeros = False
+            excludeBinary = False
 
-        if check_preamble_for_zeros:
+        if excludeBinary:
             # Check first few bytes for presence of zero bytes.
             # Git supposedly uses the same logic to determine whether
             # a file is binary. Note that files with certain encodings

--- a/pyzo/tools/pyzoFileBrowser/tasks.py
+++ b/pyzo/tools/pyzoFileBrowser/tasks.py
@@ -47,28 +47,41 @@ class SearchTask(proxies.Task):
         path = proxy.path()
         fsProxy = proxy._fsProxy
 
-        # Get file size
-        try:
-            size = fsProxy.fileSize(path)
-        except NotImplementedError:
-            pass
-        size = size or 0
+        # # Get file size
+        # try:
+        #     size = fsProxy.fileSize(path) or 0
+        # except NotImplementedError:
+        #     size = 0
 
-        # Search all Python files. Other files need be < xx bytes
-        if path.lower().endswith(".py") or size < 100 * 1024:
-            pass
+        # Search all Python files. Other files need to look like text.
+        check_preamble_for_zeros = True
+        if path.lower().endswith(".py"):
+            check_preamble_for_zeros = False
+
+        if check_preamble_for_zeros:
+            # Check first few bytes for presence of zero bytes.
+            # Git supposedly uses the same logic to determine whether
+            # a file is binary. Note that files with certain encodings
+            # other than utf-8 can be marked binary too.
+            preamble_len = 8000
+            bb_preamble = fsProxy.read(path, preamble_len)
+            if bb_preamble is None:
+                return None
+            if 0 in bb_preamble:
+                return None
+            # Ready bytes (or re-use)
+            if len(bb_preamble) < preamble_len:
+                bb = bb_preamble
+            else:
+                bb = fsProxy.read(path)
         else:
-            return None
+            bb = fsProxy.read(path)
 
-        # Get text
-        bb = fsProxy.read(path)
+        # Convert to str
         if bb is None:
-            return
-        try:
-            return bb.decode("utf-8")
-        except UnicodeDecodeError:
-            # todo: right now we only do utf-8
             return None
+        else:
+            return bb.decode("utf-8", errors="replace")
 
     def _getIndicesRegExp(self, text, pattern):
         indices = []


### PR DESCRIPTION
* [x] Search no longer excludes files based on file size, but on whether they look like binary. Closes #849.
* [x] Add an option to also search inside binary files. This is potentially slow.
* [x] Filename filters are case insensitive.
* [x] Inclusive filename filters (not prepended with `!`) are AND'd. In other words, all must match, not any. (In yet other words, each filter can cause a filename to be hidden, and if a filename is not hidden by any of the filters, it is shown.)
* [x] If a filename filter includes a dash (`/`), it is applied to the relative path, not just the basename. Closes #848.