### PR TITLE
close subprocess pipe in pipper when finished

### DIFF
--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -43,6 +43,7 @@ def subprocess_with_callback(callback, cmd, **kwargs):
     # Process remaining text
     pending += p.stdout.read()
     callback(pending.decode("utf-8", "ignore"))
+    p.stdout.close()  # avoid ResourceWarning: unclosed file <_io.BufferedReader>
 
     # Done
     return p.returncode


### PR DESCRIPTION
When "PYTHONWARNINGS=error" is added to the environ field of the shell configuration, the magic command `pip list` will print the following error after listing the packages:
```
Exception ignored in: <_io.FileIO name=18 mode='rb' closefd=True>
Traceback (most recent call last):
  File "/tmp/pyzo/_internal/source/pyzo/pyzokernel/pipper.py", line 63, in pip_command_exe
    subprocess_with_callback(print_, cmd)
ResourceWarning: unclosed file <_io.BufferedReader name=18>
```
I added a code line to close the buffered reader. This will not cause a warning resp. an error anymore.