### PR TITLE
Fix foreground colour not resetting in the shell when using the ANSI foreground reset code

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -907,6 +907,8 @@ class BaseShell(BaseTextCtrl):
                 elif 30 <= param <= 37:  # Set foreground color
                     clr = CLRS[param - 30]
                     format.setForeground(QtGui.QColor(clr))
+                elif param == 39:  # Reset the foreground color
+                    format.clearForeground()
                 elif 40 <= param <= 47:
                     pass  # Cannot set background text in QPlainTextEdit
                 #


### PR DESCRIPTION
The foreground colour was not resetting in the shell when using the ANSI foreground reset code. Fixes #996 