### PR TITLE
disable faulthandler in pyzolauncher.py in MS Windows to prevent crash

### DIFF
--- a/pyzolauncher.py
+++ b/pyzolauncher.py
@@ -29,6 +29,9 @@ import subprocess
 try:
     if sys.executable.lower().endswith("pythonw.exe"):
         raise ImportError("Dont use faulthandler in pythonw.exe")
+    if sys.platform == "win32":
+        raise ImportError("Prevent crash with QFileIconProvider")
+        # see https://github.com/pyzo/pyzo/issues/875 for details
     import faulthandler
 
     faulthandler.enable()


### PR DESCRIPTION
This PR will change pyzolauncher.py so that module "faulthandler" will not be used on MS Windows operating systems. This will prevent crashes when using the "File Browser" tool and native file dialogs when Pyzo is launched via pyzolauncher.py.
See issue #875 for details.

Deactivating the faulthandler on MS Windows is acceptable IMHO. When running Pyzo via the binary distribution (pyzo.exe) or via `python -m pyzo` there has also no faulthandler been activated.