### PR TITLE
keep vertical scroll bar position when copying text

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -390,7 +390,14 @@ class SmartCopyAndPaste:
                 else:
                     self.__setCursorPositionAndAnchor(cursor, start, end)
 
+                # Setting the textcursor might scroll to another place
+                # (e.g. Ctrl+A, Ctrl+C would scroll to the very bottom).
+                # To prevent this, we store and then restore the position
+                # of the vertical scrollbar
+                sb = self.verticalScrollBar()
+                scrollbarPos = sb.value()
                 self.setTextCursor(cursor)
+                sb.setValue(scrollbarPos)
 
         # Call our supers copy slot to do the actual copying
         super().copy()


### PR DESCRIPTION
Currently, copying text in a text editor or shell will scroll to the end of the selected text.
For example, when opening a larger script (scrolled to the top) and pressing Ctrl+A and Ctrl+C, the editor/shell will be suddenly scrolled to the very bottom.
This is not normal behavior but a side effect of the overloaded `copy` method that implements the "smart copy" feature.

With this PR, the scroll position will be kept in such cases.