### PR TITLE
preserve case for TODO-type entries in Source Structure tool

### DIFF
--- a/pyzo/core/codeparser.py
+++ b/pyzo/core/codeparser.py
@@ -425,7 +425,7 @@ class Parser(threading.Thread):
 
             # Split in line and comment
             line, tmp, cmnt = line.partition("#")
-            line, cmnt = line.rstrip(), cmnt.lower().strip()
+            line, cmnt = line.rstrip(), cmnt.strip()
 
             # Detect todos
             firstWord = cmnt.lstrip().split(" ", 1)[0].rstrip(":")


### PR DESCRIPTION
The source structure tool displayed entries for TODO type entries (such as TODO, FIXME, etc.) always converted to lowercase.
I changed the code to keep the original case.