### PR TITLE
prevent autocomplete infinite loop for class lookup

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -778,6 +778,10 @@ class PyzoEditor(BaseTextCtrl):
                     if fictiveClass:
                         aco.addNames(fictiveClass.members)
                         classNames.extend(fictiveClass.supers)
+                        if className in classNames:
+                            # avoid infinite loop if the parent class is the same as the
+                            # current class, see https://github.com/pyzo/pyzo/issues/944
+                            break
                 else:
                     nameForShell = className
                     break


### PR DESCRIPTION
Issue #944 describes a special case where Pyzo autocomplete lookup gets stuck in an infinite loop when the parent class in a class definition is the same as the current class.

This PR fixes the bug by aborting the loop in that case.