### PR TITLE
remove unused QtHelp dependency

### DIFF
--- a/freeze/pyzo_freeze.py
+++ b/freeze/pyzo_freeze.py
@@ -149,7 +149,6 @@ qt_includes = [
     "QtCore",  # Standard
     "QtGui",  # Standard
     "QtWidgets",  # Standard
-    "QtHelp",  # For docs
     "QtPrintSupport",  # For PDF export
 ]
 includes += [f"{qt_api}.{sub}" for sub in qt_includes]
@@ -196,6 +195,7 @@ qt_excludes = [
     "QtWebChannel",
     "QtWebKitWidgets",
     "QtWebSockets",
+    "QtHelp",
 ]
 excludes += [f"{qt_api}.{sub}" for sub in qt_excludes]
 

--- a/pyzo/qt/__init__.py
+++ b/pyzo/qt/__init__.py
@@ -72,7 +72,6 @@ del os, sys, _get_versions, _load_modules, _get_desired_api
 QtCore = importlib.import_module(API + '.QtCore')
 QtGui = importlib.import_module(API + '.QtGui')
 QtWidgets = importlib.import_module(API + '.QtWidgets')
-QtHelp = importlib.import_module(API + '.QtHelp')
 QtPrintSupport = importlib.import_module(API + '.QtPrintSupport')
 
 del importlib


### PR DESCRIPTION
Since #1045 we don't need `QtHelp` anymore. This makes it a bit easier to run Pyzo from source when using the Linux distribution's package manager instead of pip. And this also saves a bit of memory for all binary releases.