### PR TITLE
fix for fix initial horizontal scrollbar positions for editors

### DIFF
--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -120,8 +120,8 @@ class MainWindow(QtWidgets.QMainWindow):
         # Restore window state, force updating, and restore again
         self.restoreState()
         self.paintNow()
-        pyzo.editors.restoreEditorState()
         self.restoreState()
+        pyzo.editors.restoreEditorState()
 
         # Present user with wizard if he/she is new.
         if False:  # pyzo.config.state.newUser:


### PR DESCRIPTION
Sorry for the inconvenience. I just discovered that this did not work on the MS Windows version. Fixed that.