### PR TITLE
make codeeditor autoclose settings independent of pyzo

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -13,7 +13,6 @@ from ..qt import QtGui, QtCore
 
 Qt = QtCore.Qt
 
-import pyzo
 from ..misc import ce_option
 from ..parsers.tokens import (
     CommentToken,
@@ -484,6 +483,20 @@ class AutoCloseQuotesAndBrackets:
 
     """
 
+    def autoClose_Brackets(self):
+        return self.__autoClose_Brackets
+
+    @ce_option(False)
+    def setAutoClose_Brackets(self, value):
+        self.__autoClose_Brackets = value
+
+    def autoClose_Quotes(self):
+        return self.__autoClose_Quotes
+
+    @ce_option(False)
+    def setAutoClose_Quotes(self, value):
+        self.__autoClose_Quotes = value
+
     def _get_token_at_cursor(self, cursor=None, relpos=0):
         """Get token at the (current or given) cursor position. Can be None."""
         if cursor is None:
@@ -524,7 +537,7 @@ class AutoCloseQuotesAndBrackets:
         char = event.text()
 
         #  brackets
-        if char in brackets and pyzo.config.settings.autoClose_Brackets:
+        if char in brackets and self.__autoClose_Brackets:
             # Dont autobracket inside comments and strings
             if isinstance(
                 self._get_token_at_cursor(cursor),
@@ -575,7 +588,7 @@ class AutoCloseQuotesAndBrackets:
                     cursor.insertText(char)  # == super().keyPressEvent(event)
 
         # quotes
-        elif char in quotes and pyzo.config.settings.autoClose_Quotes:
+        elif char in quotes and self.__autoClose_Quotes:
             next_char = self.__getNextCharacter()
 
             # Don't autoquote inside comments and multiline strings
@@ -633,7 +646,7 @@ class AutoCloseQuotesAndBrackets:
 
         # remove whole couple of brackets when hitting backspace
         elif (
-            event.key() == Qt.Key_Backspace and pyzo.config.settings.autoClose_Brackets
+            event.key() == Qt.Key_Backspace and self.__autoClose_Brackets
         ):
             if isinstance(
                 self._get_token_at_cursor(cursor),

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -160,6 +160,8 @@ class BaseTextCtrl(CodeEditor):
             pyzo.config.settings.autoComplete_caseSensitive
         )
         self.setAutocompleteMinChars(pyzo.config.settings.autoComplete_minChars)
+        self.setAutoClose_Quotes(pyzo.config.settings.autoClose_Quotes)
+        self.setAutoClose_Brackets(pyzo.config.settings.autoClose_Brackets)
         self.setCancelCallback(self.restoreHelp)
 
     def setAutoCompletionAcceptKeysFromStr(self, keys):

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -2528,16 +2528,16 @@ class AutocompMenu(Menu):
                 "menu", "Auto close quotes ::: Auto close single and double quotes."
             ),
             None,
-            self._setQuotes,
-            None,
+            self._configEditor,
+            "autoClose_Quotes",
             pyzo.config.settings.autoClose_Quotes,
         )
 
         self.addCheckItem(
             translate("menu", "Auto close brackets ::: Auto close ( { [ ] } )."),
             None,
-            self._setBrackets,
-            None,
+            self._configEditor,
+            "autoClose_Brackets",
             pyzo.config.settings.autoClose_Brackets,
         )
 
@@ -2559,14 +2559,20 @@ class AutocompMenu(Menu):
     def _setCompleteKeywords(self, value):
         pyzo.config.settings.autoComplete_keywords = bool(value)
 
-    def _setQuotes(self, value):
-        # Set automatic insertion of single and double quotes
-        pyzo.config.settings.autoClose_Quotes = bool(value)
-
-    def _setBrackets(self, value):
-        # Set automatic insertion of parenthesis, braces and brackets
-        pyzo.config.settings.autoClose_Brackets = bool(value)
-
+    def _configEditor(self, state, param):
+        """
+        Callback for code editor settings
+        """
+        # Store this parameter in the config
+        setattr(pyzo.config.settings, param, state)
+        # Apply to all editors and shells and the logger tool
+        setter = "set" + param[0].upper() + param[1:]
+        codeEditorList = list(pyzo.editors) + list(pyzo.shells)
+        logger = pyzo.toolManager.getTool("pyzologger")
+        if logger is not None:
+            codeEditorList.append(logger._logger_shell)
+        for editor in codeEditorList:
+            getattr(editor, setter)(state)
 
 class SettingsMenu(Menu):
     def build(self):


### PR DESCRIPTION
The autoclose settings were not implemented in a clean way -- the `codeeditor` module had hardcoded access to the `pyzo` module to get the settings. I changed this to be more like other editor settings.
After this PR, there is no more dependency of the `codeeditor` module on `pyzo` (except qt.py).