### PR TITLE
keep autocompletion popup within the shell/editor widget

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -8,7 +8,6 @@
 Code editor extensions that provides autocompleter functionality
 """
 
-import pyzo
 from ..qt import QtGui, QtCore, QtWidgets
 
 Qt = QtCore.Qt
@@ -199,15 +198,17 @@ class AutoCompletion(object):
         # Initial choice for position of the completer
         position = self.cursorRect(cur).bottomLeft() + self.viewport().pos()
 
-        # Check if the completer is going to go off the screen
-        # top_geometry = QtWidgets.qApp.qApp.screens()[0].availableVirtualSize()
-        top_geometry = pyzo.main.geometry()
-        global_position = self.mapToGlobal(position)
-        if global_position.y() + geometry.height() > top_geometry.height():
+        # Check if the completer is going to go off the editor/shell widget
+        if (
+            position.y() + geometry.height()
+            > self.viewport().pos().y() + self.viewport().height()
+        ):
             # Move the completer to above the current line
             position = self.cursorRect(cur).topLeft() + self.viewport().pos()
             global_position = self.mapToGlobal(position)
             global_position -= QtCore.QPoint(0, int(geometry.height()))
+        else:
+            global_position = self.mapToGlobal(position)
 
         self.__completer.popup().move(global_position)
 


### PR DESCRIPTION
When the cursor is at the bottom of a shell or editor widget, an autocompletion popup will occlude other widgets that are below. This is a bit annoying when having the "Interactive help" tool below the shell, as shown in the following picture.

![before](https://github.com/pyzo/pyzo/assets/119257544/eee70cbb-cb01-461a-840c-4c387bd1b8fd)

Currently, the autocompletion popup will only switch from expanding downwards to expanding upwards when it would go deeper than the bottom border of the Pyzo main window.

With this PR, the autocompletion popup will expand upwards when it would go deeper than the shell resp. editor widget bottom border. The scene from above would then look like this:

![after](https://github.com/pyzo/pyzo/assets/119257544/9a9ea584-843f-4c43-ac74-a61ab0c24f2b)

