### PR TITLE
exclude broken PySide6 6.7.0 from CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
-          pip install -U pyside6 pyinstaller
+          pip install -U pyside6!=6.7.0 pyinstaller
           pip install -r freeze/frozen_libs.txt
     - name: Freeze
       run: python freeze/pyzo_freeze.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           # Main test builds, 3 OS's times 4 Qt toolkits
           - os: windows-latest
             pyversion: '3.12'
-            qtlib: pyside6
+            qtlib: pyside6!=6.7.0
           - os: windows-latest
             pyversion: '3.11'
             qtlib: pyqt6
@@ -52,7 +52,7 @@ jobs:
           # ---
           - os: ubuntu-latest
             pyversion: '3.12'
-            qtlib: pyside6
+            qtlib: pyside6!=6.7.0
           - os: ubuntu-latest
             pyversion: '3.11'
             qtlib: pyqt6
@@ -84,7 +84,7 @@ jobs:
             qtlib: pyside6
           - os: windows-latest
             pyversion: '3.9'
-            qtlib: pyside6
+            qtlib: pyside6!=6.7.0
     steps:
     - uses: actions/checkout@v3
     - name: Setup os


### PR DESCRIPTION
Excluding PySide6 v6.7.0 because it is broken -- see issue #984.