### PR TITLE
Replace logging.warn usage with logging.warning

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -387,7 +387,7 @@ class PyzoInterpreter:
 
         # Warn when logging.basicConfig is used (see issue #645)
         def basicConfigDoesNothing(*args, **kwargs):
-            logging.warn(
+            logging.warning(
                 "Pyzo already added handlers to the root handler, "
                 + "so logging.basicConfig() does nothing."
             )


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.