### PR TITLE
properly close socket when aborting via an exception

### DIFF
--- a/pyzo/yoton/clientserver.py
+++ b/pyzo/yoton/clientserver.py
@@ -289,6 +289,7 @@ def do_request(address, request, timeout=-1):
     try:
         s.connect((host, port))
     except socket.error:
+        s.close()
         raise RuntimeError("No server is listening at the given port.")
 
     # Send request


### PR DESCRIPTION
When running Pyzo from source with `PYTHONWARNINGS=error` in MS Windows, a "ResourceWarning: unclosed socket" appeared.

This PR will properly close the socket.