### PR TITLE
fix boot.py for new qt wrapper

### DIFF
--- a/freeze/boot.py
+++ b/freeze/boot.py
@@ -105,10 +105,9 @@ with BootAction("Applying pre-import Qt tweaks"):
     importlib.import_module("pyzo.pre_qt_import")
 
 
+# let Pyzo fail early if there are problems with Qt
 with BootAction("Importing Qt"):
-    QtCore = importlib.import_module("pyzo.qt." + "QtCore")
-    QtGui = importlib.import_module("pyzo.qt." + "QtGui")
-    QtWidgets = importlib.import_module("pyzo.qt." + "QtWidgets")
+    importlib.import_module("pyzo.qt")
 
 
 with BootAction("Running Pyzo"):


### PR DESCRIPTION
For freezing Pyzo, file "boot.py" needs a fix to work with the new Qt wrapper, introduced via #1091.

The command `importlib.import_module("pyzo.qt.QtCore")` does not work anymore.
But as far as I have seen, it is not necessary, because the Qt modules will be imported later anyways.

@almarklein
Was there a special reason to do the Qt imports in boot.py (except the pre_qt_import)?
If there was an exception during importing the Qt libraries, the `BootAction("Running Pyzo")` would show the error message box anyways.

In case the import is necessary in boot.py, there are two alternatives:
```python3
from pyzo.qt import QtCore, QtGui, QtWidgets
```
or
```python3
_pyzo_qt_ = importlib.import_module("pyzo.qt")
QtCore = _pyzo_qt_.QtCore
QtGui = _pyzo_qt_.QtGui
QtWidgets = _pyzo_qt_.QtWidgets
```