### PR TITLE
set focus to search field when opening Advanced Settings dialog

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -3360,6 +3360,8 @@ class AdvancedSettings(QtWidgets.QDialog):
         self.fillTree()
         self._tree.expandAll()
 
+        self._search.setFocus()
+
     def btnFoldClicked(self):
         self._tree.collapseAll()
 


### PR DESCRIPTION
The "Advanced Settings" dialog will automatically set the focus in the search textbox when opened.
This means that the user can immediately start typing the needle text after opening the dialog.