### PR TITLE
fix autocompletion for numeric keys

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -208,7 +208,7 @@ class AutoCompletion:
                 i += 1
                 charRight = line[i : i + 1]
 
-        if text.isdecimal():
+        if not text.isidentifier():
             # e.g. key autocompletion with list index
             isKeyAutocompletion = True
 

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -501,6 +501,10 @@ class BaseTextCtrl(CodeEditor):
             nameTokens, needleToken = parseLine_autocomplete(tokens)
             keyLookUp = False
 
+            if not nameTokens and not str(needleToken).isidentifier():
+                # nameTokens could be None or []
+                nameTokens = None  # force key-auto-completion (for indices, and numeric keys)
+
             if nameTokens is None:
                 # no auto-completion for a name or attribute found --> try key-auto-completion instead
                 keyLookUp = True


### PR DESCRIPTION
This PR will make it possible to properly use key autocompletion with, for example, negative numbers, numbers with multiple digits, numbers with a decimal point etc..