### PR TITLE
Fix unused default settings

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -100,6 +100,13 @@ class AutoCompletion(object):
         """
         self.__popupSize = width, height
 
+    def setAutocompleteCaseSensitive(self, b):
+        """
+        Set the case sensitivity for autocompletion.
+        """
+        cs = Qt.CaseSensitive if b else Qt.CaseInsensitive
+        self.__completer.setCaseSensitivity(cs)
+
     def setAutocompleteMinChars(self, n):
         """
         Set the number of chars where we show the popup.

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -185,6 +185,9 @@ class BaseTextCtrl(CodeEditor):
         self.setIndentUsingSpaces(pyzo.config.settings.defaultIndentUsingSpaces)
         self.setIndentWidth(pyzo.config.settings.defaultIndentWidth)
         self.setAutocompletPopupSize(*pyzo.config.view.autoComplete_popupSize)
+        self.setAutocompleteCaseSensitive(
+            pyzo.config.settings.autoComplete_caseSensitive
+        )
         self.setAutocompleteMinChars(pyzo.config.settings.autoComplete_minChars)
         self.setCancelCallback(self.restoreHelp)
 

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -52,7 +52,6 @@ settings= dict:
     autoComplete_keywords = 1
     autoComplete = 1
     autoComplete_caseSensitive = 0
-    autoComplete_fillups = '\n'
     autoComplete_acceptKeys = 'Tab'
     autoComplete_minChars = 3
     justificationWidth = 70
@@ -69,7 +68,6 @@ advanced = dict:
     fileExtensionsToLoadFromDir = 'py,pyw,pyx,txt,bat'
     autoCompDelay = 200
     titleText = '{fileName} ({fullPath}) - Interactive Editor for Python'
-    homeAndEndWorkOnDisplayedLine = 0
     find_autoHide_timeout = 10
     useNativeFileDialogs = 1
 


### PR DESCRIPTION
This PR will remove two unused settings in defaultConfig.ssdf: "autoComplete_fillups" and "homeAndEndWorkOnDisplayedLine".
Both entries have never been used as far as the commit history goes back here on GitHub.

And for the third entry, that has also not been used, "autoComplete_caseSensitive", I have added code to implement that feature.