### PR TITLE
fix interactive help via context menu, and fix inital text

### DIFF
--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -557,6 +557,8 @@ class BaseTextCtrl(CodeEditor):
             nameTokens, needleToken = parseLine_autocomplete(tokens)
             if nameTokens:
                 name = "{}.{}".format("".join([str(t) for t in nameTokens]), needleToken)
+            elif needleToken:
+                name = str(needleToken)
 
         if name != "":
             hw.setObjectName(name, True)

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -338,8 +338,9 @@ initText = pyzo.translate(
     "pyzoInteractiveHelp",
     """
 Help information is queried from the current shell
-when moving up/down in the autocompletion list
-and when double clicking on a name.
+automatically when moving up/down in the autocompletion list,
+or manually via the context menu in the shell and editor,
+or via the Workspace tool.
 """,
 )
 


### PR DESCRIPTION
The interactive help via the context menu only worked for selected text in the shell or editor, or for non-selected text under the mouse cursor if there was at least one dot in the simple expression (such as `foo.bar`). With this fix, it will also work for simple expressions without a dot (single variable).

And the initial text of the Interactive help tool stated that double clicking a name would trigger the interactive help, but this is not true (anymore). Therefore I fixed that as well.
