### PR TITLE
fix magician confused by comment ending with question mark

### DIFF
--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -110,9 +110,10 @@ def _should_not_interpret_as_magic(line):
         if interpreter.globals and command in interpreter.globals:
             return True
     else:  # command is not alone ; next token should not be an operator (this includes parentheses)
-        if ltok[pos].type == token.OP and not line.endswith("?"):
-            return True
-
+        if ltok[pos].type == token.OP:
+            # this is not a magic command: "b = a > 1  # is valid?"
+            if not line.endswith("?") or "#" in line:
+                return True
     return False
 
 


### PR DESCRIPTION
When entering a command in the shell that has a comment ending in a question mark, the command is misinterpreted as a magic command, e.g.:
```python3
b = a > 0  # is valid?
```
is converted to
```python3
print(b = a > 0  # is valid.__doc__)
```

I added a check to fix that.