### PR TITLE
improve auto-completion and call-tips, and add key-completion

### DIFF
--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -393,14 +393,6 @@ class BaseTextCtrl(CodeEditor):
             qtKeys.append(QtCore.Qt.Key.Key_Return)
         self.setAutoCompletionAcceptKeys(*qtKeys)
 
-    def _isValidPython(self):
-        """Check if the code at the cursor is valid python:
-        - the active lexer is the python lexer
-        - the style at the cursor is "default"
-        """
-        # TODO:
-        return True
-
     def getTokensUpToCursor(self, cursor):
         # In order to find the tokens, we need the userState from the highlighter
         if cursor.block().previous().isValid():
@@ -547,10 +539,6 @@ class BaseTextCtrl(CodeEditor):
         """Overridden in derive class"""
         pass
 
-    def _onDoubleClick(self):
-        """When double clicking on a name, autocomplete it."""
-        self.processHelp(addToHist=True)
-
     def helpOnText(self, pos):
         hw = pyzo.toolManager.getTool("pyzointeractivehelp")
         if not hw:
@@ -573,10 +561,9 @@ class BaseTextCtrl(CodeEditor):
         if name != "":
             hw.setObjectName(name, True)
 
-    def processHelp(self, name=None, showError=False, addToHist=False):
+    def processHelp(self, name, showError=False, addToHist=False):
         """Show help on the given full object name.
         - called when going up/down in the autocompletion list.
-        - called when double clicking a name
         """
         # uses parse_autocomplete() to find baseName and objectName
 
@@ -588,20 +575,6 @@ class BaseTextCtrl(CodeEditor):
         # Both should exist
         if not hw or not shell:
             return
-
-        if not name:
-            # Obtain name from current cursor position
-
-            # Is this valid python?
-            if self._isValidPython():
-                # Obtain line from text
-                cursor = self.textCursor()
-                line = cursor.block().text()
-                text = line[: cursor.positionInBlock()]
-                # Obtain
-                nameTokens, needleToken = parseLine_autocomplete(text)
-                if nameTokens:
-                    name = "{}.{}".format("".join([str(t) for t in nameTokens]), needleToken)
 
         if name:
             hw.helpFromCompletion(name, addToHist)

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -198,6 +198,16 @@ class PyzoIntrospector(yoton.RepChannel):
 
         return sigs, kind
 
+    def dirWithIntermediateResult(self, objectName):
+        cacheVarName = "__pyzo__autocomp"
+        try:
+            command = cacheVarName + " = " + str(objectName)
+            exec(command, sys._pyzoInterpreter.globals, sys._pyzoInterpreter.locals)
+        except Exception:
+            return []
+        else:
+            return self.dir(cacheVarName)
+
     # todo: variant that also says whether it's a property/function/class/other
     def dir(self, objectName):
         """Get list of attributes for the given name."""
@@ -240,6 +250,16 @@ class PyzoIntrospector(yoton.RepChannel):
 
         # Respond
         return list(names)
+
+    def dir2WithIntermediateResult(self, objectName):
+        cacheVarName = "__pyzo__autocomp"
+        try:
+            command = cacheVarName + " = " + str(objectName)
+            exec(command, sys._pyzoInterpreter.globals, sys._pyzoInterpreter.locals)
+        except Exception:
+            return []
+        else:
+            return self.dir2(cacheVarName)
 
     def dir2(self, objectName):
         """Get variable names in currently active namespace plus extra information.
@@ -339,6 +359,16 @@ class PyzoIntrospector(yoton.RepChannel):
 
         except Exception:
             return []
+
+    def signatureWithIntermediateResult(self, objectName):
+        cacheVarName = "__pyzo__calltip"
+        try:
+            command = cacheVarName + " = " + str(objectName)
+            exec(command, sys._pyzoInterpreter.globals, sys._pyzoInterpreter.locals)
+        except Exception:
+            return None
+        else:
+            return self.signature(cacheVarName)
 
     def signature(self, objectName):
         """Get signature."""


### PR DESCRIPTION
This PR adds some handy auto-completion features to Pyzo:

- better working call-tips for complex expressions like `abc = (myfunc(x + ((y + 2) + otherfunc(1, 2) - `
- key auto-completion (for dictionaries, lists and similar objects)
- auto-completion and calltips using a cached evaluated object, using the new shortcut Ctrl+Space

Examples for cached auto-completion:

Type `locals().` (with the **dot** at the end) and press Ctrl+Space. This will evaluate `locals()` and assign the result to `__pyzo__autocomp` in the local scope. Then auto-completion continues and displays the list widget with the **attributes**.

Type `locals()[` (with the **open bracket** at the end) and press Ctrl+Space. This will evaluate `locals()` and assign the result to `__pyzo__autocomp` in the local scope. Then auto-completion continues and displays the list widget with the **keys**.

Type `locals().get(` (with the **open parenthesis** at the end) and press Ctrl+Space. This will evaluate `locals()` and assign the result to **`__pyzo__calltip`** in the local scope. Then auto-completion continues and displays the **calltip** for `dict.get(...)`.

The new Ctrl+Spacehot key can also be pressed while having already entered some characters of the attribute, key or arguments, in case someone cancelled the autocompletion list widget resp. calltip and wants to show it again

I chose this approach with manually pressing the new hotkey instead of automatically evaluating the expression because the latter could unintendedly and silently modify the data, for example with the `pop()` in `mylist = [1, 'b', ()]; mylist.pop().count(`.
The old auto-completer for attribute-look-up also evaluated expressions during auto-completion, but only for simpler expressions and without caching -- properties and methods like `__getattribute__` were called multiple times in the background, and still are, but only for simple expressions.
Key-auto-completion will, like attribute-auto-completion and calltips, also work for simple expressions without pressing a hot-key.