### PR TITLE
fix context menu behavior in editor

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -289,12 +289,10 @@ class PyzoEditor(BaseTextCtrl):
         # This timer is used to hide the marker that shows which code is executed
         self._showRunCursorTimer = QtCore.QTimer()
 
-        # Add context menu (the offset is to prevent accidental auto-clicking)
+        # Add context menu
         self._menu = EditorContextMenu(self)
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.customContextMenuRequested.connect(
-            lambda p: self._menu.popup(self.mapToGlobal(p) + QtCore.QPoint(0, 3))
-        )
+        self.customContextMenuRequested.connect(self._onContextMenu)
 
         # Update status bar
         self.cursorPositionChanged.connect(self._updateStatusBar)
@@ -427,6 +425,20 @@ class PyzoEditor(BaseTextCtrl):
 
     def _onModified(self):
         pyzo.parser.parseThis(self)
+
+    def _onContextMenu(self, point):
+        cur = self.textCursor()
+        curFromEvent = self.cursorForPosition(point)
+        moveTextCursor = True
+        if cur.hasSelection():
+            i1 = cur.selectionStart()
+            i2 = cur.selectionEnd()
+            if i1 <= curFromEvent.position() <= i2:
+                moveTextCursor = False
+        if moveTextCursor:
+            self.setTextCursor(curFromEvent)
+        # the offset is to prevent accidental auto-clicking
+        self._menu.popup(self.mapToGlobal(point) + QtCore.QPoint(0, 3))
 
     def _updateStatusBar(self):
         editor = pyzo.editors.getCurrentEditor()


### PR DESCRIPTION
When pressing the right mouse button or the [menu key](https://en.wikipedia.org/wiki/Menu_key) in the editor, the editor's context menu will appear.
With this PR, I will fix the behavior to be similar to other popular editors, which is more intuitive in my opinion.
When invoking the context menu by a right mouse click and when there was no text selected, the text cursor will be moved to the mouse cursor's position. All subsequent actions in the context menu, such as paste, indent, comment, run selection, ... will therefore operate on the new text cursor position. Before this PR, these actions were performed on the text cursor position no matter at which position the mouse was clicked at (except for "help on this expression"), so one had to first left click on the line to comment and then right click to open the context menu and then left click again to perform the "comment" action.
When invoking the context menu by a right mouse click, and there was text selected, and the mouse click happend at the selected text, then the text cursor will not be moved and the selection kept unchanged (so the same as the old behavior).
If the context menu was invoked via the menu key, Qt will automatically give the position of the text cursor instead of the mouse position, so there is no behavior change.