### PR TITLE
refer to GH discussions rather than google groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ If you want to help out, create an issue or pull request on GitHub.
 
 * main website: https://pyzo.org
 * code repository: https://github.com/pyzo/pyzo
-* mailing list: https://groups.google.com/group/pyzo
+* issues: * questions: https://github.com/pyzo/pyzo/issues
+* questions: https://github.com/pyzo/pyzo/discussions

--- a/pyzo/resources/tutorial.py
+++ b/pyzo/resources/tutorial.py
@@ -3,7 +3,7 @@
 Welcome to the tutorial for Pyzo! This tutorial should get you
 familiarized with Pyzo in just a few minutes. If you feel this tutorial
 contains errors or lacks some information, please let us know via
-pyzo@googlegroups.com.
+https://github.com/pyzo/pyzo/discussions.
 
 Pyzo is a cross-platform Python IDE focused on interactivity and
 introspection, which makes it very suitable for scientific computing.


### PR DESCRIPTION
Closes #1021

I also updated the main website at https://pyzo.org

This does require people who want to ask a question to create a GH account. But for the target audience that seems fine.