### PR TITLE
fix filebrowser tool namefilter combination

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -66,10 +66,12 @@ def _filterFileByName(path, filters, base_path):
             # If the filename matches an exclusive filter, hide it
             if fnmatch.fnmatch(filename, filter[1:]):
                 return False
+            default = True
         else:
-            # If the filename does not match an inclusive filter, hide it
-            if not fnmatch.fnmatch(filename, filter):
-                return False
+            # If the file name matches a filter not starting with!, show it
+            if fnmatch.fnmatch(filename, filter):
+                return True
+            default = False
 
     return default
 


### PR DESCRIPTION
When setting the filename filter in the "File Browser" tool to a suggested default value, e.g. `*.py *.pyw`, then no more *.py files are visible because in the new implementation, the filename only matches if all filter parts match (logical AND).
I reverted parts of #926 to get back the old behaviour (logical OR).