### PR TITLE
prevent crash on invalid regexp in filebrowser tool

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -5,6 +5,7 @@ Defines the tree widget to display the contents of a selected directory.
 """
 
 
+import re
 import os
 import sys
 import subprocess
@@ -98,6 +99,13 @@ def createItemsFun(browser, parent):
     searchFilter = searchFilter if searchFilter["pattern"] else None
     expandedDirs = browser.expandedDirs
     starredDirs = browser.starredDirs
+
+    if searchFilter and searchFilter["regExp"]:
+        try:
+            re.compile(searchFilter["pattern"], re.MULTILINE)
+        except re.error as err:
+            ErrorItem(parent, "Error in regular expression:\n{}".format(err))
+            return
 
     # Prepare name filter info
     nameFilters = browser.nameFilter().replace(",", " ").split()


### PR DESCRIPTION
I have experienced reproducible crashes of Pyzo, where the application is suddenly closed, on both Linux and MS Windows with the current binary version of Pyzo.
The crash happens when searching in the "File Browser" tool with an invalid regular expression as the needle, e.g. `a(`.

With this fix, the problem is detected early and an error message is displayed in the tree widget, e.g.:
```
Error in regular expression:
missing ), unterminated subpattern at position 1
```