### PR TITLE
fix file opening via QFileOpenEvent on Macs

### DIFF
--- a/pyzo/_start.py
+++ b/pyzo/_start.py
@@ -69,7 +69,7 @@ class MyApp(QtWidgets.QApplication):
         if isinstance(event, QtGui.QFileOpenEvent):
             fname = str(event.file())
             if fname and fname != "pyzo":
-                sys.argv[-1:] = [fname]
+                sys.argv[1:] = [fname]
                 res = commandline.handle_cmd_args()
                 if not commandline.is_our_server_running():
                     print(res)


### PR DESCRIPTION
As reported via https://github.com/pyzo/pyzo/issues/946#issuecomment-1947920124, files cannot be opened anymore via file association on Mac computers.
```
# in the callback for QFileOpenEvent:
fname = '/path/to/script/tobeopened.py'
sys.argv = ['/path/to/pyzo']
sys.argv[-1:] = [fname]  # <-- bug is here
res = commandline.handle_cmd_args()

# in function handle_cmd_args:
args = sys.argv[1:]  # <-- args is then an empty list
```

This seems to be a bug introduced by #923.
In #923, two files were changed:
I fully know about the problem and its solution that lead to changes in file `pyzo/pyzokernel/start.py`.
But I have no idea, what the reason was to also modify file `pyzo/_start.py` in that PR.