### PR TITLE
allow execution of multiple lines in the Logger tool

### DIFF
--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -93,11 +93,12 @@ class PyzoLoggerShell(BaseShell):
 
         # "Echo" stdin
         self.write(command, 1)
-        more = self._interpreter.push(command.rstrip("\n"))
-        if more:
-            self.write(str(sys.ps2), 2)
-        else:
-            self.write(str(sys.ps1), 2)
+        for line in command.splitlines():
+            more = self._interpreter.push(line)
+            if more:
+                self.write(str(sys.ps2), 2)
+            else:
+                self.write(str(sys.ps1), 2)
 
     def writeErr(self, msg):
         """This is what the logger uses to write errors."""


### PR DESCRIPTION
This PR makes it possible to insert and execute whole code blocks in Pyzo's Logger tool.

For example, the following code block can now be copied to the clipboard and then pasted and executed in the Logger tool:
```python3
def my_func(a, b):
    print('my_func', a, b)

my_func(1, 2)
```
