### PR TITLE
fix opening UNC paths in MS Windows via tracebacks

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -367,7 +367,7 @@ class BaseShell(BaseTextCtrl):
                 return
 
             if sys.platform.startswith("win"):
-                if piece[1] != ":":
+                if piece[1] != ":" and piece[:2] != r"\\":
                     return
             else:
                 if not piece.startswith("/"):


### PR DESCRIPTION
This will allow to open also Python scripts with [UNC filepaths](https://en.wikipedia.org/wiki/Path_(computing)#UNC) in MS Windows when double clicking the filepath for example in a traceback in the shell.