### PR TITLE
properly close pipes and sockets

### DIFF
--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -774,6 +774,8 @@ class StreamReader(threading.Thread):
             if not msg:  # or self._process.poll() is not None:
                 break
         # self._strm_broker.send('streamreader exit\n')
+        self._process.stdout.close()
+        self._process.stdin.close()
 
 
 class Kernelmanager:

--- a/pyzo/yoton/clientserver.py
+++ b/pyzo/yoton/clientserver.py
@@ -97,8 +97,12 @@ class RequestServer(threading.Thread):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-        # Bind (can raise error is port is not available)
-        s.bind((host, port))
+        # Bind (can raise error if port is not available)
+        try:
+            s.bind((host, port))
+        except Exception:
+            s.close()
+            raise
 
         # Store socket instance
         self._bsd_socket = s


### PR DESCRIPTION
This PR will prevent some warnings that are visible when running Pyzo from source with `PYTHONWARNINGS=error`.
