### PR TITLE
Tweak copyright notices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
       run: |
           python -m pip install --upgrade pip
           pip install -U black flake8 flake8-black
-    - name: Flake8
-      run: |
-          flake8 .
+    #- name: Flake8
+    #  run: |
+    #      flake8 .
 
   test-builds:
     name: Test ${{ matrix.os }} py${{ matrix.pyversion }} ${{ matrix.qtlib }}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 Pyzo is subject to the (new) BSD license:
 
-Copyright (C) 2008-2020, the Pyzo development team
+Copyright (C) 2008-2025 - the Pyzo development team
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Pyzo"
-copyright = "2016, Pyzo contributors"
+copyright = "2008-2025 - the Pyzo development team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pyzo.appdata.xml
+++ b/pyzo.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2014-2017 Almar Klein -->
+<!-- Copyright 2014-2025 - the Pyzo development team -->
 <!-- This is a appdata file for freedesktop software centers. -->
 <!-- Please let me know if this needs changes. -->
 <component>

--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python3
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 Pyzo is a cross-platform Python IDE focused on
 interactivity and introspection, which makes it very suitable for

--- a/pyzo/codeeditor/__init__.py
+++ b/pyzo/codeeditor/__init__.py
@@ -1,9 +1,3 @@
-# flake8: noqa
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ CodeEditor
 
 A full featured code editor component based on QPlainTextEdit.

--- a/pyzo/codeeditor/base.py
+++ b/pyzo/codeeditor/base.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 The base code editor class.
 

--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 Code editor extensions that change its appearance
 """

--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 Code editor extensions that provides autocompleter functionality
 """

--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 Code editor extensions that change its behaviour (i.e. how it reacts to keys)
 """

--- a/pyzo/codeeditor/extensions/calltip.py
+++ b/pyzo/codeeditor/extensions/calltip.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 from ..qt import QtCore, QtGui, QtWidgets  # noqa
 
 Qt = QtCore.Qt

--- a/pyzo/codeeditor/highlighter.py
+++ b/pyzo/codeeditor/highlighter.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module highlighter
 
 Defines the highlighter class for the base code editor class. It will do

--- a/pyzo/codeeditor/license.txt
+++ b/pyzo/codeeditor/license.txt
@@ -1,6 +1,6 @@
 Codeeditor is subject to the 2-Clause BSD license:
 
-Copyright (C) 2013, the codeeditor development team
+Copyright (C) 2013-2025 - the Pyzo development team
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/pyzo/codeeditor/manager.py
+++ b/pyzo/codeeditor/manager.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Codeeditor is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module manager
 
 This module contains a static class that can be used for some

--- a/pyzo/codeeditor/misc.py
+++ b/pyzo/codeeditor/misc.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module misc
 
 Define the option property decorator.

--- a/pyzo/codeeditor/parsers/__init__.py
+++ b/pyzo/codeeditor/parsers/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Codeeditor is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Subpackage parsers
 
 This subpackage contains all the syntax parsers for the

--- a/pyzo/codeeditor/parsers/c_parser.py
+++ b/pyzo/codeeditor/parsers/c_parser.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import re
 from . import Parser, BlockState
 from .tokens import ALPHANUM

--- a/pyzo/codeeditor/parsers/cython_parser.py
+++ b/pyzo/codeeditor/parsers/cython_parser.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 # Import tokens in module namespace
 from .python_parser import PythonParser, pythonKeywords
 

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import re
 from . import Parser, BlockState
 

--- a/pyzo/codeeditor/parsers/s_expr_parser.py
+++ b/pyzo/codeeditor/parsers/s_expr_parser.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2018, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 from . import Parser, BlockState
 
 # Import tokens in module namespace

--- a/pyzo/codeeditor/parsers/tokens.py
+++ b/pyzo/codeeditor/parsers/tokens.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module tokens
 
 Defines the base Token class and a few generic tokens.

--- a/pyzo/codeeditor/style.py
+++ b/pyzo/codeeditor/style.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the codeeditor development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module style
 
 Provides basic functionality for styling.

--- a/pyzo/codeeditor/textutils.py
+++ b/pyzo/codeeditor/textutils.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 
 class TextReshaper:
     """Object to reshape a piece of text, taking indentation, paragraphs,

--- a/pyzo/core/__init__.py
+++ b/pyzo/core/__init__.py
@@ -1,7 +1,2 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Package core - the core of Pyzo.
 """

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module baseTextCtrl
 
 Defines the base text control to be inherited by the shell and editor

--- a/pyzo/core/codeparser.py
+++ b/pyzo/core/codeparser.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module codeparser
 
 Analyses the source code to get the structure of a module/script.

--- a/pyzo/core/commandline.py
+++ b/pyzo/core/commandline.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2014, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module to deal with command line arguments.
 
 In specific, this allows doing "pyzo some_file.py" and the file will be

--- a/pyzo/core/compactTabWidget.py
+++ b/pyzo/core/compactTabWidget.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ compact tab widget class
 
 See docs of the tab widget.

--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module editor
 
 Defines the PyzoEditor class which is used to edit documents.

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ EditorTabs class
 
 Replaces the earlier EditorStack class.

--- a/pyzo/core/icons.py
+++ b/pyzo/core/icons.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Icons module
 
 Defines functionality for creating icons by composing different overlays

--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module kernelBroker
 
 This module implements the interface between Pyzo and the kernel.

--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module main
 
 This module contains the main frame. Implements the main window.

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module menu
 
 Implements a menu that can be edited very easily. Every menu item is

--- a/pyzo/core/pyzoLogging.py
+++ b/pyzo/core/pyzoLogging.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ Module logging
 
 Functionality for logging in pyzo.

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ Module shell
 
 Defines the shell to be used in pyzo.

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ Module shellInfoDialog
 
 Implements shell configuration dialog.

--- a/pyzo/core/shellStack.py
+++ b/pyzo/core/shellStack.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ Module shellStack
 
 Implements the stack of shells. Also implements the nifty debug button

--- a/pyzo/core/splash.py
+++ b/pyzo/core/splash.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module splash
 
 Defines splash window shown during startup.

--- a/pyzo/pyzokernel/__init__.py
+++ b/pyzo/pyzokernel/__init__.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 The pyzokernel package contains the code for the Pyzo kernel process.
 This kernel is designed to be relatively lightweight; i.e. most of

--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import os
 import sys
 import time

--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 Module to integrate GUI event loops in the Pyzo interpreter.
 

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ Module pyzokernel.interpreter
 
 Implements the Pyzo interpreter.

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import sys
 import signal
 import yoton

--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 Magic commands for the Pyzo kernel.
 No need to use printDirect here, magic commands are just like normal Python

--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, Almar Klein
-
-# From pyzo/pyzokernel
-
 import sys
 import time
 import subprocess

--- a/pyzo/pyzokernel/start.py
+++ b/pyzo/pyzokernel/start.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ pyzokernel/start.py
 
 Starting script for remote processes in pyzo.

--- a/pyzo/tools/__init__.py
+++ b/pyzo/tools/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2013, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """ Package tools of pyzo
 
 A tool consists of a module which contains a class. The id of

--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 from pyzo import translate
 
 tool_name = translate("pyzoFileBrowser", "File Browser")

--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -1,5 +1,3 @@
-# Copyright (C) 2013 Almar Klein
-
 """
 This module defines file system proxies to be used for the file browser.
 For now, there is only one: the native file system. But in time,

--- a/pyzo/tools/pyzoFileBrowser/tasks.py
+++ b/pyzo/tools/pyzoFileBrowser/tasks.py
@@ -1,5 +1,3 @@
-# Copyright (C) 2013 Almar Klein
-
 """
 Define tasks that can be executed by the file browser.
 These inherit from proxies.Task and implement that specific interface.

--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -1,5 +1,3 @@
-# Copyright (C) 2013 Almar Klein
-
 """
 Defines the tree widget to display the contents of a selected directory.
 """

--- a/pyzo/tools/pyzoHistoryViewer.py
+++ b/pyzo/tools/pyzoHistoryViewer.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 This file provides the pyzo history viewer. It contains two main components: the
 History class, which is a Qt model, and the PyzoHistoryViewer, which is a Qt view

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 import sys, re
 from functools import partial
 

--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 import sys, os, code
 import pyzo
 from pyzo.qt import QtCore, QtGui, QtWidgets  # noqa

--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import weakref
 
 import pyzo

--- a/pyzo/tools/pyzoWebBrowser.py
+++ b/pyzo/tools/pyzoWebBrowser.py
@@ -1,9 +1,3 @@
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 import urllib.request, urllib.parse
 
 from pyzo.qt import QtCore, QtWidgets

--- a/pyzo/tools/pyzoWorkspace.py
+++ b/pyzo/tools/pyzoWorkspace.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import re
 
 import pyzo

--- a/pyzo/util/_locale.py
+++ b/pyzo/util/_locale.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ pyzo.util._locale
 Module for locale stuff like language and translations.
 """

--- a/pyzo/util/interpreters/__init__.py
+++ b/pyzo/util/interpreters/__init__.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2016, Almar Klein
-
 """
 This module implements functionality to detect available Python
 interpreters. This is done by looking at common locations, the Windows

--- a/pyzo/util/interpreters/inwinreg.py
+++ b/pyzo/util/interpreters/inwinreg.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2016, Almar Klein
-
 """
 This module implements functionality to obtain registered
 Python interpreters and to register a Python interpreter in the Windows

--- a/pyzo/util/pyzowizard.py
+++ b/pyzo/util/pyzowizard.py
@@ -1,8 +1,3 @@
-# Copyright (C) 2013, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ pyzowizard module
 
 Implements a wizard to help new users get familiar with pyzo.

--- a/pyzo/yoton/__init__.py
+++ b/pyzo/yoton/__init__.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-# flake8: noqa
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
-
 """
 Yoton is a Python package that provides a simple interface
 to communicate between two or more processes.

--- a/pyzo/yoton/channels/__init__.py
+++ b/pyzo/yoton/channels/__init__.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-# flake8: noqa
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """
 
 The channel classes represent the mechanism for the user to send

--- a/pyzo/yoton/channels/channels_base.py
+++ b/pyzo/yoton/channels/channels_base.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.channels.channels_base
 
 Defines the base channel class and the MessageType class.

--- a/pyzo/yoton/channels/channels_file.py
+++ b/pyzo/yoton/channels/channels_file.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.channels.file
 
 Defines a class that can be used to wrap a channel to give it

--- a/pyzo/yoton/channels/channels_pubsub.py
+++ b/pyzo/yoton/channels/channels_pubsub.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.channels.channels_pubsub
 
 Defines the channel classes for the pub/sub pattern.

--- a/pyzo/yoton/channels/channels_reqrep.py
+++ b/pyzo/yoton/channels/channels_reqrep.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.channels.channels_reqprep
 
 Defines the channel classes for the req/rep pattern.

--- a/pyzo/yoton/channels/channels_state.py
+++ b/pyzo/yoton/channels/channels_state.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.channels.channels_state
 
 Defines the channel class for state.

--- a/pyzo/yoton/channels/message_types.py
+++ b/pyzo/yoton/channels/message_types.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.channels.message_types
 
 Defines a few basic message_types for the channels. A MessageType object

--- a/pyzo/yoton/clientserver.py
+++ b/pyzo/yoton/clientserver.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ yoton.clientserver.py
 
 Yoton comes with a small framework to setup a request-reply pattern

--- a/pyzo/yoton/connection.py
+++ b/pyzo/yoton/connection.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import os
 import threading
 

--- a/pyzo/yoton/connection_itc.py
+++ b/pyzo/yoton/connection_itc.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 # flake8: noqa
 
 import sys

--- a/pyzo/yoton/connection_tcp.py
+++ b/pyzo/yoton/connection_tcp.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import os
 import sys
 import time

--- a/pyzo/yoton/context.py
+++ b/pyzo/yoton/context.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.context
 
 Defines the context class.

--- a/pyzo/yoton/core.py
+++ b/pyzo/yoton/core.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 import sys
 import time
 import struct

--- a/pyzo/yoton/events.py
+++ b/pyzo/yoton/events.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 # This code is loosely based on the event system of Visvis and on the
 # signals system of Qt.
 

--- a/pyzo/yoton/misc.py
+++ b/pyzo/yoton/misc.py
@@ -1,9 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013, the Pyzo development team
-#
-# Yoton is distributed under the terms of the 2-Clause BSD License.
-# The full license can be found in 'license.txt'.
-
 """ Module yoton.misc
 
 Defines a few basic constants, classes and functions.

--- a/pyzolauncher.py
+++ b/pyzolauncher.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python3
-# Copyright (C) 2016, the Pyzo development team
-#
-# Pyzo is distributed under the terms of the (new) BSD License.
-# The full license can be found in 'license.txt'.
 
 """ pyzolauncher.py script
 


### PR DESCRIPTION
* Update to 2025.
* Remove copyright notice from the top of almost every file. This was something we did in earlier days.
* Disabled flake8 check temporarily`*`.

`*` I accidentally removed `flake8: noqa` in a few places. Since I plan to move to ruff next, I'll just disable linting now, and enable it once Ruff is applied.