### PR TITLE
remove old workaround for shortcuts now causing issues

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -236,9 +236,6 @@ class KeyMapper(QtCore.QObject):
             # Set shortcut so Qt can do its magic
             shortcuts = pyzo.config.shortcuts2[action.menuPath]
             action.setShortcuts(shortcuts.split(","))
-            pyzo.main.addAction(
-                action
-            )  # issue #470, http://stackoverflow.com/questions/23916623
             # Also store shortcut text (used in display of tooltip
             shortcuts = shortcuts.replace(",", ", ").replace("  ", " ")
             action._shortcutsText = shortcuts.rstrip(", ")


### PR DESCRIPTION
Old issue #470 seems to be fixed in Qt 5.15 LTS and Qt 6. Old workaround causes error "QAction::event: Ambiguous shortcut overload" now in latest Qt versions, at least when creating shortcuts for actions like "tool selection".

Fixes #1059.