### PR TITLE
enhance "Find via File Browser" to use selection from widget with focus

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -962,11 +962,26 @@ class EditMenu(Menu):
     def _findViaFilebrowserCallback(self):
         fileBrowser = pyzo.toolManager.getTool("pyzofilebrowser")
         if fileBrowser is not None:
-            editor = pyzo.editors.getCurrentEditor()
-            if editor is None:
-                needle = ""
+            textWidgets = [
+                pyzo.editors.getCurrentEditor(),
+                pyzo.shells.getCurrentShell(),
+            ]
+
+            t = pyzo.toolManager.getTool("pyzologger")
+            if t:
+                textWidgets.append(t._logger_shell)
+
+            t = pyzo.toolManager.getTool("pyzointeractivehelp")
+            if t:
+                textWidgets.append(t._browser)
+
+            for w in textWidgets:
+                if w and w.hasFocus():
+                    needle = w.textCursor().selectedText().replace("\u2029", "\n")
+                    break
             else:
-                needle = editor.textCursor().selectedText().replace("\u2029", "\n")
+                needle = ""
+
             fileBrowser.setSearchText(needle, setFocus=True)
 
 


### PR DESCRIPTION
Up to now, the "Find via File Browser" action (e.g. triggered via Ctrl+Shift+F) copied the selected text in the editor to the search box of the file browser tool, no matter if the editor had the focus or not.

I modified the behavior so that the selected text in the editor will only be used as the needle if the editor widget has the keyboard focus. If the focus is in the shell instead, the selected text in the shell will be used as the needle. The same logic now goes for selected text in the "Logger" tool and the "Interactive help" tool.