### PR TITLE
fix introspection of non-numeric numpy elements

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -317,10 +317,9 @@ class PyzoIntrospector(yoton.RepChannel):
                             values_repr,
                         )
                     elif val.size:
-                        tmp = str(float(val))
-                        if "int" in val.dtype.name:
-                            tmp = str(int(val))
-                        repres = "<array scalar %s (%s)>" % (val.dtype.name, tmp)
+                        # val can be a non-numeric or structured type as well, e.g.:
+                        #     val = np.array(['abc'], dtype=np.dtype('U3'))[0]
+                        repres = "<array scalar %s (%s)>" % (val.dtype.name, str(val))
                     else:
                         repres = "<array empty %s>" % (val.dtype.name)
                 elif kind == "list":


### PR DESCRIPTION
Introspection of numpy array elements (scalars) failed for special types such as `np.dtype('U3')` (U3 ... three unicode characters).
This resulted in variables not showing up in the workspace tool.
For example:
```python3
import numpy as np
val = np.array(['abc'], dtype=np.dtype('U3'))[0]  # val did not show up in the workspace tool
```

This PR fixes the problem, and this also fixes issue #1051.
