### PR TITLE
make matching occurrences highlighter less restrictive

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -51,6 +51,10 @@ class HighlightMatchingOccurrences(object):
         self.viewport().update()
 
     def _doHighlight(self, text):
+        if text.strip() != text or "\u2029" in text:
+            # selection has leading/trailing whitespace or contains a line break
+            return
+
         # make cursor at the beginning of the first visible block
         cursor = self.cursorForPosition(QtCore.QPoint(0, 0))
         cursor.movePosition(cursor.StartOfWord)
@@ -121,18 +125,12 @@ class HighlightMatchingOccurrences(object):
     def paintEvent(self, event):
         """paintEvent(event)
 
-        If there is a current selection, and the selected text is a valid Python
-        identifier (no whitespace, starts with a letter), then highlight all the
-        matching occurrences of the selected text in the current view.
-
         Paints behinds its super().
-
         """
         cursor = self.textCursor()
         if self.__highlightMatchingOccurrences and cursor.hasSelection():
             text = cursor.selectedText()
-            if text.isidentifier():
-                self._doHighlight(text)
+            self._doHighlight(text)
 
         super(HighlightMatchingOccurrences, self).paintEvent(event)
 


### PR DESCRIPTION
Currently, the matching occurrence highlighter only accepts valid Python identifiers but not number literals.

```python3
needle = 0x13992B232623056

haystack = [
    0x139928232622992,
    0x139928232623056,
    0x139928232622992,
    0x139928232623056,
    0x139928232622992,
    0x13992B232623056,
    0x139928232622992,
    0x139928232623056,
    0x139928232622992,
    0x139928232623056,
]
```
I removed that restriction.

With the new implementation, the editor or shell will highlight selections that
* have no leading or trailing whitespace (but may contain whitespace)
* contain no line breaks (`"\u2029"` because of `QPlainTextEdit`)
* start and end with a word boundary (because of the `FindWholeWords` flag)
