### PR TITLE
fix style of scrollbar in source structure tool

### DIFF
--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -379,7 +379,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
             currentPath.pop()
 
         # Go
-        self._tree.setStyleSheet("background-color: " + colors["background"] + ";")
+        self._tree.setStyleSheet("QTreeWidget {background-color: " + colors["background"] + ";}")
         self._tree.setUpdatesEnabled(False)
         self._tree.clear()
         SetItems(self._tree, result.rootItem.children, 0)


### PR DESCRIPTION
This fixes #1110.
Previously, the white background color was also applied to the scrollbar of the source structure tool, which made it look different than all other scrollbars.