### PR TITLE
remove limitations for usage of Python's logging module

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -373,36 +373,60 @@ class PyzoInterpreter:
 
                 _nope.nope()
 
-        # Setup post-mortem debugging via appropriately logged exceptions
-        class PMHandler(logging.Handler):
-            def emit(self, record):
-                if record.exc_info:
-                    sys.last_type, sys.last_value, sys.last_traceback = record.exc_info
-                return record
-
-        # Setup logging
-        root_logger = logging.getLogger()
-        if not root_logger.handlers:
-            root_logger.addHandler(logging.StreamHandler())
-        root_logger.addHandler(PMHandler())
-
-        # Warn when logging.basicConfig is used (see issue #645)
-        def basicConfigDoesNothing(*args, **kwargs):
-            logging.warning(
-                "Pyzo already added handlers to the root handler, "
-                + "so logging.basicConfig() does nothing."
-            )
-
-        try:
-            logging.basicConfig = basicConfigDoesNothing
-        except Exception:
-            pass
+        if guiName in ("ASYNCIO", "TORNADO"):
+            # The "TORNADO" entry is just for older versions of the tornado package.
+            # Newer tornado versions use Python's asyncio.
+            self._add_postmortem_for_logged_exceptions()
 
         # Setup pausing of running code using SIGFPE
         signal.signal(signal.SIGFPE, self._handle_sigfpe)
 
         # Update startup info
         self.context._stat_startup.send(startup_info)
+
+    def _add_postmortem_for_logged_exceptions(self):
+        # Setup post-mortem debugging via appropriately logged exceptions
+
+        class PMHandler(logging.Handler):
+            def emit(self, record):
+                if record.exc_info:
+                    sys.last_type, sys.last_value, sys.last_traceback = record.exc_info
+                return record
+
+        # Setup logging so that we can do post-mortem debugging in async code.
+        root_logger = logging.getLogger()
+        if not root_logger.handlers:
+            root_logger.addHandler(logging.StreamHandler())
+
+        def addLoggerPostMortemHandler():
+            root_logger = logging.getLogger()
+            root_logger.addHandler(PMHandler())
+
+        addLoggerPostMortemHandler()
+
+        def basicConfigPatched(*args, **kwargs):
+            if "force" in kwargs and self._original_logging_basicConfig is not None:
+                self._original_logging_basicConfig(*args, **kwargs)
+                addLoggerPostMortemHandler()
+            else:
+                # Warn when logging.basicConfig is used (see issue #645)
+                msgList = [
+                    "Pyzo already added handlers to the root handler, ",
+                    "so logging.basicConfig() does nothing.",
+                ]
+                if sys.version_info >= (3, 8):
+                    msgList.extend([
+                        " But you can reconfigure the logging configuration by setting ",
+                        "the force argument: logging.basicConfig(..., force=True).",
+                    ])
+                logging.warning("".join(msgList))
+
+        self._original_logging_basicConfig = None
+        try:
+            self._original_logging_basicConfig = logging.basicConfig
+            logging.basicConfig = basicConfigPatched
+        except Exception:
+            pass
 
     def _handle_sigfpe(self, sig, frame):
         self.debugger.set_trace(frame)


### PR DESCRIPTION
### Description of the problem

As already reported in #645, logging does not work with a custom logging configuration:
```python3
import logging

logging.basicConfig(level=logging.DEBUG)
# --> Pyzo prints "Pyzo already added handlers to the root handler, so logging.basicConfig() does nothing."

logging.debug('test debug')  # --> not shown
logging.info('test info')  # --> not shown
logging.warning('test warning')
logging.error('test error')
logging.critical('test critical')

logging.basicConfig(level=logging.DEBUG, force=True)
# --> the force argument is ignored -- Pyzo prints the same message "Pyzo already addded handlers ..."
logging.info('test info after force')  # --> not shown
```
That problem was only mitigated a bit via https://github.com/pyzo/pyzo/pull/675/commits/8fc48a8568949f6afb148b9cd472d950f8d07df0 by displaying a warning message to inform the user about the ignored logging configuration.

### Why do we need to mess up logging in Pyzo?
The usage of the `logging` module in the interpreter was introduced via https://github.com/pyzo/pyzo/commit/7e32265395a75bd96355ef449b4d300a1f118732.
When I removed that, the only case I found where post-mortem debugging did not work anymore, was with the asyncio code:
```python3
assert __pyzo__.guiName == 'ASYNCIO', 'run this in a shell with ASYNCIO event loop'

import asyncio

def myfunc():
    a = 123
    raise ValueError('test post-mortem')

loop = asyncio.get_running_loop()
loop.call_soon(myfunc)

# now press Ctrl+P to start post-mortem debugging
```
Without the logging handler, post-mortem does not work in that asyncio example: "No debug information available."

### New solution
With this PR, Pyzo will only setup the logging configuration and add logging handlers when they are required, that means, when having configured the asyncio and old tornado event loop.
And even in that case, if the user calls `logging.basicConfig(...)` (without the "force" keyword) it informs the user about the force argument which was introduced in Python 3.8 (which was released a month after #645): `logging.basicConfig(..., force=True)`. When that force argument is used, Pyzo will execute the original `basicConfig` function and afterwards reinstall the logging handlers so that the custom logging configuration and post-mortem debugging still work for async code.
When using another event loop, e.g. PySide6, or none, logging is not influenced by Pyzo anymore.