### PR TITLE
fix shell keyboard shortcuts bug

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1352,6 +1352,8 @@ class ShellMenu(Menu):
         """Remove, then add the items for the creation of each shell"""
         for action in self._shellCreateActions:
             self.removeAction(action)
+            # actions with key sequence were added in pyzo.main too
+            pyzo.main.removeAction(action)
 
         self._shellCreateActions = []
         for i, config in enumerate(pyzo.config.shellConfigs2):


### PR DESCRIPTION
**Description of the problem**
Keyboard shortcuts for creating a new shell (Ctrl+1, Ctrl+2, etc.) stop working after just popping up the "Shell" menu (next to File, Edit, View, Settings).
The problem occurs in all tested operating systems (Linux, MS Windows) and all Qt wrappers (PySide2/6 and PyQt5/6).

**Analysis**
As far as I have seen, the menu action that includes the shortcut is stored twice:
First here: https://github.com/pyzo/pyzo/blob/31a00a62036bd3609c94ad42273c9ac5ba101358/pyzo/core/menu.py#L248
And then in the same function via the call to `pyzo.keyMapper.setShortcut(a)`: https://github.com/pyzo/pyzo/blob/31a00a62036bd3609c94ad42273c9ac5ba101358/pyzo/core/menu.py#L147
But when updating the shell entries
https://github.com/pyzo/pyzo/blob/31a00a62036bd3609c94ad42273c9ac5ba101358/pyzo/core/menu.py#L1354
only one action is removed and then the action added again in both places. This seems to have caused a conflict with an existing shortcut.

**Fix**
I added a line to remove the action also in the second place.

This, at least, solves the described problem.

**Further remarks**
Nevertheless, there are other issues (also before this PR). When changing the shell configuration order (swapping tabs in the shell configuration dialog) or adding/removing configs, the keyboard shortcuts are stuck to the old shell configs and not to the shell index. Changing the shortcuts via the key mappings dialog also has some issues. In these cases, restarting Pyzo solves the problem.