### PR TITLE
do not hide calltip on mouse hover

### DIFF
--- a/pyzo/codeeditor/extensions/calltip.py
+++ b/pyzo/codeeditor/extensions/calltip.py
@@ -29,10 +29,6 @@ class Calltip:
             self.setIndent(2)
             self.setWindowFlags(QtCore.Qt.WindowType.ToolTip)
 
-        def enterEvent(self, event):
-            # Act a bit like a tooltip
-            self.hide()
-
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
         # Create label for call tips


### PR DESCRIPTION
Before this PR, moving the mouse cursor over the calltip closed the calltip.
The problem with that approach was that, before any calltip is active, a calltip would immediately be closed/hidden during typing when the mouse cursor was left in an unfavorable position before (inside the rectangle where the calltip would normally appear).
There are already many ways to close the calltip, for example finishing the parenthesis expression for the call, or pressing the ESC key, or clicking outside the text editor widget.
I had a look at other editors that show calltips and none of them closed the calltip on a mouse hover event (and also not on a mouse click event).

Therefore, this PR will remove the close on mouse hover mechanism for the calltips.