### PR TITLE
exclude broken PySide6 6.8.0 from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           # Main test builds, 3 OS's times 4 Qt toolkits
           - os: windows-latest
             pyversion: '3.12'
-            qtlib: pyside6
+            qtlib: pyside6!=6.8.0
           - os: windows-latest
             pyversion: '3.11'
             qtlib: pyqt6
@@ -53,7 +53,7 @@ jobs:
           # ---
           - os: ubuntu-latest
             pyversion: '3.12'
-            qtlib: pyside6
+            qtlib: pyside6!=6.8.0
           - os: ubuntu-latest
             pyversion: '3.11'
             qtlib: pyqt6
@@ -66,7 +66,7 @@ jobs:
           # ---
           - os: macos-latest
             pyversion: '3.12'
-            qtlib: 'pyside6'
+            qtlib: pyside6!=6.8.0
           - os: macos-latest
             pyversion: '3.11'
             qtlib: pyqt6
@@ -86,7 +86,7 @@ jobs:
             qtlib: pyside6
           - os: windows-latest
             pyversion: '3.9'
-            qtlib: pyside6
+            qtlib: pyside6!=6.8.0
     steps:
     - uses: actions/checkout@v4
     - name: Setup os


### PR DESCRIPTION
PySide6 6.8.0 is broken, see issue #1088.
I will exclude it from the CI workflow for now, but keep it in the CD workflow.