### PR TITLE
implement proper editor tab switching with history

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -229,14 +229,11 @@ class Indentation:
                     w = self.indentWidth()
                     cursor.insertText(" " * (w - ((cursor.positionInBlock() + w) % w)))
                     return
-                # else: default behaviour, insert tab character
-            else:  # Some other modifiers + Tab: ignore
-                return
 
         # If backspace is pressed in the leading whitespace, (except for at the first
         # position of the line), and there is no selection
         # dedent that line and move cursor to end of whitespace
-        if (
+        elif (
             key == Qt.Key.Key_Backspace
             and modifiers == Qt.KeyboardModifier.NoModifier
             and self.__cursorIsInLeadingWhitespace()
@@ -252,7 +249,7 @@ class Indentation:
         # todo: Same for delete, I think not (what to do with the cursor?)
 
         # Auto-unindent
-        if key == Qt.Key.Key_Delete:
+        elif key == Qt.Key.Key_Delete:
             cursor = self.textCursor()
             if not cursor.hasSelection():
                 cursor.movePosition(

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -646,6 +646,8 @@ class BaseTextCtrl(CodeEditor):
         or other stuff...
         """
 
+        KM = QtCore.Qt.KeyboardModifier
+
         # Get ordinal key
         ordKey = -1
         if event.text():
@@ -656,8 +658,8 @@ class BaseTextCtrl(CodeEditor):
 
         # Invoke advanced autocomplete/calltips Ctrl+Space key combination?
         has_control = (
-            event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier
-            or event.modifiers() & QtCore.Qt.KeyboardModifier.MetaModifier
+            event.modifiers() & KM.ControlModifier
+            or event.modifiers() & KM.MetaModifier
         )
         if has_control and event.key() == QtCore.Qt.Key.Key_Space:
             cursor = self.textCursor()
@@ -668,8 +670,10 @@ class BaseTextCtrl(CodeEditor):
                     return
 
         # Invoke autocomplete via tab key?
-        elif event.key() == QtCore.Qt.Key.Key_Tab and not self.autocompleteActive():
-            if pyzo.config.settings.autoComplete:
+        elif (
+            event.modifiers() == KM.NoModifier and event.key() == QtCore.Qt.Key.Key_Tab
+        ):
+            if pyzo.config.settings.autoComplete and not self.autocompleteActive():
                 cursor = self.textCursor()
                 if cursor.position() == cursor.anchor():
                     text = cursor.block().text()[: cursor.positionInBlock()]

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1072,13 +1072,6 @@ class ViewMenu(Menu):
             icons.application_edit,
             self._selectEditor,
         )
-        self.addItem(
-            translate(
-                "menu", "Select previous file ::: Select the previously selected file."
-            ),
-            icons.application_double,
-            pyzo.editors._tabs.selectPreviousItem,
-        )
         self.addSeparator()
         self.addEditorItem(
             translate("menu", "Show whitespace ::: Show spaces and tabs."),

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -135,7 +135,6 @@ shortcuts2 = dict:
     shell__terminate = 'Ctrl+Shift+K,'
     shell__postmortem_debug_from_last_traceback = 'Ctrl+P,'
     view__select_editor = 'Ctrl+9,F2'
-    view__select_previous_file = 'Ctrl+Tab,' # On Mac, this is replaced by Alt+Tab in pyzo.py
     view__select_shell = 'Ctrl+0,F1'
     view__zooming__zoom_in = 'Ctrl+=,Ctrl++'
     view__zooming__zoom_out = 'Ctrl+-,'


### PR DESCRIPTION
Before this PR, editor tab switching was a bit strange in Pyzo (at least on Linux and MS Windows):
`Ctrl+Tab` would only toggle between the currently and the previously selected editor tab.
`Ctrl+Shift+Tab` would switch to the tab that is on the left of the current tab.

The old implementation of the tab switching history was limited to only 10 entries and could contain invalid values (`None`). Now there is no such history length limit anymore, and the history is now always a subset of all open editor tabs.
I removed the "View -> Select previous file" menu entry with its shortcut and the default configuration value.
There were some bugs in `keyPressEvent` methods that needlessly ate `Ctrl+Tab` keypress events. These are now fixed.

With this new editor tab switching feature, a dialog with a list of all open editor tabs will appear as soon as `Ctrl+Tab` or `Ctrl+Shift+Tab` is pressed, unless there are less than two editor tabs present.
The dialog will close itself as soon as `Ctrl` key is released and will then switch to the tab represented by the selected list entry. To go forward or backward in the history list, just press Tab again while Ctrl resp. Ctrl+Shift is still pressed. The list entry selection could also be done by clicking the entry with the mouse and then releasing the Ctrl key. To cancel tab switching, just close the dialog with the mouse.

As far as I have seen, there have also been othere people who wished for such a feature: see issues #527 and #219.