### PR TITLE
fix misinterpretation of variables as magic commands

### DIFF
--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -104,7 +104,11 @@ def _should_not_interpret_as_magic(line):
         return True
     pos = pos + 1
     # command is alone on the line
-    if pos >= len(ltok) or ltok[pos].type in [token.ENDMARKER, tokenize.COMMENT]:
+    if pos >= len(ltok) or ltok[pos].type in [
+        token.ENDMARKER,
+        token.NEWLINE,
+        token.COMMENT,
+    ]:
         if command in interpreter.locals:
             return True
         if interpreter.globals and command in interpreter.globals:


### PR DESCRIPTION
When entering the command `cls = None` in the shell, pressing RETURN, and then entering `cls` and pressing RETURN, the magic command "clear screen" is executed instead of showing the value of the variable.

I found the bug and fixed it.
