### PR TITLE
fix filebrowser regexp search and add "whole words" option

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/__init__.py
+++ b/pyzo/tools/pyzoFileBrowser/__init__.py
@@ -20,7 +20,7 @@ The config consists of three fields:
       * str path, the directory that is starred
       * str name, the name of the project (op.basename(path) by default)
       * bool addToPythonpath
-  * searchMatchCase, searchRegExp, searchSubDirs, searchExcludeBinary
+  * searchMatchCase, searchRegExp, wholeWords, searchSubDirs, searchExcludeBinary
   * nameFilter
 
 """

--- a/pyzo/tools/pyzoFileBrowser/browser.py
+++ b/pyzo/tools/pyzoFileBrowser/browser.py
@@ -109,6 +109,7 @@ class Browser(QtWidgets.QWidget):
             "pattern": self._searchFilter.text(),
             "matchCase": self.config.searchMatchCase,
             "regExp": self.config.searchRegExp,
+            "wholeWords": self.config.wholeWords,
             "subDirs": self.config.searchSubDirs,
             "excludeBinary": self.config.searchExcludeBinary,
         }
@@ -654,6 +655,7 @@ class SearchFilter(LineEditWithToolButtons):
         map = [
             ("searchMatchCase", False, translate("filebrowser", "Match case")),
             ("searchRegExp", False, translate("filebrowser", "RegExp")),
+            ("wholeWords", False, translate("filebrowser", "Whole words")),
             ("searchSubDirs", True, translate("filebrowser", "Search in subdirs")),
             ("searchExcludeBinary", True, translate("filebrowser", "Exclude binary")),
         ]

--- a/pyzo/tools/pyzoFileBrowser/browser.py
+++ b/pyzo/tools/pyzoFileBrowser/browser.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import os.path as op
 
@@ -116,6 +117,8 @@ class Browser(QtWidgets.QWidget):
 
     def setSearchText(self, needle, setFocus=False):
         """Set the text in the search field."""
+        if self.config.searchRegExp:
+            needle = re.escape(needle)
         self._searchFilter.setText(needle)
         if setFocus:
             self._searchFilter.setFocus()


### PR DESCRIPTION
This PR fixes some issues of the filebrowser tool:

When doing a case insensitive search and using a RegExp pattern as the needle, the needle was converted into lowercase, and this turned `\B` into `\b` which has a different meaning in regular expressions. --> fixed

When invoking "Edit -> Find via File Browser" (or Ctrl+Shift+F), the selected text in the editor is searched via the filebrowser tool. But the problem was that this would not always work when option "RegExp" was activated. Now, the needle from the editor will automatically be escaped into a regular expression in the filebrowser search text box.

And this PR adds a new feature:
Now there is a new "Whole words" search option in the filebrowser tool with same behavior as in the code editor's search.