### PR TITLE
fix search path for portable settings

### DIFF
--- a/pyzo/util/paths.py
+++ b/pyzo/util/paths.py
@@ -22,7 +22,7 @@ def prepare_appdata_appconfig_dirs():
     use_portable_settings = False
     if is_frozen():
         exec_dir = os.path.abspath(os.path.dirname(sys.executable))
-        for reldir in ("settings", "../settings"):
+        for reldir in ("_internal/settings", "settings", "../settings"):
             localpath = os.path.abspath(os.path.join(exec_dir, reldir))
             if os.path.isdir(localpath):
                 try:


### PR DESCRIPTION
Frozen (binary) Pyzo versions can be used with a portable settings folder by renaming the folder "_settings" to "settings".

The problem is that since around Pyzo v4.14.2, PyInstaller puts the Pyzo source code with the "_settings" folder inside a subfolder "_internal" next to the executable.

I fixed the search paths for that portable settings folder.