### PR TITLE
fix matching occurrences highlighter word detection

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -66,11 +66,14 @@ class HighlightMatchingOccurrences(object):
         painter.setBrush(color)
         painter.setPen(color.darker(110))
 
+        # flag "FindWholeWords" in doc.find would not consider "_" as a word character
+        # therefore use a custom regular expression instead
+        QRE = QtCore.QRegularExpression
+        needle = QRE(r"\b" + QRE.escape(text) + r"\b")
+
         # find occurrences
         for i in range(500):
-            cursor = doc.find(
-                text, cursor, doc.FindCaseSensitively | doc.FindWholeWords
-            )
+            cursor = doc.find(needle, cursor, doc.FindCaseSensitively)
             if cursor is None or cursor.isNull():
                 # no more matches
                 break


### PR DESCRIPTION
The `doc.FindWholeWords` flag in the `doc.find(...)` method for the matching occurrences highlighter does not treat the underscore as a word character. When, for example, selecting a variable `data`, then variable `another_data` would also be partially highlighted. This problem is similar to #276.

With this fix, an identifier or numeric literal will only be highlightes if it is the same as the selected one.


 