### PR TITLE
remove support for Qt4 GUI event loops

### DIFF
--- a/pyzo/__init__.py
+++ b/pyzo/__init__.py
@@ -24,7 +24,7 @@ and workspace.
 * *Multiple shells* can be used at the same time, and can be of different
   Python versions (from v2.7 to 3.x, including PyPy)
 * Support for using several *GUI toolkits* interactively:
-  asyncio, PySide, PySide2, PyQt4, PyQt5, wx, fltk, GTK, Tk, Tornado.
+  asyncio, PySide2/6, PyQt5/6, wx, fltk, GTK, Tk, Tornado.
 * Run IPython shell or native shell.
 * *Full Unicode support* in both editor and shell.
 * Various handy *tools*, plus the ability to make your own.

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -99,9 +99,6 @@ class ShellInfo_ipython(QtWidgets.QCheckBox):
 
 
 class ShellInfo_gui(QtWidgets.QComboBox):
-    # For (backward) compatibility
-    COMPAT = {"QT4": "PYQT4"}
-
     # GUI names
     GUIS = [
         ("None", "no GUI support"),
@@ -109,10 +106,8 @@ class ShellInfo_gui(QtWidgets.QComboBox):
         ("Asyncio", "Python's builtin event loop"),
         ("PySide6", "LGPL licensed wrapper to Qt6"),
         ("PySide2", "LGPL licensed wrapper to Qt5"),
-        ("PySide", "LGPL licensed wrapper to Qt4"),
         ("PyQt6", "GPL/commercial licensed wrapper to Qt6"),
         ("PyQt5", "GPL/commercial licensed wrapper to Qt5"),
-        ("PyQt4", "GPL/commercial licensed wrapper to Qt4"),
         ("Tornado", "Tornado asynchronous networking library"),
         ("Tk", "Tk widget toolkit"),
         ("WX", "wxPython"),
@@ -125,7 +120,6 @@ class ShellInfo_gui(QtWidgets.QComboBox):
     def setTheText(self, value):
         # Process value
         value = value.upper()
-        value = self.COMPAT.get(value, value)
 
         # Set options
         ii = 0

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -527,8 +527,6 @@ class PyzoInterpreter:
                     ("PYQT6", guiintegration.App_pyqt6),
                     ("PYSIDE2", guiintegration.App_pyside2),
                     ("PYQT5", guiintegration.App_pyqt5),
-                    ("PYSIDE", guiintegration.App_pyside),
-                    ("PYQT4", guiintegration.App_pyqt4),
                     # ('WX', guiintegration.App_wx),
                     ("ASYNCIO", guiintegration.App_asyncio_new),
                     ("TK", guiintegration.App_tk),
@@ -553,14 +551,10 @@ class PyzoInterpreter:
                 self.guiApp = guiintegration.App_pyside6()
             elif guiName == "PYSIDE2":
                 self.guiApp = guiintegration.App_pyside2()
-            elif guiName == "PYSIDE":
-                self.guiApp = guiintegration.App_pyside()
             elif guiName in ["PYQT6", "QT6"]:
                 self.guiApp = guiintegration.App_pyqt6()
             elif guiName in ["PYQT5", "QT5"]:
                 self.guiApp = guiintegration.App_pyqt5()
-            elif guiName in ["PYQT4", "QT4"]:
-                self.guiApp = guiintegration.App_pyqt4()
             elif guiName == "FLTK":
                 self.guiApp = guiintegration.App_fltk()
             elif guiName == "GTK":


### PR DESCRIPTION
This will remove the support of event loops for PySide and PyQt4 in Pyzo kernels.
The reason is to make the Pyzo code easier to maintain and extend.