### PR TITLE
Autocomp mac

### DIFF
--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -644,8 +644,11 @@ class BaseTextCtrl(CodeEditor):
         self._delayTimer._line = ""
 
         # Invoke advanced autocomplete/calltips Ctrl+Space key combination?
-        hascontrol = event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier or event.modifiers() & QtCore.Qt.KeyboardModifier.MetaModifier
-        if (hascontrol and event.key() == QtCore.Qt.Key.Key_Space):
+        has_control = (
+            event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier or
+            event.modifiers() & QtCore.Qt.KeyboardModifier.MetaModifier
+        )
+        if (has_control and event.key() == QtCore.Qt.Key.Key_Space):
             cursor = self.textCursor()
             if cursor.position() == cursor.anchor():
                 text = cursor.block().text()[: cursor.positionInBlock()]

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -644,8 +644,8 @@ class BaseTextCtrl(CodeEditor):
         self._delayTimer._line = ""
 
         # Invoke advanced autocomplete/calltips Ctrl+Space key combination?
-        if (event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier
-                and event.key() == QtCore.Qt.Key.Key_Space):
+        hascontrol = event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier or event.modifiers() & QtCore.Qt.KeyboardModifier.MetaModifier
+        if (hascontrol and event.key() == QtCore.Qt.Key.Key_Space):
             cursor = self.textCursor()
             if cursor.position() == cursor.anchor():
                 text = cursor.block().text()[: cursor.positionInBlock()]


### PR DESCRIPTION
Changes the shortcut introduced in #1030, so it also works on MacOS.

----

The `ControlModifier` binds to the  `Command` key on MacOS (because in most use-cases that key is used where Windows users use `Control`, e.g. `Command+S` for saving a file).

The `Command+space` is a reserved key binding on MacOS that opens the spotlight. Therefore Pyzo cannot capture the `Command+space` shortcut.

In VSCode they had the same problem, and solved it by introducing `Command/Control + I` (capital i). However, we already use that for terminating the shell.

So this PR makes that it works with the actual `Control` key on MacOS (The `MetaModifier` means `Ctrl` on MacOS and Windows key on Windows/Linux).