### PR TITLE
fix calltips and autocompletion crash with Qt6 on Wayland

### DIFF
--- a/pyzo/codeeditor/extensions/calltip.py
+++ b/pyzo/codeeditor/extensions/calltip.py
@@ -18,8 +18,8 @@ class Calltip:
     ]
 
     class __CalltipLabel(QtWidgets.QLabel):
-        def __init__(self):
-            super().__init__()
+        def __init__(self, parent):
+            super().__init__(parent)
 
             # Start hidden
             self.hide()
@@ -31,8 +31,8 @@ class Calltip:
 
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
-        # Create label for call tips
-        self.__calltipLabel = self.__CalltipLabel()
+        # Create label for call tips  -- it needs a parent, otherwise it will cause a crash on Linux with Wayland
+        self.__calltipLabel = self.__CalltipLabel(self)
         # Be notified of style updates
         self.styleChanged.connect(self.__afterSetStyle)
 


### PR DESCRIPTION
As reported in #1068, Pyzo crashed when triggering the calltips text on Linux with Qt6, Wayland and gdm3.
I could reproduce the problem with such a setup, and I also found that Pyzo also crashed when triggering the autocompletion pop-up lists.

The first problem (calltips crash) was quite easy to fix -- after adding the parents assignment for the QLabel tooltip object, the crashes did not happen anymore.

The second problem was quite tricky to fix. I had to implement a specific workaround for the autocompletion pop-up list.
This workaround normally would also work on other operating systems, but to be on the safe side, I limited this workaround to be used only for Wayland environments.