### PR TITLE
fix Python syntax parser and quotes/brackets autocompletion

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -493,7 +493,7 @@ class AutoCloseQuotesAndBrackets(object):
         token = None
         for token in tokens:
             if hasattr(token, "start"):
-                if token.start >= pos:
+                if token.start <= pos < token.end:
                     break
             elif getattr(token, "state", 0) in (1, 2):
                 token = MultilineStringToken()  # 1 and 2 are mls, by convention, sortof
@@ -572,7 +572,7 @@ class AutoCloseQuotesAndBrackets(object):
         elif char in quotes and pyzo.config.settings.autoClose_Quotes:
             next_char = self.__getNextCharacter()
 
-            # Dont autoquote inside comments and multiline strings
+            # Don't autoquote inside comments and multiline strings
             # Only allow "doing our thing" when we're at the end of a normal string
             token = self._get_token_at_cursor(cursor)
             if isinstance(token, (CommentToken, MultilineStringToken)):

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -447,12 +447,16 @@ class CellCommentToken(CommentToken):
     defaultStyle = "bold:yes, underline:yes"
 
 
+stringLiteralPrefixes = frozenset("u|r|b|f|rb|br|rf|fr".split("|"))
+
 # This regexp is used to find special stuff, such as comments, numbers and
 # strings.
 tokenProg = re.compile(
     "#|"  # Comment or
     + "("  # Begin of string group (group 1)
-    + "(u|r|b|f|rb|br|rf|fr)?"  # prefixes for unicode raw byte format
+    + "("
+    + "|".join(stringLiteralPrefixes)
+    + ")?"  # (group 2)
     + "(\"\"\"|'''|\"|')"  # String start (triple quotes first, group 3)
     + ")|"  # End of string group
     + "([a-z0-9_]+)|"  # Identifiers/numbers (group 4) or

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -451,24 +451,24 @@ class CellCommentToken(CommentToken):
 # This regexp is used to find special stuff, such as comments, numbers and
 # strings.
 tokenProg = re.compile(
-    "#|"
-    + "(["  # Comment or
-    + ALPHANUM
+    "#|"  # Comment or
+    + "(["
+    + ALPHANUM  # Identifiers/numbers (group 1) or
     + "_]+)|"
-    + "("  # Identifiers/numbers (group 1) or
-    + "([bB]|[uU])?"  # Begin of string group (group 2)
-    + "[rR]?"  # Possibly bytes or unicode (py2.x)
-    + "(\"\"\"|'''|\"|')"  # Possibly a raw string
-    + ")|"  # String start (triple qoutes first, group 4)
-    + r"(\(|\[|\{)|"  # End of string group
-    + r"(\)|\]|\})|"  # Opening parenthesis (gr 5)
-    + "("  # Closing parenthesis (gr 6)
-    + chr(160)
-    + ")"  # non-breaking space (gr 7)
+    + "("  # Begin of string group (group 2)
+    + "([bB]|[uU])?"  # Possibly bytes or unicode (py2.x)
+    + "[rR]?"  # Possibly a raw string
+    + "(\"\"\"|'''|\"|')"  # String start (triple quotes first, group 4)
+    + ")|"  # End of string group
+    + r"(\(|\[|\{)|"  # Opening parenthesis (gr 5)
+    + r"(\)|\]|\})|"  # Closing parenthesis (gr 6)
+    + "("
+    + chr(160)  # non-breaking space (gr 7)
+    + ")"
 )
 
 
-# For a given type of string ( ', " , ''' , """ ),get  the RegExp
+# For a given type of string ( ', " , ''' , """ ), get the RegExp
 # program that matches the end. (^|[^\\]) means: start of the line
 # or something that is not \ (since \ is supposed to escape the following
 # quote) (\\\\)* means: any number of two slashes \\ since each slash will

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -67,7 +67,7 @@ python2Keywords = set(
     ]
 )
 
-# Source: import keyword; keyword.kwlist (Python 3.1.2)
+# Source: import keyword; keyword.kwlist (Python 3.12)
 python3Keywords = set(
     [
         "False",
@@ -262,7 +262,7 @@ python2Builtins = set(
     ]
 )
 
-# Source: import builtins; dir(builtins) (Python 3.5.2)
+# Source: import builtins; dir(builtins) (Python 3.12)
 # Note: Removed 'False', 'None', 'True'. They are keyword in Python 3
 python3Builtins = set(
     [
@@ -270,6 +270,7 @@ python3Builtins = set(
         "AssertionError",
         "AttributeError",
         "BaseException",
+        "BaseExceptionGroup",
         "BlockingIOError",
         "BrokenPipeError",
         "BufferError",
@@ -282,8 +283,10 @@ python3Builtins = set(
         "DeprecationWarning",
         "EOFError",
         "Ellipsis",
+        "EncodingWarning",
         "EnvironmentError",
         "Exception",
+        "ExceptionGroup",
         "FileExistsError",
         "FileNotFoundError",
         "FloatingPointError",
@@ -300,6 +303,7 @@ python3Builtins = set(
         "KeyboardInterrupt",
         "LookupError",
         "MemoryError",
+        "ModuleNotFoundError",
         "NameError",
         "NotADirectoryError",
         "NotImplemented",
@@ -333,6 +337,7 @@ python3Builtins = set(
         "ValueError",
         "Warning",
         "ZeroDivisionError",
+        "_",
         "__build_class__",
         "__debug__",
         "__doc__",
@@ -342,11 +347,14 @@ python3Builtins = set(
         "__package__",
         "__spec__",
         "abs",
+        "aiter",
         "all",
+        "anext",
         "any",
         "ascii",
         "bin",
         "bool",
+        "breakpoint",
         "bytearray",
         "bytes",
         "callable",


### PR DESCRIPTION
Actually, I only wanted to fix the following bug:
Syntax highlighting for a normal string literal that has a line-continuation backslash does not work, e.g.:
```python3
s = 'abc\
def'
```
While fixing this and testing, I encountered several bugs that are related (and were already present before this PR).

The first commit adds some missing bult-in identifiers for newer Python versions.
The second commit fixes some comments for the parser regular expressions that probably got mixed up when reformatting the code.
The third commit adds the line-continuation with backslash for normal strings, as described at the beginning.

When testing auto-completion with the line-continued string I saw that, when entering `[`
```python3
s = 'abc\
def  [   \
'
```
autocompletion added the `]` which should not happen inside string literals.
So I fixed the bug in method `_get_token_at_cursor` via the fourth commit.

With the fifth commit I fixed the parser so that it properly recognizes string literals with prefixes with valid prefix combinations, e.g. `rf"abc"`.
Then I did some testing again, also with autocompletion enabled. I normally do not have quotes and brackets autocompletion enabled, so I was surprised that quotes autocompletion never has worked for prefixed string literals. For example `s = r'` will not close the single quote automatically because the "r" was parsed as an identifier (because the single quote was too new). I fixed this, together with some other adjustements, via the sixth commit.


With these changes, the syntax highlighter now formats the prefix for string literals in the same color/format as the remaining string literal. In the official Python docs, and in some code editors, the prefix is also included in syntax highlighting. Autocompletion will now also complete brackets directly after a string literal, e.g. `"xyz"[` will turn into `"xyz"[]`.
