### PR TITLE
keep vertical scroll bar position when saving in the editor

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -502,6 +502,7 @@ class PyzoEditor(BaseTextCtrl):
             editCursor = self.textCursor()
             # Go!
             editCursor.beginEditBlock()
+
             try:
                 editCursor.setPosition(screenCursor.selectionStart())
                 editCursor.movePosition(editCursor.MoveOperation.StartOfBlock)
@@ -521,8 +522,14 @@ class PyzoEditor(BaseTextCtrl):
                         break
                     editCursor.movePosition(editCursor.MoveOperation.NextBlock)
             finally:
+                # Setting the textcursor might scroll to another place
+                # To prevent this, we store and then restore the position
+                # of the vertical scrollbar
+                sb = self.verticalScrollBar()
+                scrollbarPos = sb.value()
                 self.setTextCursor(oricursor)
                 editCursor.endEditBlock()
+                sb.setValue(scrollbarPos)
 
         # Get text and convert line endings
         text = self.toPlainText().replace("\n", self.lineEndings)


### PR DESCRIPTION
When saving in the editor (e.g. Ctrl+S) the Pyzo editor always scrolled to a position where the text cursor was visible. This was a side effect of `removeTrailingWS`.

I fixed that by saving and restoring the position of the vertical scrollbar.