### PR TITLE
add "Save a copy as..." menu entry for creating file backups

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -553,6 +553,14 @@ class PyzoEditor(BaseTextCtrl):
         # allow item to update its texts (no need: onModifiedChanged does this)
         # self.somethingChanged.emit()
 
+    def saveCopy(self, filepath):
+        """Creates a backup of the current editor's contents. No checking is done."""
+
+        text = self.toPlainText().replace("\n", self.lineEndings)
+        bb = text.encode(self.encoding)
+        with open(filepath, "wb") as f:
+            f.write(bb)
+
     def reload(self):
         """Reload text using the self._filename.
         We do not have a load method; we first try to load the file

--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -539,6 +539,10 @@ def loadIcons():
     artist.addLayer("arrow_refresh")
     pyzo.icons["reload_file_from_disk"] = artist.finish()
 
+    artist = IconArtist("page_white_copy")
+    artist.addLayer("overlay_disk")
+    pyzo.icons["save_copy_as"] = artist.finish()
+
 
 def loadFonts():
     """Load all fonts that come with Pyzo."""

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -610,6 +610,13 @@ class FileMenu(Menu):
                 pyzo.editors.saveFileAs,
             ),
             self.addItem(
+                translate(
+                    "menu", "Save a copy as... ::: Create a backup of the current editor's contents."
+                ),
+                icons.save_copy_as,
+                lambda: pyzo.editors.saveFileAs(saveCopyAs=True),
+            ),
+            self.addItem(
                 translate("menu", "Save all ::: Save all open files."),
                 icons.disk_multiple,
                 pyzo.editors.saveAllFiles,


### PR DESCRIPTION
This PR adds a menu entry to create a backup of the current editor's contents, without modifying the editor's state.
And the file-save-as dialog, which is also used for saving the copy, now suggests not only the directory but also the filename if the current editor already had one before.

This feature was suggested by a user from the FreeCAD forum.
As far as I have seen, programs such as Notepad++, Gimp and LibreOffice also have such a feature.

I will wait around one week before merging this, so that there is time for review and suggestions.