### PR TITLE
apply keys introspection to objects with keys method

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -45,8 +45,8 @@ class PyzoIntrospector(yoton.RepChannel):
                 ob = eval(name, None, NS)
 
                 # Get namespace for this object
-                if isinstance(ob, dict):
-                    NS = {"[" + repr(el) + "]": ob[el] for el in ob}
+                if isinstance(ob, dict) or hasattr(ob, "keys"):  # os.environ is no dict but has keys
+                    NS = {"[" + repr(el) + "]": ob[el] for el in ob.keys()}
                 elif isinstance(ob, (list, tuple)):
                     NS = {}
                     count = -1


### PR DESCRIPTION
The keys for non-dicts like `os.environ` or pandas dataframes can then be seen in the Workspace tool and used for key autocompletion.