### PR TITLE
fix green debug position marker not shown for first line

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -1165,7 +1165,7 @@ class BreakPoints(object):
                         )
 
             # Draw *the* debug marker
-            if debugBlockIndicator > 0:
+            if debugBlockIndicator >= 0:
                 painter.setBrush(QtGui.QColor("#6F6"))
                 # Get block
                 block = editor.document().findBlockByNumber(debugBlockIndicator)


### PR DESCRIPTION
How to reproduce the problem:
create a new file in the Pyzo editor
enter "1" in the first line
set a breakpoint at the first line
run the script
execution is stopped at the breakpoint in line 1 but the green marker is not shown (this problem occurs only for the first line)

This is an index-off-by-one bug. I fixed that.
