### PR TITLE
improve source structure tool

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -250,6 +250,9 @@ class PyzoEditor(BaseTextCtrl):
     # called when dirty changed or filename changed, etc
     somethingChanged = QtCore.Signal()
 
+    def __repr__(self):  # just for easier debugging
+        return "<{} - {}, {}>".format(self.__class__.__qualname__, id(self), self.name)
+
     def __init__(self, parent, **kwds):
         super().__init__(parent, showLineNumbers=True, **kwds)
 

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1136,14 +1136,14 @@ class ViewMenu(Menu):
         self._nextTopLevelObject(type="cell")
 
     def _previousTopLevelObject(self, type=None):
-        # Get parser result
-        result = pyzo.parser._getResult()
-        if not result:
-            return
-
         # Get editor
         editor = pyzo.editors.getCurrentEditor()
         if not editor:
+            return
+
+        # Get parser result
+        result = pyzo.parser._getResult(editor)
+        if not result:
             return
 
         # Get current line number
@@ -1176,14 +1176,14 @@ class ViewMenu(Menu):
                 return
 
     def _nextTopLevelObject(self, type=None):
-        # Get parser result
-        result = pyzo.parser._getResult()
-        if not result:
-            return
-
         # Get editor
         editor = pyzo.editors.getCurrentEditor()
         if not editor:
+            return
+
+        # Get parser result
+        result = pyzo.parser._getResult(editor)
+        if not result:
             return
 
         # Get current line number

--- a/pyzo/qt/__init__.py
+++ b/pyzo/qt/__init__.py
@@ -257,3 +257,5 @@ elif PYSIDE_VERSION:
         _warn_old_minor_version("PySide2", PYSIDE_VERSION, PYSIDE2_VERSION_MIN)
     elif PYSIDE6 and (parse(PYSIDE_VERSION) < parse(PYSIDE6_VERSION_MIN)):
         _warn_old_minor_version("PySide6", PYSIDE_VERSION, PYSIDE6_VERSION_MIN)
+
+from . import qtutils

--- a/pyzo/qt/qtutils.py
+++ b/pyzo/qt/qtutils.py
@@ -1,0 +1,29 @@
+from . import PYQT6, PYQT5, PYSIDE2, PYSIDE6, PythonQtError
+
+
+if PYSIDE2 or PYSIDE6:
+
+    if PYSIDE2:
+        import shiboken2 as _shiboken
+    else:
+        import shiboken6 as _shiboken
+
+    def isDeleted(qtObj):
+        return not _shiboken.isValid(qtObj)
+
+    def isOwnedByPython(qtObj):
+        return _shiboken.isOwnedByPython(qtObj)
+
+
+elif PYQT5 or PYQT6:
+
+    if PYQT5:
+        import PyQt5.sip as _sip
+    elif PYQT6:
+        import PyQt6.sip as _sip
+
+    def isDeleted(qtObj):
+        return _sip.isdeleted(qtObj)
+
+    def isOwnedByPython(qtObj):
+        return _sip.ispyowned(qtObj)


### PR DESCRIPTION
Before this PR, the source structure tool did not update the cursor when just navigating around without editing the text. So I implemented this and some other features and optimizations:
- update of the selected item in the tree widget even when just navigating
- improved performance (e.g. by caching)
- output of the current (nested) class/method/function in the status bar
- added module pyzo.qt.qtutils with functions isOwnedByPython and isDeleted
- added results buffer to parser because there were sometimes timing problems

I recommend to have the status bar activated. Then the source structure tool will give you information about the current class, method and function. For example when setting the cursor in funtion `getBlocks` in pyzo/core/editor.py, then the following message will be printed to the status bar:
Source structure:    class PyzoEditor --> def toggleCommentCode() --> def toggleComment() --> def getBlocks()