### PR TITLE
fix reload dialogs for PySide6

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -405,19 +405,17 @@ class PyzoEditor(BaseTextCtrl):
                 "File has been modified outside of the editor:\n" + self._filename
             )
             dlg.setInformativeText("Do you want to reload?")
-            t = dlg.addButton("Reload", QtWidgets.QMessageBox.AcceptRole)  # 0
-            dlg.addButton("Keep this version", QtWidgets.QMessageBox.RejectRole)  # 1
-            dlg.setDefaultButton(t)
+            btnReload = dlg.addButton("Reload", QtWidgets.QMessageBox.AcceptRole)
+            dlg.addButton("Keep this version", QtWidgets.QMessageBox.RejectRole)
+            dlg.setDefaultButton(btnReload)
 
             # whatever the result, we will reset the modified time
             self._modifyTime = os.path.getmtime(path)
 
             # get result and act
-            result = dlg.exec_()
-            if result == 0:  # in PySide6 AcceptRole != 0
+            dlg.exec_()
+            if dlg.clickedButton() == btnReload:
                 self.reload()
-            else:
-                pass  # when cancelled or explicitly said, do nothing
 
             # Return that indeed the file was changes
             return True

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1334,11 +1334,13 @@ class EditorTabs(QtWidgets.QWidget):
                 'Do you want to reload file\n"{}"\n'
                 "and lose unsaved changes?".format(editor.filename)
             )
-            dlg.addButton("Reload", QtWidgets.QMessageBox.AcceptRole)
-            btn = dlg.addButton("Keep this version", QtWidgets.QMessageBox.RejectRole)
-            dlg.setDefaultButton(btn)
-            btnIndex = dlg.exec_()
-            if btnIndex != 0:
+            btnReload = dlg.addButton("Reload", QtWidgets.QMessageBox.AcceptRole)
+            btnKeep = dlg.addButton(
+                "Keep this version", QtWidgets.QMessageBox.RejectRole
+            )
+            dlg.setDefaultButton(btnKeep)
+            dlg.exec_()
+            if dlg.clickedButton() != btnReload:
                 return  # cancel reloading
 
         editor.reload()


### PR DESCRIPTION
I have seen that the buttons of the dialogs "reloading of modified file" and "reload from disk" did not work anymore with PySide6 v6.7.1, and therefore I fixed that.