### PR TITLE
restore compatibility with Python 2.7 shells

### DIFF
--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -497,7 +497,10 @@ class App_qt(App_base):
                     except Exception:
                         pass  # tough luck
 
-                theApp.exec = theApp.exec_
+                # "exec" as an attribute would cause a syntax error in Python 2.7
+                # because it is a keyword.
+                # So we have to use setattr instead of assigning theApp.exec
+                setattr(theApp, "exec", theApp.exec_)  # noqa: B010
 
                 # Call init function (in case the user overloaded it)
                 theApp.__init__(*args, **kwargs)

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -11,6 +11,10 @@ else:
     import _thread as thread
 
 
+# we keep this file in ascii encoding to stay compatible with Python 2.7 kernels
+THREE_DOTS_CHAR = b"\xe2\x80\xa6".decode("utf-8")
+
+
 class PyzoIntrospector(yoton.RepChannel):
     """This is a RepChannel object that runs a thread to respond to
     requests from the IDE.
@@ -313,7 +317,7 @@ class PyzoIntrospector(yoton.RepChannel):
                                 # "<array 3 int64: np.int64(1), np.int64(2), np.int64(3)>"
                                 values_repr += ", " + str(el)
                                 if len(values_repr) > 70:
-                                    values_repr = values_repr[:69] + "…"
+                                    values_repr = values_repr[:69] + THREE_DOTS_CHAR
                                     break
                         repres = "<array %s %s: %s>" % (
                             tmp,
@@ -331,7 +335,7 @@ class PyzoIntrospector(yoton.RepChannel):
                     for el in val:
                         values_repr += ", " + repr(el)
                         if len(values_repr) > 70:
-                            values_repr = values_repr[:69] + "…"
+                            values_repr = values_repr[:69] + THREE_DOTS_CHAR
                             break
                     repres = "<%i-element list: %s>" % (len(val), values_repr[2:])
                 elif kind == "tuple":
@@ -339,7 +343,7 @@ class PyzoIntrospector(yoton.RepChannel):
                     for el in val:
                         values_repr += ", " + repr(el)
                         if len(values_repr) > 70:
-                            values_repr = values_repr[:69] + "…"
+                            values_repr = values_repr[:69] + THREE_DOTS_CHAR
                             break
                     repres = "<%i-element tuple: %s>" % (len(val), values_repr[2:])
                 elif kind == "dict":
@@ -347,13 +351,13 @@ class PyzoIntrospector(yoton.RepChannel):
                     for k, v in val.items():
                         values_repr += ", " + repr(k) + ": " + repr(v)
                         if len(values_repr) > 70:
-                            values_repr = values_repr[:69] + "…"
+                            values_repr = values_repr[:69] + THREE_DOTS_CHAR
                             break
                     repres = "<%i-item dict: %s>" % (len(val), values_repr[2:])
                 else:
                     repres = repr(val)
                     if len(repres) > 80:
-                        repres = repres[:79] + "…"
+                        repres = repres[:79] + THREE_DOTS_CHAR
                 # Store
                 tmp = (name, typeName, kind, repres)
                 names.append(tmp)
@@ -476,7 +480,7 @@ class PyzoIntrospector(yoton.RepChannel):
             try:
                 result = str(eval(expr, None, NS))[: maxChars + 1]
                 if len(result) > maxChars:
-                    result = result[: maxChars - 1] + "…"
+                    result = result[: maxChars - 1] + THREE_DOTS_CHAR
                 success = True
             except Exception as e:
                 result = str(e)

--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -24,7 +24,7 @@ def subprocess_with_callback(callback, cmd, **kwargs):
         callback(str(err) + "\n")
         return -1
 
-    progressBarDash = b"\xe2\x94\x81"  # character "━"
+    progressBarDash = b"\xe2\x94\x81"  # U+2501, a thick horizontal line character
     pending = b""
     while p.poll() is None:
         time.sleep(0.001)

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -69,7 +69,7 @@ Outside such constructs, ``in`` is an operator and its precise meaning depends o
     ),
     "is": pyzo.translate(
         "pyzoInteractiveHelp",
-        """This operator tests for an object’s identity: ``x is y`` is true if and only if ``x`` and ``y`` are the same object.
+        """This operator tests for an object's identity: ``x is y`` is true if and only if ``x`` and ``y`` are the same object.
 
 See also: ``id``""",
     ),
@@ -101,7 +101,7 @@ else:       # optional
 ```
 The expression ``iterable`` is evaluated once; its value should be an iterable object. An iterator is created for the result of that expression. The ``body`` is then executed once for each item provided by the iterator, in the order returned by the iterator: each item in turn is assigned to the ``variable`` and then the ``body`` is executed. When the items are exhausted (which is immediately when the ``iterable`` is empty), the ``suite`` in the ``else`` clause, if present, is executed, and the loop terminates.
 
-A ``break`` statement executed in the first suite terminates the loop without executing the ``else`` clause’s ``suite``. A ``continue`` statement executed in the first suite skips the rest of the ``body`` and continues with the next item, or with the ``else`` clause if there is no next item.
+A ``break`` statement executed in the first suite terminates the loop without executing the ``else`` clause's ``suite``. A ``continue`` statement executed in the first suite skips the rest of the ``body`` and continues with the next item, or with the ``else`` clause if there is no next item.
 
 The for-loop makes assignments to the ``variable``. This overwrites all previous assignments to that variable including those made in the ``body`` of the for-loop:
 ```
@@ -151,7 +151,7 @@ try:
 finally:
     suite
 ```
-If ``critical_section`` raises an exception, the ``suite`` will be executed before aborting the program. The ``suite`` is also executed when no exception is raised. When a ``return``, ``break`` or ``continue`` statement is executed in the ``critical_section``, the ``finally`` clause is also executed ‘on the way out.’ A ``continue`` statement is illegal in the ``finally`` clause.
+If ``critical_section`` raises an exception, the ``suite`` will be executed before aborting the program. The ``suite`` is also executed when no exception is raised. When a ``return``, ``break`` or ``continue`` statement is executed in the ``critical_section``, the ``finally`` clause is also executed 'on the way out.' A ``continue`` statement is illegal in the ``finally`` clause.
 
 Both mechanisms can be combined, the ``finally`` clause coming after the last ``except`` clause or after the optional ``else`` clause.""",
     ),
@@ -184,7 +184,7 @@ else:           # optional
 ```
 This repeatedly tests the ``expression`` and, if it is true, executes the ``body``; if the ``expression`` is false (which may be the first time it is tested) the ``suite`` of the ``else`` clause, if present, is executed and the loop terminates.
 
-A ``break`` statement executed in the ``body`` terminates the loop without executing the ``else`` clause’s ``suite``. A ``continue`` statement executed in the ``body`` skips the rest of the ``body`` and goes back to testing the ``expression``.""",
+A ``break`` statement executed in the ``body`` terminates the loop without executing the ``else`` clause's ``suite``. A ``continue`` statement executed in the ``body`` skips the rest of the ``body`` and goes back to testing the ``expression``.""",
     ),
     "assert": pyzo.translate(
         "pyzoInteractiveHelp",
@@ -258,7 +258,7 @@ See also: ``and``, ``not``, ``True``, ``False``""",
     ),
     "yield": pyzo.translate(
         "pyzoInteractiveHelp",
-        """The ``yield`` expression is used when defining a generator function or an asynchronous generator function and thus can only be used in the body of a function definition. Using a yield expression in a function’s body causes that function to be a generator, and using it in an ``async def`` function’s body causes that coroutine function to be an asynchronous generator.""",
+        """The ``yield`` expression is used when defining a generator function or an asynchronous generator function and thus can only be used in the body of a function definition. Using a yield expression in a function's body causes that function to be a generator, and using it in an ``async def`` function's body causes that coroutine function to be an asynchronous generator.""",
     ),
 }
 

--- a/pyzo/yoton/channels/channels_reqrep.py
+++ b/pyzo/yoton/channels/channels_reqrep.py
@@ -158,9 +158,9 @@ class Future(object):
             time.sleep(0.01)  # 10 ms
 
     def result(self, timeout=None):
-        """Return the value returned by the call. If the call hasn’t yet
+        """Return the value returned by the call. If the call hasn't yet
         completed then this method will wait up to timeout seconds. If
-        the call hasn’t completed in timeout seconds, then a TimeoutError
+        the call hasn't completed in timeout seconds, then a TimeoutError
         will be raised. timeout can be an int or float. If timeout is not
         specified or None, there is no limit to the wait time.
 
@@ -184,9 +184,9 @@ class Future(object):
             return self._result
 
     def result_or_cancel(self, timeout=1.0):
-        """Return the value returned by the call. If the call hasn’t yet
+        """Return the value returned by the call. If the call hasn't yet
         completed then this method will wait up to timeout seconds. If
-        the call hasn’t completed in timeout seconds, then the call is
+        the call hasn't completed in timeout seconds, then the call is
         cancelled and the method will return None.
         """
 
@@ -201,9 +201,9 @@ class Future(object):
             return None
 
     def exception(self, timeout=None):
-        """Return the exception raised by the call. If the call hasn’t yet
+        """Return the exception raised by the call. If the call hasn't yet
         completed then this method will wait up to timeout seconds. If
-        the call hasn’t completed in timeout seconds, then a TimeoutError
+        the call hasn't completed in timeout seconds, then a TimeoutError
         will be raised. timeout can be an int or float. If timeout is not
         specified or None, there is no limit to the wait time.
 

--- a/pyzo/yoton/tests/test_speed.py
+++ b/pyzo/yoton/tests/test_speed.py
@@ -103,7 +103,7 @@ fig, (ax1, ax2) = plt.subplots(2, 1, num=10, clear=True, sharex=True)
 
 
 def format_si(value, unit):
-    prefixes = ["µ", "m", "", "k", "M", "G"]
+    prefixes = ["micro", "m", "", "k", "M", "G"]
     i3 = int(np.log10(value) // 3)
     i = i3 + prefixes.index("")
     i = max(0, min(i, len(prefixes) - 1))


### PR DESCRIPTION
Recent commits made Python 2.7 kernels crash in Pyzo.

#1121 removed the `"# -*- coding: utf-8 -*-"` headers from files executed by the kernel.
#1123 used the Python 2.7 keyword `exec` as an attribute, resulting in a SyntaxError

All files inside the folder `pyzo/pyzokernel` are executed only by the kernel (Python 2.7).
All files inside the folder `pyzo/yoton` are executed by both the Pyzo IDE (Python >= v3.6) and the kernel (Python 2.7).
All remaining Python files are executed only by the Pyzo IDE (Python >= v3.6).

I changed all Python scripts that are executed by the kernel so that they are (7 bit) ASCII files.
And I fixed the `exec` attribute and added an override for `ruff` to not touch that anymore.