### PR TITLE
More rubust tracebacks

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1215,7 +1215,6 @@ class PyzoInterpreter:
         except Exception:
             type, value, tb = sys.exc_info()
             tb = None
-            frames = None
             t = "An error occured, but then another one when trying to write the traceback: "
             t += str(value) + "\n"
             self.write(t)


### PR DESCRIPTION
I found that `ExceptionGroup` exceptions are not formatted correctly: all the sub-exceptions are swallowed. This is a problem e.g. when working with trio. The reason is that we examine and tweak the traceback to resolve line number offsets.

This PR just lets Pythons traceback formatter do the work, and then fix the linenr offset by examining the resulting string lines.