### PR TITLE
fix ci workflow for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt update
-        sudo apt install libegl1-mesa
+        sudo apt install libegl1 libegl-mesa0
     - name: Set up Python ${{ matrix.pyversion }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
The current CI workflow for Ubuntu 24.04.1 aborts with an error:
E: Unable to locate package libegl1-mesa
