### PR TITLE
add menu entry for search in file browser tool

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -819,12 +819,30 @@ class EditMenu(Menu):
             None,
             pyzo.editors._findReplace.findPrevious,
         )
+        self.addItem(
+            translate(
+                "menu",
+                "Find via File Browser ::: Find using the File Browser tool. Initialize with selected text.",
+            ),
+            icons.find,
+            self._findViaFilebrowserCallback,
+        )
 
     def _editItemCallback(self, action):
         widget = QtWidgets.qApp.focusWidget()
         # If the widget has a 'name' attribute, call it
         if hasattr(widget, action):
             getattr(widget, action)()
+
+    def _findViaFilebrowserCallback(self):
+        fileBrowser = pyzo.toolManager.getTool("pyzofilebrowser")
+        if fileBrowser is not None:
+            editor = pyzo.editors.getCurrentEditor()
+            if editor is None:
+                needle = ""
+            else:
+                needle = editor.textCursor().selectedText().replace("\u2029", "\n")
+            fileBrowser.setSearchText(needle, setFocus=True)
 
 
 class ZoomMenu(Menu):

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -96,6 +96,7 @@ shortcuts2 = dict:
     edit__find_previous = 'Ctrl+Shift+G,Shift+F3'
     edit__find_selection = 'Ctrl+F3,'
     edit__find_selection_backward = 'Ctrl+Shift+F3,'
+    edit__find_via_file_browser = 'Ctrl+Shift+F,'
     edit__indent = 'Tab,'
     edit__justify_commentdocstring = 'Ctrl+J,'
     edit__paste = 'Ctrl+V,Shift+Insert'

--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -129,6 +129,11 @@ class PyzoFileBrowser(QtWidgets.QWidget):
         browser = self._browsers[0]
         browser._tree.setPath(path)
 
+    def setSearchText(self, needle, setFocus=False):
+        """Set the text in the search field."""
+        browser = self._browsers[0]
+        browser.setSearchText(needle, setFocus)
+
     def getAddToPythonPath(self):
         """
         Returns the path to be added to the Python path when starting a shell

--- a/pyzo/tools/pyzoFileBrowser/browser.py
+++ b/pyzo/tools/pyzoFileBrowser/browser.py
@@ -113,6 +113,12 @@ class Browser(QtWidgets.QWidget):
             "excludeBinary": self.config.searchExcludeBinary,
         }
 
+    def setSearchText(self, needle, setFocus=False):
+        """Set the text in the search field."""
+        self._searchFilter.setText(needle)
+        if setFocus:
+            self._searchFilter.setFocus()
+
     @property
     def expandedDirs(self):
         """The list of the expanded directories."""


### PR DESCRIPTION
This PR adds a menu entry for searching via the File Browser tool.
Similar to the normal search (Ctrl+F), the selected text in the editor is copied into the search field and the focus is moved to the search field.
This also works if no editor tab is open.
Default keyboard shortcut is Ctrl+Shift+F.