### PR TITLE
add support for soft keywords "match" and "case"

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -315,8 +315,8 @@ class PythonAutoIndent(object):
                     ppreviousState = (
                         ppreviousBlock.userState() if previousBlock.isValid() else 0
                     )
-                    tokens = list(
-                        self.parser().parseLine(previousBlock.text(), ppreviousState)
+                    tokens = self.parser().parseLine(
+                        previousBlock.text(), ppreviousState
                     )
                     # because of the ":" on that line, there is at least one token
                     t = tokens[-1]

--- a/pyzo/codeeditor/highlighter.py
+++ b/pyzo/codeeditor/highlighter.py
@@ -81,7 +81,7 @@ class Highlighter(QtGui.QSyntaxHighlighter):
         tokens = []
         if parser:
             self.setCurrentBlockState(0)
-            tokens = list(parser.parseLine(line, previousState))
+            tokens = parser.parseLine(line, previousState)
             for token in tokens:
                 # Handle block state
                 if isinstance(token, parsers.BlockState):

--- a/pyzo/codeeditor/parsers/__init__.py
+++ b/pyzo/codeeditor/parsers/__init__.py
@@ -44,11 +44,9 @@ class BlockState(object):
     The blockstate object should be used by parsers to
     return the block state of the processed line.
 
-    This would typically be the last item to be yielded, but this
-    it may also be yielded befor the last yielded token. One can even
-    yield multiple of these items, in which case the last one considered
-    valid.
-
+    This would typically be the last token in a line, but this might also
+    be before the last token in a line. Even multiple BlockState objects
+    can be present in a line, in which case the last one is considered valid.
     """
 
     isToken = False
@@ -99,13 +97,12 @@ class Parser(object):
         is an integer, the meaning of which is only known to the
         specific parser.
 
-        This method should yield token instances. The last token can
-        be a BlockState to specify the previousState for the
-        next block.
-
+        This method should reaturn a list of token instances. The
+        last token can be a BlockState to specify the previousState
+        for the next block.
         """
 
-        yield tokens.TextToken(line, 0, len(line))
+        return [tokens.TextToken(line, 0, len(line))]
 
     def name(self):
         """name()

--- a/pyzo/codeeditor/parsers/c_parser.py
+++ b/pyzo/codeeditor/parsers/c_parser.py
@@ -65,12 +65,13 @@ class CParser(Parser):
     def parseLine(self, line, previousState=0):
         """parseLine(line, previousState=0)
 
-        Parses a line of C code, yielding tokens.
-
+        Parses a line of C code, returning a list of tokens.
         """
         line = text_type(line)
 
         pos = 0  # Position following the previous match
+
+        tokensForLine = []
 
         # identifierState and previousstate values:
         # 0: nothing special
@@ -84,18 +85,18 @@ class CParser(Parser):
             tokens = self._findEndOfString(line, token)
             # Process tokens
             for token in tokens:
-                yield token
+                tokensForLine.append(token)
                 if isinstance(token, BlockState):
-                    return
+                    return tokensForLine
             pos = token.end
         elif previousState == 2:
             token = MultilineCommentToken(line, 0, 0)
             tokens = self._findEndOfComment(line, token)
             # Process tokens
             for token in tokens:
-                yield token
+                tokensForLine.append(token)
                 if isinstance(token, BlockState):
-                    return
+                    return tokensForLine
             pos = token.end
 
         # Enter the main loop that iterates over the tokens and skips strings
@@ -103,7 +104,7 @@ class CParser(Parser):
             # Get next tokens
             tokens = self._findNextToken(line, pos)
             if not tokens:
-                return
+                return tokensForLine
             elif isinstance(tokens[-1], StringToken):
                 moreTokens = self._findEndOfString(line, tokens[-1])
                 tokens = tokens[:-1] + moreTokens
@@ -113,9 +114,9 @@ class CParser(Parser):
 
             # Process tokens
             for token in tokens:
-                yield token
+                tokensForLine.append(token)
                 if isinstance(token, BlockState):
-                    return
+                    return tokensForLine
             pos = token.end
 
     def _findEndOfComment(self, line, token):

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -166,7 +166,7 @@ class ShellHighlighter(Highlighter):
             if specialinput:
                 pass  # Let the kernel decide formatting
             else:
-                tokens = list(parser.parseLine(line, previousState))
+                tokens = parser.parseLine(line, previousState)
                 bd.tokens = tokens
                 for token in tokens:
                     # Handle block state


### PR DESCRIPTION
This will add proper syntax highlighting for the keywords "match" and "case" but only if they are used in such a way.
See the doc string of method `_promoteMatchCaseSoftKeywords(tokens)` for details and examples.

This will also close issue #841.