### PR TITLE
fix errors that occurred when dropping text in the shell

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -557,7 +557,7 @@ class BaseShell(BaseTextCtrl):
     def dragEnterEvent(self, event):
         """We only support copying of the text"""
         if event.mimeData().hasText():
-            event.setDropAction(QtCore.Qt.CopyAction)
+            event.setDropAction(QtCore.Qt.DropAction.CopyAction)
             event.accept()
 
     def dragMoveEvent(self, event):

--- a/pyzo/qt/QtGui.py
+++ b/pyzo/qt/QtGui.py
@@ -15,6 +15,7 @@ elif API == "PyQt5":
 
 if API in ("PySide2", "PyQt5"):
     QMouseEvent.position = lambda self: _QPointF(self.pos())
+    QDropEvent.position = QDropEvent.posF
 
     # For Qt5 we need something like QFontDatabase = QFontDatabase()
     # but with instance creation just when first accessing the class.


### PR DESCRIPTION
This PR fixes two bugs that occurred when drag'n'dropping some selected text with the mouse into the shell widget.

One error was when using PyQt6 because of the missing fully qualified enum.
The other error was when using Qt5 because of the new `QDropEvent.position` method which only exists in Qt6.