### PR TITLE
add "Reload from disk" to the File menu

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1319,6 +1319,31 @@ class EditorTabs(QtWidgets.QWidget):
         # return lastopened item
         return item
 
+    def reloadFile(self, editor=None):
+        if editor is None:
+            editor = self.getCurrentEditor()
+            if editor is None:
+                return
+        if editor.name.startswith("<tmp"):
+            return
+
+        if editor.document().isModified():
+            dlg = QtWidgets.QMessageBox(self)
+            dlg.setWindowTitle("Reload file with unsaved changes?")
+            dlg.setText(
+                'Do you want to reload file\n"{}"\n'
+                "and lose unsaved changes?".format(editor.filename)
+            )
+            dlg.addButton("Reload", QtWidgets.QMessageBox.AcceptRole)
+            btn = dlg.addButton("Keep this version", QtWidgets.QMessageBox.RejectRole)
+            dlg.setDefaultButton(btn)
+            btnIndex = dlg.exec_()
+            if btnIndex != 0:
+                return  # cancel reloading
+
+        editor.reload()
+        self._tabs.updateItems()
+
     def saveFileAs(self, editor=None):
         """Create a dialog for the user to select a file.
         returns: True if succesfull, False if fails

--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -539,6 +539,10 @@ def loadIcons():
                 pyzo.icons[name] = dummyIcon
                 print("Could not load icon %s: %s" % (fname, str(err)))
 
+    artist = IconArtist("folder_page")
+    artist.addLayer("arrow_refresh")
+    pyzo.icons["reload_file_from_disk"] = artist.finish()
+
 
 def loadFonts():
     """loadFonts()

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -513,6 +513,13 @@ class FileMenu(Menu):
         #
         self._items += [
             self.addItem(
+                translate(
+                    "menu", "Reload from disk ::: Reload the current file from disk."
+                ),
+                icons.reload_file_from_disk,
+                pyzo.editors.reloadFile,
+            ),
+            self.addItem(
                 translate("menu", "Save ::: Save the current file to disk."),
                 icons.disk,
                 pyzo.editors.saveFile,


### PR DESCRIPTION
This will add a new menu entry "Reload from disk" to the "File" menu. This is especially useful when file change notification does not work properly on network shares.