### PR TITLE
allow "clear all breakpoints" action also in debug mode

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1415,10 +1415,9 @@ class ShellMenu(Menu):
         for e in pyzo.editors:
             bpcount += len(e.breakPoints())
         self._debug_clear.setText(self._debug_clear_text.format(bpcount))
-        # Determine state of PM and clear button
+        # Determine state of PM button
         debugmode = pyzo.shells._debugmode
         self._debug_pm.setEnabled(debugmode == 0)
-        self._debug_clear.setEnabled(debugmode == 0)
         # The _shellDebugActions are enabled/disabled by the shellStack
 
     def _shellAction(self, action):


### PR DESCRIPTION
I see no reason why the menu entry for clearing all breakpoints was disabled during debug mode. Breakpoints can be removed one by one anyways, and breakpoints are updated always when executing new code or running a debug command.
It is more comfortable to have that action always enabled, for example to be able to continue execution in full speed mode (without tracing).