### PR TITLE
always use built-in dir command for autocompletion introspection

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -203,8 +203,8 @@ class PyzoIntrospector(yoton.RepChannel):
 
         # Obtain all attributes of the class
         try:
-            command = "dir(%s.__class__)" % (objectName)
-            d = eval(command, {}, NS)
+            command = "__pyzo_builtin_dir__(%s.__class__)" % (objectName)
+            d = eval(command, {"__pyzo_builtin_dir__": dir}, NS)
         except Exception:
             pass
         else:
@@ -222,8 +222,8 @@ class PyzoIntrospector(yoton.RepChannel):
         # That should be enough, but in case __dir__ is overloaded,
         # query that as well
         try:
-            command = "dir(%s)" % (objectName)
-            d = eval(command, {}, NS)
+            command = "__pyzo_builtin_dir__(%s)" % (objectName)
+            d = eval(command, {"__pyzo_builtin_dir__": dir}, NS)
         except Exception:
             pass
         else:


### PR DESCRIPTION
As described in issue #891, naming a variable "dir" will break autocompletion in Pyzo.

With this PR, the introspection for autocompletion will always use the built-in "dir" command, even when the user executed code such as `dir = 'northeast'`.