### PR TITLE
fix wrong enum for Qt6 in styles.py

### DIFF
--- a/pyzo/codeeditor/style.py
+++ b/pyzo/codeeditor/style.py
@@ -213,7 +213,7 @@ class StyleFormat:
             if val in ["yes", "true"]:
                 self._linestyle = Qt.PenStyle.SolidLine
             elif val in ["dotted", "dot", "dots", "dotline"]:
-                self._linestyle = Qt.DotLine
+                self._linestyle = Qt.PenStyle.DotLine
             elif val in ["dashed", "dash", "dashes", "dashline"]:
                 self._linestyle = Qt.PenStyle.DashLine
             else:


### PR DESCRIPTION
This fixes a bug that caused different styles such as dark mode not to work.