### PR TITLE
fix error message in filebrowser tool

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -427,7 +427,7 @@ class NativeFSProxy(BaseFSProxy):
 
     def rename(self, path1, path2):
         if op.exists(path2):
-            raise FileExistsError("file {!r} already exists".format(path))
+            raise FileExistsError("file {!r} already exists".format(path2))
         os.rename(path1, path2)
 
     def remove(self, path):


### PR DESCRIPTION
This fixes a minor bug in an error message.
Normally, that error message cannot occur because there is already [another check with its own error message at a higher level](https://github.com/pyzo/pyzo/blob/3201ab5db5dd0126499c0f42ff494952ad70ca6a/pyzo/tools/pyzoFileBrowser/tree.py#L993-L1002).

Found via `ruff check`, by the way.