### PR TITLE
fix minor issues in filebrowser tool

### DIFF
--- a/pyzo/tools/pyzoFileBrowser/browser.py
+++ b/pyzo/tools/pyzoFileBrowser/browser.py
@@ -68,7 +68,7 @@ class Browser(QtWidgets.QWidget):
 
         # Set and sync path ...
         if path is not None:
-            self._tree.SetPath(path)
+            self._tree.setPath(path)
         self._tree.dirChanged.emit(self._tree.path())
 
     def getImportWizard(self):

--- a/pyzo/tools/pyzoFileBrowser/proxies.py
+++ b/pyzo/tools/pyzoFileBrowser/proxies.py
@@ -239,7 +239,7 @@ class BaseFSProxy(threading.Thread):
 
     This class has methods to use the file system (list files and
     directories, etc.). These can be used directly, but may be slow.
-    Therefor it is recommended to use the FileProxy and DirProxy objects
+    Therefore it is recommended to use the FileProxy and DirProxy objects
     instead.
 
     """

--- a/pyzo/tools/pyzoFileBrowser/tasks.py
+++ b/pyzo/tools/pyzoFileBrowser/tasks.py
@@ -146,7 +146,7 @@ class PeekTask(proxies.Task):
         '"""': re.compile(r'(^|[^\\])(\\\\)*"""'),
     }
 
-    definition = re.compile(r"^(def|class)\s*(\w*)")
+    definition = re.compile(r"^(def|class)\s+(\w+)")
 
     def process(self, proxy):
         path = proxy.path()

--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -556,7 +556,7 @@ class TemporaryDirItem:
 class TemporaryFileItem:
     """Created when searching. This object posts a requests to search
     its contents which are then processed, after which this object
-    disbands itself, passin the proxy object to a real FileItem if the
+    disbands itself, passing the proxy object to a real FileItem if the
     search had results.
     """
 
@@ -608,7 +608,7 @@ class Tree(QtWidgets.QTreeWidget):
         self.setHeaderHidden(True)
         self.setIconSize(QtCore.QSize(24, 16))
 
-        # Connecy signals
+        # Connect signals
         self.itemExpanded.connect(self.onItemExpanded)
         self.itemCollapsed.connect(self.onItemCollapsed)
         self.itemClicked.connect(self.onItemClicked)
@@ -681,7 +681,7 @@ class Tree(QtWidgets.QTreeWidget):
 
     def clear(self):
         """Overload the clear method to remove the items in a nice
-        way, alowing the pathProxy instance to be closed correctly.
+        way, allowing the pathProxy instance to be closed correctly.
         """
         # Clear temporary (invisible) items
         for item in self._temporaryItems:


### PR DESCRIPTION
This PR fixes some minor issues I encountered in the filebrowser tool:

The peek task which extracts top level class and function definitions interpreted an identifier `default` as function `def ault`.

A method name was wrong, but that code line was never executed anyways.

And I also fixed some typos in comments and docstrings.