### PR TITLE
fix invalid regex escape in c_parser.py

### DIFF
--- a/pyzo/codeeditor/parsers/c_parser.py
+++ b/pyzo/codeeditor/parsers/c_parser.py
@@ -39,11 +39,11 @@ class CharToken(Token):
 tokenProg = re.compile(
     "(["
     + ALPHANUM
-    + "_]+)|"
-    + "(\/\/)|"  # Identifiers/numbers (group 1) or
-    + "(\/\*)|"  # Single line comment (group 2)
-    + "('\\\\?.')|"  # Comment (group 3) or
-    + '(")'  # char (group 4)  # string (group 5)
+    + "_]+)|"  # Identifiers/numbers (group 1) or
+    + "(//)|"  # Single line comment (group 2)
+    + "(/\\*)|"  # Comment (group 3) or
+    + "('\\\\?.')|"  # char (group 4)
+    + '(")'  # string (group 5)
 )
 
 


### PR DESCRIPTION
I have seen a warning about an invalid regex escape, so I fixed that.
And I also fixed some comments that got pushed down a line during the reformatting in #669.
