### PR TITLE
fix relative line number correction in showsyntaxerror

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1096,14 +1096,16 @@ class PyzoInterpreter:
         """
 
         # Get info (do not store)
-        type, value, tb = sys.exc_info()
+        type_, value, tb = sys.exc_info()
         del tb
 
         # Work hard to stuff the correct filename in the exception
-        if filename and type is SyntaxError:
+        if filename and type_ is SyntaxError:
             try:
                 # unpack information
-                msg, (dummy_filename, lineno, offset, line) = value
+                msg = value.args[0]
+                # since Python v3.10 there are also end_lineno and end_offset
+                dummy_filename, lineno, offset, line = value.args[1][:4]
                 # correct line-number
                 fname, lineno = self.correctfilenameandlineno(filename, lineno)
             except Exception:
@@ -1115,7 +1117,7 @@ class PyzoInterpreter:
                 sys.last_value = value
 
         # Show syntax error
-        strList = traceback.format_exception_only(type, value)
+        strList = traceback.format_exception_only(type_, value)
         for s in strList:
             self.write(s)
 


### PR DESCRIPTION
**Description of the problem**
When executing seleted lines of code in the editor with a syntax error, the relative line number was not converted to the absolute line number:
```
>>> (executing lines 4 to 8 of "asdf.py")
  File "/tmp/aa/asdf.py+3", line 4
    z = x / y /
               ^
SyntaxError: invalid syntax
```

After this fix, it works as expected:
```
>>> (executing lines 4 to 8 of "asdf.py")
  File "/tmp/aa/asdf.py", line 7
    z = x / y /
               ^
SyntaxError: invalid syntax
```

**Fixes**
There were two bugs:
1. The exception variable `value` cannot be directly unpacked in Python 3 -- this only worked in Python 2. Unpacking `value.args` instead works for all Python versions.
2. The tuple in `value.args[1]` got two extra values since Python v3.10 that contain `end_lineno` and `end_offset`. This was not accounted for.

I fixed both bugs.
