### PR TITLE
improve freeze instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ via the Python package manager, e.g.:
 To run Pyzo, execute:  
 `python3 -m pyzo`
 
+#### Building your own binary executable of Pyzo
+
+If you prefer a binary version of Pyzo instead of running Pyzo directly from soure or downloading a release then you can
+build your own Pyzo executable:  
+Download the [source code](https://github.com/pyzo/pyzo/archive/refs/heads/main.zip) and follow the
+instructions in the comment block on top of [pyzo_freeze.py](https://github.com/pyzo/pyzo/blob/main/freeze/pyzo_freeze.py).
+Basically, this is just  
+`pip install --upgrade pip pyside6 pyinstaller dialite` and executing pyzo_freeze.py.
+
 
 ### License
 

--- a/freeze/pyzo_freeze.py
+++ b/freeze/pyzo_freeze.py
@@ -1,19 +1,29 @@
 #!/usr/bin/env python3
 
 """ PyInstaller script
+
+You can build a binary executable of Pyzo yourself:
+
+* Install the dependencies, for example by typing the following line in a shell in Pyzo:
+pip install --upgrade pip pyside6 pyinstaller dialite
+
+* Run this script.
+
+* The result is in the "dist" folder, in the same directory as this script.
+
 """
 
 import os
 import sys
 import shutil
-
+import inspect
 
 # Definitions
 name = "pyzo"
 qt_api = os.getenv("PYZO_QT_API", "PySide6")
-this_dir = os.path.abspath(os.path.dirname(__file__)) + "/"
-exe_script = this_dir + "boot.py"
-dist_dir = this_dir + "dist/"
+this_dir = os.path.abspath(os.path.dirname(inspect.getfile(inspect.currentframe())))
+exe_script = os.path.join(this_dir, "boot.py")
+dist_dir = os.path.join(this_dir, "dist")
 icon_file = os.path.abspath(
     os.path.join(this_dir, "..", "pyzo", "resources", "appicons", "pyzologo.ico")
 )


### PR DESCRIPTION
This PR adds some instructions for freezing Pyzo (e.g. building "Pyzo.exe" on MS Windows).
In pyzo_freeze.py I replaced "\_\_file\_\_" with an `inspect` expression so that the script can be normally executed inside Pyzo without the need of "Run file as script".