### PR TITLE
fix breakpoints and stepping after interruption in list comprehension

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1051,6 +1051,7 @@ class PyzoInterpreter:
                 for fname in breaks:
                     for linenr in breaks[fname]:
                         self.debugger.set_break(fname, linenr)
+            if breaks or self.debugger._last_db_command in ("step", "next", "return"):
                 sys.settrace(self.debugger.trace_dispatch)
         except Exception:
             type, value, tb = sys.exc_info()


### PR DESCRIPTION
There was an issue when the debugger is activated inside a list comprehension (not mater if by breakpoint or pause).
The problem only occurs for 3.0 <= PythonVersion < 3.12 -- with Python 2.7 and 3.12 there would be no need for the workaround implemented in this PR.

The following example can be used to reproduce the problem and test the fix:
```python3
# run the following code without any breakpoints:
[breakpoint() for _ in range(1)]
# [breakpoint()]  # this does not cause any problem
x = 1
y = 2  # set a breakpoint in this line once stopped in the upper breakpoint()
```

And there was another issue, also when the debugger is activated inside a list comprehension: Continuing execution via stepping did not work. I also fixed that.