### PR TITLE
Enable pm for logging again

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -404,8 +404,12 @@ class PyzoInterpreter:
                 sys.last_type, sys.last_value, sys.last_traceback = record.exc_info
             return callHandlers_ori(self, record)
 
-        callHandlers_ori = logging.Logger.callHandlers
-        logging.Logger.callHandlers = callHandlers_patched
+        try:
+            callHandlers_ori = logging.Logger.callHandlers
+            logging.Logger.callHandlers = callHandlers_patched
+        except Exception:
+            pass
+
 
     def _handle_sigfpe(self, sig, frame):
         self.debugger.set_trace(frame)

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -392,7 +392,7 @@ class PyzoInterpreter:
         #
         # Adding a handler to the root logger (as we did earlier) seems like
         # an elegant approach, but it gets complicated as to whether Pyzo should
-        # take responsibility for pinting the message. The fact that a handler
+        # take responsibility for printing the message. The fact that a handler
         # is present, will stop the logging module from printing the message,
         # because it considers it handled. We can detect whether our handler
         # is the only one and print if it is, but the log action may be
@@ -409,7 +409,6 @@ class PyzoInterpreter:
             logging.Logger.callHandlers = callHandlers_patched
         except Exception:
             pass
-
 
     def _handle_sigfpe(self, sig, frame):
         self.debugger.set_trace(frame)


### PR DESCRIPTION
Follow-up on #1103

The ability for setting up PM debugging when a ``logger.error()`` is quite generally useful IMO. Basically any case where there is some sort of event-loop that catches and logs exceptions instead of letting them fall through. In any case, I make use of it a lot :)

I took some time to look into what the least invasive approach could be, and come to the conclusion that adding a handler will always hurt one use-case or another. So I applied a somewhat dirtier monkey-patch, but that otherwise leaves the logging system alone.