### PR TITLE
show interactive help for active calltip

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -55,7 +55,7 @@ class AutoCompletion:
         if USE_WAYLAND_WORKAROUND:
             self.__completerWindow.setWindowFlags(QtCore.Qt.WindowType.ToolTip)
 
-        self.__cancelCallback = None
+        self.__finishedCallback = None
 
         # geometry
         self.__popupSize = 300, 100
@@ -103,8 +103,8 @@ class AutoCompletion:
         """
         self.__autocompletionAcceptKeys = keys
 
-    def setCancelCallback(self, cb):
-        self.__cancelCallback = cb
+    def setAutocompleteFinishedCallback(self, cb):
+        self.__finishedCallback = cb
 
     ## Autocompletion
 
@@ -165,16 +165,15 @@ class AutoCompletion:
         self.__completerWindow.hide()
         self.__autocompleteStart = None
         self.__autocompleteVisible = False
+        if self.__finishedCallback is not None:
+            self.__finishedCallback()
 
     def autocompleteCancel(self):
         self.__completerWindow.hide()
         self.__autocompleteStart = None
         self.__autocompleteVisible = False
-        if self.__cancelCallback is not None:
-            try:
-                self.__cancelCallback()
-            except Exception as err:
-                print("Exception in autocomp cancel callback: " + str(err))
+        if self.__finishedCallback is not None:
+            self.__finishedCallback()
 
     def onAutoComplete(self, text=None):
         if text is None:

--- a/pyzo/codeeditor/extensions/calltip.py
+++ b/pyzo/codeeditor/extensions/calltip.py
@@ -45,6 +45,9 @@ class Calltip:
         )
         self.__calltipLabel.setStyleSheet(ss)
 
+    def setCalltipFinishedCallback(self, cb):
+        self.__finishedCallback = cb
+
     def calltipShow(self, offset=0, richText="", highlightFunctionName=False):
         """Shows the given calltip.
 
@@ -105,6 +108,8 @@ class Calltip:
     def calltipCancel(self):
         """Hides the calltip."""
         self.__calltipLabel.hide()
+        if self.__finishedCallback is not None:
+            self.__finishedCallback()
 
     def calltipActive(self):
         """Get whether the calltip is currently active."""


### PR DESCRIPTION
Before this PR, the "Interactive help" tool dynamically displayed the help text for the currently selected item in the autocompletion list.

I reworked this so that also calltips will tell the interactive help tool to display the help text for the current function/method.
If both, the autocompletion list and the calltip are shown at the same time, autocompletion takes precedence for the displayed help text.