### PR TITLE
increase search speed in File Browser tool

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -253,7 +253,7 @@ class BaseFSProxy(threading.Thread):
     # For testing to induce extra delay. Should normally be close to zero,
     # but not exactly zero!
     IDLE_DELAY = 0.01
-    QUEUE_DELAY = 0.01  # 0.5
+    QUEUE_DELAY = 1e-4
 
     def __init__(self):
         threading.Thread.__init__(self)


### PR DESCRIPTION
This change will increase the speed of searching text via the File Browser tool by a factor 5 to 10 -- tested on Linux when searching in the Pyzo code base.
This PR sets `QUEUE_DELAY` to 0.1 ms (instead of 10 ms). The `IDLE_DELAY` value remains at 10 ms, so there should be no negative impact on CPU load or battery energy usage while not searching.
