### PR TITLE
use macOS Intel image for CI with PySide2 instead of Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,8 @@ jobs:
           - os: macos-latest
             pyversion: '3.10'
             qtlib: pyqt5
-          - os: macos-latest
+          # --- PySide2 requires macOS with Intel CPU
+          - os: macos-12  # ... has Intel instead of Apple Silicon
             pyversion: '3.9'
             qtlib: pyside2
           # --- Older Python versions and qt libs


### PR DESCRIPTION
CI workflow runs with "macos-latest" image, Python 3.9 and PySide2 suddenly started to fail.
Two weeks ago, "macos-latest" was
https://github.com/actions/runner-images/releases/tag/macOS-12%2F20240406.2
but now it is
https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240422.3

As far as I have read, PySide2 is not available for Apple's ARM CPU. Therefore I changed the workflow to use the older Intel-CPU macOS image for the PySide2 configuration.

