### PR TITLE
fix QFontDatabase deprecation warning for PySide6

### DIFF
--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -60,5 +60,11 @@ elif PYSIDE6:
     from .enums_compat import promote_enums
 
     promote_enums(QtGui)
+
+    # in Qt6 use QtGui.QFontDatabase.families() instead of QtGui.QFontDatabase().families()
+    # https://doc.qt.io/qt-6/qfontdatabase-obsolete.html#QFontDatabase
+    QtGui.QFontDatabase.__new__ = lambda cls: cls
+
+    del QtGui
 else:
     raise PythonQtError("No Qt bindings could be found")


### PR DESCRIPTION
This will fix a warning that was printed when hovering the mouse over the "Font" menu when using PySide6.
And I also added the line `del QtGui` to remove `pyzo.qt.QtGui.QtGui`.