### PR TITLE
improve signature extraction for calltips

### DIFF
--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -109,6 +109,10 @@ class PyzoIntrospector(yoton.RepChannel):
             tmp = eval("%s.__doc__" % (objectNames[-1]), {}, NS)
             sigs = ""
             if tmp:
+                # we need the lstrip for docstrings like the one of np.where:
+                #   np.where.__doc__[:34] == '\n    where(condition, [x, y], /)\n\n'
+                tmp = tmp.lstrip()
+
                 # we will try joining several lines because doc strings of objects
                 # like np.array have a new line inside the signature
                 for line in tmp.splitlines()[:3]:


### PR DESCRIPTION
I have encountered some numpy functions where calltips do not work.

This PR will strip the docstring before trying to get the signature from the first lines because some of them start with a newline and whitespace, e.g.:
`>>> np.where.__doc__[:34]`
`'\n    where(condition, [x, y], /)\n\n'`

With this PR, the following numpy functions will also have a calltip shown:
`bincount`, `can_cast`, `copyto`, `datetime_as_string`, `dot`, `empty_like`, `inner`, `lexsort`, `may_share_memory`, `min_scalar_type`, `packbits`, `putmask`, `ravel_multi_index`, `result_type`, `shares_memory`, `unpackbits`, `unravel_index`, `vdot`, `where`
