### PR TITLE
update macOS version in CI workflow to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             pyversion: '3.10'
             qtlib: pyqt5
           # --- PySide2 requires macOS with Intel CPU
-          - os: macos-12  # ... has Intel instead of Apple Silicon
+          - os: macos-13  # ... has Intel instead of Apple Silicon
             pyversion: '3.9'
             qtlib: pyside2
           # --- Older Python versions and qt libs


### PR DESCRIPTION
The CI workflow gave the following error after I submitted the previous PR:
>The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721


Therefore I updated `macos-12` to `macos-13`.
The CD workflow already had `macos-13`.

According to [the Qt page](https://doc.qt.io/qt-5/supported-platforms.html), Qt5 is supported for all CPU architectures.