### PR TITLE
disconnect breakpoint-changed callback when closing shell

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1546,6 +1546,8 @@ class PythonShell(BaseShell):
 
         """
 
+        pyzo.editors.breakPointsChanged.disconnect(self.sendBreakPoints)
+
         # If we can, try to tell the broker to terminate the kernel
         if self._context and self._context.connection_count:
             self.terminate()


### PR DESCRIPTION
**How to reproduce the problem**
start pyzo
close the shell
(optionally start a new shell)
set a breakpoint
--> error message "Uncaught Python exception: Cannot send from closed StateChannel" will appear in the Logger tool and in the status bar

**Root cause analysis and fix**
During the shell creation, a `breakPointsChanged` callback is registered. But this callback was never unregistered and kept being called when updating breakpoints, causing the error message.
I added a code line to unregister that callback when the shell is closed.

