### PR TITLE
extend showsyntaxerror for SyntaxError subclasses

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1100,7 +1100,7 @@ class PyzoInterpreter:
         del tb
 
         # Work hard to stuff the correct filename in the exception
-        if filename and type_ is SyntaxError:
+        if filename and issubclass(type_, SyntaxError):
             try:
                 # unpack information
                 msg = value.args[0]
@@ -1113,7 +1113,7 @@ class PyzoInterpreter:
                 pass
             else:
                 # Stuff in the right filename
-                value = SyntaxError(msg, (fname, lineno, offset, line))
+                value = type_(msg, (fname, lineno, offset, line))
                 sys.last_value = value
 
         # Show syntax error


### PR DESCRIPTION
When executing only selected lines, the line number is corrected for syntax errors. But this did not work for subclasses of `SyntaxError`, such as `IndentationError`.

For example, when running the middle cell of
```python3
pass
##

if True:
pass

##


```
The error message contained `File "<tmp 1>+2", line 3`.

After this fix, the corrected line number will be displayed in the error message:
`File "<tmp 1>", line 5`
