### PR TITLE
add soft keywords to autocompletion list

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1187,6 +1187,7 @@ class PythonShell(BaseShell):
         self._version = ""
         self._builtins = []
         self._keywords = []
+        self._softKeywords = []
         self._startup_info = {}
         self._start_time = 0
 
@@ -1281,6 +1282,11 @@ class PythonShell(BaseShell):
         if isinstance(L, list):
             self._keywords = L
 
+        # Set soft keywords
+        L = startup_info.get("softkeywords", None)
+        if isinstance(L, list):
+            self._softKeywords = L
+
         # Set builtins
         L = startup_info.get("builtins", None)
         if isinstance(L, list):
@@ -1361,6 +1367,7 @@ class PythonShell(BaseShell):
             aco.addNames(self._builtins)
             if pyzo.config.settings.autoComplete_keywords:
                 aco.addNames(self._keywords)
+                aco.addNames(self._softKeywords)
         elif aco.name == "[":
             return
 

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -260,6 +260,7 @@ class PyzoInterpreter:
         startup_info["builtins"] = list(builtins)
         startup_info["version"] = tuple(sys.version_info)
         startup_info["keywords"] = keyword.kwlist
+        startup_info["softkeywords"] = getattr(keyword, "softkwlist", [])
         # Update startup info, we update again at the end of this method
         self.context._stat_startup.send(startup_info.copy())
 


### PR DESCRIPTION
Now, soft keyword such as `match` and `case` are also part of the autocompletion list.