### PR TITLE
avoid duplicated closing quote or paren on key autocompletion

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -166,6 +166,16 @@ class AutoCompletion:
         cursor = self.textCursor()
         cursor.setPosition(self.__autocompleteStart.position(), cursor.MoveMode.KeepAnchor)
         # Replace it with the selected text
+
+        # get the character that would be on the right of the cursor after auto completion
+        i = cursor.positionInBlock() + len(cursor.selectedText())
+        charAfterAutoCompText = cursor.block().text()[i : i + 1]
+
+        if text[-1] in "'\")" and text[-1] == charAfterAutoCompText:
+            # remove the duplicated closing quote resp. closing parenthesis
+            # ... during key autocompletion with a string literal or tuple
+            text = text[:-1]
+
         cursor.insertText(text)
         self.autocompleteAccept()  # Reset the completer
 


### PR DESCRIPTION
When "Auto close quotes" or "Auto close brackets" is activated and triggering key autocompletion for a dict like
`dd = {'abc': 0, "d'ef": 0, (1, 2): 3}`
by typing `dd['` there will be the characters `dd['']` and an autocompletion list with the single entry `'abc'`.
Accepting the completion suggestion by pressing TAB will then result in `dd['abc'']` with the closing quote twice: one because of the autocompletion entry and one that was there before from auto closing quotes.
The same happens for parens: After typing `dd[(` there will be the text `dd[()]` and the completion list with entry `(1, 2)`. Accepting the suggestion will result in `dd[(1, 2))]`.

This PR will fix that double closing quote (for single and double quotes) and that double closing parenthesis.
