### PR TITLE
support relative filepaths in Pyzo's command line arguments to open files

### DIFF
--- a/pyzo/core/commandline.py
+++ b/pyzo/core/commandline.py
@@ -116,11 +116,16 @@ def handle_cmd_args():
     otherwise.
     """
     args = sys.argv[1:]
-    request = " ".join(arg for arg in args if not arg.startswith("--"))
-    if "psn_" in request and not os.path.isfile(request):
-        request = " ".join(args[1:])  # An OSX thing when clicking app icon
-    request = request.strip()
-    #
+    args = [s for s in args if not s.startswith("--")]
+    if sys.platform == "darwin" and len(args) > 0 and args[0].startswith("-psn_"):
+        del args[0]  # An OSX thing when clicking app icon
+
+    # support relative paths, e.g. with command line "pyzo ./myfile.py"
+    if len(args) == 1 and args[0].startswith(".") and os.path.isfile(args[0]):
+        args = [os.path.abspath(args[0])]
+
+    request = " ".join(args).strip()
+
     if not request:
         return None
     else:


### PR DESCRIPTION
This PR adds support to open scripts in Pyzo by passing a relative filepath as the command line argument.

Before this PR, the command `pyzo ./abc.py` passed the relative path `./abc.py` to the Pyzo command server. The command server then resolved the relative path using the server's current path but not the client's current path.

With this PR, Pyzo resolves the relative path to an absolute path in the client code and then passes the absolute path to the server.
A relative path has to start with a dot, and the `open` command must not be used.
`pyzo ./abc.py` will work as intended now, but `pyzo open ./abc.py` would use the server's working directory.

@almarklein: Can you please test this on macOS because I also changed the `psn_` stuff?

This solves issue #752.