### PR TITLE
fix traceback for Python < v3.10 and for temporary files

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1172,34 +1172,28 @@ class PyzoInterpreter:
         try:
             if useLastTraceback:
                 # Get traceback info from buffered
-                type = sys.last_type
+                etype = sys.last_type
                 value = sys.last_value
                 tb = sys.last_traceback
             else:
                 # Get exception information and remove first, since that's us
-                type, value, tb = sys.exc_info()
+                etype, value, tb = sys.exc_info()
                 tb = tb.tb_next
 
                 # Store for debugging, but only store if not in debug mode
                 if not self._dbFrames:
-                    sys.last_type = type
+                    sys.last_type = etype
                     sys.last_value = value
                     sys.last_traceback = tb
 
-            lines = traceback.format_exception(value)
-
-            # Remove exec() call in interpreter.py"
-            for i in range(max(len(lines), 5)):
-                if "pyzo" in lines[i] and "interpreter.py" in lines[i] and "exec(" in lines[i]:
-                    lines.pop(i)
-                    break
+            lines = traceback.format_exception(etype, value, tb)
 
             for line in lines:
                 line = self.correctfilenameandlineno_on_line(line)
                 self.write(line)
 
         except Exception:
-            type, value, tb = sys.exc_info()
+            etype, value, tb = sys.exc_info()
             tb = None
             t = "An error occured, but then another one when trying to write the traceback: "
             t += str(value) + "\n"

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -60,7 +60,7 @@ else:
     bstr = bytes
 
 
-file_linenr_pattern = re.compile(r"\.py(\+\d+)['\",]+ line (\d+)")
+file_linenr_pattern = re.compile(r"(?:\.py|<tmp \d+>)(\+\d+)['\",]+ line (\d+)")
 
 
 class PS1:


### PR DESCRIPTION
PR #1104 broke exception formatting for older Python versions.
When starting a shell with Python < v3.10 and evaluating a variable that does not exist, instead of the `NameError` another error is displayed in the shell:
```
>>> a
An error occured, but then another one when trying to write the traceback: format_exception() takes at least 3 arguments (1 given)
```
And there was also another small bug: Line `for i in range(max(len(lines), 5)):` would iterate over at least 5 lines even if there were less, and then cause an IndexError. Probably that should have been a `min` instead of the `max`.

The third problem with PR #1104 was that it broke line number correction for temporary files:
The tracebacks then had
`File "<tmp 3>+4", line 6, in <module>`
instead of
`File "<tmp 3>", line 10, in <module>`.


With this PR, all these problems are fixed.

To reproduce the problem and check the fix, I used the following code, in both a temporary (unsaved) file and in a saved file:

```python3
# just some empty lines so that we have a line offset when executing cells


##


# execute this cell to cause a ZeroDivisionError

1 / 0

##

# execute this cell to raise multiple exceptions as a group
# ExceptionGroup was introduced in Python 3.11

e = ExceptionGroup('exception group example', [ValueError(1), TypeError(2)])

raise e

# this prints the traceback with the sub-exceptions
```