### PR TITLE
switch back to old asyncio event loop implementation

### DIFF
--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -200,7 +200,14 @@ class App_asyncio(App_base):
     def __init__(self):
         import asyncio
 
-        self.app = asyncio.get_event_loop_policy().get_event_loop()
+        if sys.version_info < (3, 12):
+            self.app = asyncio.get_event_loop_policy().get_event_loop()
+        else:
+            try:
+                self.app = asyncio.get_running_loop()
+            except RuntimeError:
+                # no running event loop
+                self.app = asyncio.new_event_loop()
         self.app._in_event_loop = "Pyzo"
         self._warned_about_process_events = False
         self._blocking = False
@@ -234,7 +241,10 @@ class App_asyncio(App_base):
         import asyncio
 
         try:
-            loop = asyncio.get_event_loop_policy().get_event_loop()
+            if sys.version_info < (3, 12):
+                loop = asyncio.get_event_loop_policy().get_event_loop()
+            else:
+                loop = asyncio.get_running_loop()
         except Exception:
             loop = None
         if loop is not self.app:

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -512,7 +512,7 @@ class PyzoInterpreter:
                     ("PYSIDE", guiintegration.App_pyside),
                     ("PYQT4", guiintegration.App_pyqt4),
                     # ('WX', guiintegration.App_wx),
-                    ("ASYNCIO", guiintegration.App_asyncio_new),
+                    ("ASYNCIO", guiintegration.App_asyncio),
                     ("TK", guiintegration.App_tk),
                 ]:
                     try:
@@ -524,7 +524,7 @@ class PyzoInterpreter:
                 else:
                     guiName = ""
             elif guiName == "ASYNCIO":
-                self.guiApp = guiintegration.App_asyncio_new()
+                self.guiApp = guiintegration.App_asyncio()
             elif guiName == "TK":
                 self.guiApp = guiintegration.App_tk()
             elif guiName == "WX":


### PR DESCRIPTION
This commit will use the old asyncio event loop implementation again instead of the new experimental one that causes a crash when interrupting exection -- see issue #989. I also updated the code for newer Python versions.