### PR TITLE
fix initial horizontal scrollbar positions for editors

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1007,9 +1007,9 @@ class EditorTabs(QtWidgets.QWidget):
         # restore state (call later so that the menu module can bind to the
         # currentChanged signal first, in order to set tab/indentation
         # checkmarks appropriately)
-        # todo: Resetting the scrolling would work better if set after
-        # the widgets are properly sized.
-        pyzo.callLater(self.restoreEditorState)
+
+        # self.restoreEditorState should be called from outside after the paintNow call
+        # otherwise the horizontal scrollbar would be set for a too small widget size
 
     @property
     def _fileDialogOptions(self):

--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -120,6 +120,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Restore window state, force updating, and restore again
         self.restoreState()
         self.paintNow()
+        pyzo.editors.restoreEditorState()
         self.restoreState()
 
         # Present user with wizard if he/she is new.


### PR DESCRIPTION
During start of Pyzo, editor tabs are created that restore the recently opened files. Also the text cursor positions are moved to the position they had last time. But the problem is that this happens before the widgets are painted the first time and therefore the editor widget is too small and has to shift the horizontal scrollbar far to the right to keep the text cursor visible. When Pyzo is fully loaded, the editor widgets have the proper size, but the scrollbars remain shifted. This is a bit annoying because (depending on the restored text cursor column) you always have to first set the cursor to the very left to not miss anything on the left when browsing the code vertically.

To fix that, I just moved the call to `restoreEditorState` right after the first `paintNow()` call.