### PR TITLE
fix wrong size of calltip label size after updating calltip text

### DIFF
--- a/pyzo/codeeditor/extensions/calltip.py
+++ b/pyzo/codeeditor/extensions/calltip.py
@@ -86,16 +86,26 @@ class Calltip:
         pos.setX(pos.x() - 3)  # Correct for border and indent
         pos = self.viewport().mapToGlobal(pos)
 
+        label = self.__calltipLabel
+        textChanged = richText != label.text()
+
         # Set text and update font
-        self.__calltipLabel.setText(richText)
-        self.__calltipLabel.setFont(self.font())
+        label.setText(richText)
+        label.setFont(self.font())
 
         # Use a qt tooltip to show the calltip
         if richText:
-            self.__calltipLabel.move(pos)
-            self.__calltipLabel.show()
+            if textChanged and label.isVisible():
+                # When the tooltip label is still shown and we update the text, the
+                # rectangle of the label is not updated. This leads to truncated text
+                # or to empty space on the right of the label.
+                # As a workaround, we hide and then show the label again.
+                label.hide()
+
+            label.move(pos)
+            label.show()
         else:
-            self.__calltipLabel.hide()
+            label.hide()
 
     def calltipCancel(self):
         """Hides the calltip."""


### PR DESCRIPTION
I observed that, when the text of a visible calltip label is changed, the size of the whole calltip rectangle is not updated. This happens on all supported Qt wrappers.

Example:
In the last line of the following code, upon entering the first open parenthesis, the calltip of `myfunc1`, which is `myfunc1(param1=None, param2=None)`, is shown. As soon as the second open parenthesis is entered, the tooltip text is updated to
`myfunc2(p3, p4)                  `.
```python3
def myfunc1(param1=None, param2=None):
    pass

def myfunc2(p3, p4):
    pass

myfunc1(324, myfunc2(
```

This PR fixes the problem.