### PR TITLE
fix keyboard interrupt for active debugger

### DIFF
--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -113,11 +113,14 @@ class Debugger(bdb.Bdb):
         # Enter interact loop. We may hang in here for a while ...
         self._interacting = True
         while self._interacting:
-            time.sleep(0.05)
-            interpreter.process_commands()
-            pe = os.getenv("PYZO_PROCESS_EVENTS_WHILE_DEBUGGING", "").lower()
-            if pe in ("1", "true", "yes"):
-                interpreter.guiApp.process_events()
+            try:
+                time.sleep(0.05)
+                interpreter.process_commands()
+                pe = os.getenv("PYZO_PROCESS_EVENTS_WHILE_DEBUGGING", "").lower()
+                if pe in ("1", "true", "yes"):
+                    interpreter.guiApp.process_events()
+            except KeyboardInterrupt:
+                self.message("KeyboardInterrupt")
 
         # Reset
         self._debugmode = 0


### PR DESCRIPTION
Using the "Interrupt" ("Shell -> Interrupt" or Ctrl+I) while the interpreter is in debug mode will keep the shell stuck in the debugging mode.

Steps to reproduce the problem:
1. start a new shell in Pyzo
2. cause an exception, e.g. via running `assert False`
3. enter post-mortem debugging (e.g. via Ctrl+P)
4. select "Shell -> Interrupt" or press Ctrl+I
5. try to stop debugging via "Shell -> Stop debugging" --> not possible anymore

This problem also occurs for regular breakpoints instead of post-mortem.


This PR will fix the problem.