### PR TITLE
fix tabswitching

### DIFF
--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -684,7 +684,7 @@ class BaseTextCtrl(CodeEditor):
             )
         ):
             event.ignore()
-            return False
+            return
 
         # Invoke advanced autocomplete/calltips Ctrl+Space key combination?
         if has_control_like and event.key() == QtCore.Qt.Key.Key_Space:

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -672,9 +672,16 @@ class BaseTextCtrl(CodeEditor):
         )
 
         # Leave tab events to editor tabs
-        if has_control_like and event.key() in (
-            QtCore.Qt.Key.Key_Tab,
-            QtCore.Qt.Key.Key_Backtab,
+        # FIXME: this is probably just a workaround for another problem
+        # FIXME: ... somewhere in a keyPressEvent in a codeeditor extension
+        if (
+            ismacos
+            and has_control_like
+            and event.key()
+            in (
+                QtCore.Qt.Key.Key_Tab,
+                QtCore.Qt.Key.Key_Backtab,
+            )
         ):
             event.ignore()
             return False
@@ -686,7 +693,7 @@ class BaseTextCtrl(CodeEditor):
                 text = cursor.block().text()[: cursor.positionInBlock()]
                 if text:
                     self.introspect(True, False, advanced=True)
-            return
+                    return
 
         # Invoke autocomplete via tab key?
         elif (

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -902,12 +902,9 @@ class FileTabWidget(CompactTabWidget):
 
         self.fileTabsChanged.emit()
 
-    def event(self, event):
-        if event.type() == event.Type.KeyPress:
-            # prevent the QTabBar widget from consuming keypress events
-            return False
-        else:
-            return super().event(event)
+    def keyPressEvent(self, event):
+        # prevent the QTabBar widget from consuming keypress events
+        event.ignore()
 
 
 class EditorTabs(QtWidgets.QWidget):

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1684,11 +1684,17 @@ class EditorTabs(QtWidgets.QWidget):
         # we're good to go closing
         return True
 
-    def keyPressEvent(self, event):
+    def processKeyPressFromMainWindow(self, event):
+        consumed = False
         if HistList.processKeyPress(event):
             histList = HistList(self, self._tabs, event)
             if histList.valid:
                 histList.exec()
+            ed = self.getCurrentEditor()
+            if ed:
+                ed.setFocus()
+            consumed = True
+        return consumed
 
 
 class HistList(QtWidgets.QDialog):

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1757,8 +1757,6 @@ class HistList(QtWidgets.QDialog):
 
     @staticmethod
     def processKeyPress(event):
-        if event.isAutoRepeat():
-            return None
         key = event.key()
         modifiers = event.modifiers()
         tab_pressed = key == QtCore.Qt.Key.Key_Tab

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1765,7 +1765,6 @@ class HistList(QtWidgets.QDialog):
         control_like_modifier = KM.AltModifier if ismacos else KM.ControlModifier
         fwd = modifiers == control_like_modifier
         bwd = modifiers == control_like_modifier | KM.ShiftModifier
-        print("tab pressed", tab_pressed, fwd, bwd)
         if (tab_pressed and fwd) or (backtab_pressed and bwd):
             k = -1 if bwd else 1
             return k

--- a/pyzo/core/main.py
+++ b/pyzo/core/main.py
@@ -468,6 +468,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
         return menu
 
+    def keyPressEvent(self, event):
+        # Here we forwared the key press events to the editor widget so that tab switching
+        # will also be possible when the focus is outside the editor widget.
+        pyzo.editors.processKeyPressFromMainWindow(event)
+
 
 def loadAppIcons():
     """Load the application icons."""


### PR DESCRIPTION
@almarklein:
Consider this PR a whiteboard for fixing tabswitching.
I added some commits that show what has to be fixed.

The first commit [use workaround only for macos](https://github.com/pyzo/pyzo/commit/aa14d4f97e7c113b8f5ef4d769482d9181f656f6) is more or less a placeholder for a proper fix.
I think, the problem can be quickly found by deactivating all the `keyPressEvent` methods in the folder "pyzo/codeeditor/extensions" -- just comment out the lines and add a `pass` instead. At least, this is how I did it when I fixed that for Linux.

Commit [fix return statement for PyQt6](https://github.com/pyzo/pyzo/commit/5d978f1b1318c14516b317e3992f3303f6199e7a) is necessary because PyQt6 throws an exception if there is a value returned from the keyPressEvent.

There was also a `print` call from the previous fix. I guess this is not necessary anymore.

The last commit is something I wanted to change anyways: Up to Pyzo v4.19.0, the tab switching key combination was application wide (only the Ctrl+Tab but not the Ctrl+Shift+Tab). With the new tab switching dialog, the key combination only worked when the focus is in the editor(tabs) widget, but not when the focus is in the shell or e.g. filebrowser search textbox. This commit makes the key combinations for tabswitching application-wide again, as before.

