### PR TITLE
use file encoding information according to PEP 263

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1000,7 +1000,6 @@ class EditorTabs(QtWidgets.QWidget):
         editor = pyzo.editors.getCurrentEditor()
         sb = pyzo.main.statusBar()
         sb.updateCursorInfo(editor)
-        sb.updateFileEncodingInfo(editor)
 
     def getCurrentEditor(self):
         """Get the currently active editor."""
@@ -1403,14 +1402,10 @@ class EditorTabs(QtWidgets.QWidget):
         # get actual normalized filename
         filename = editor._filename
 
-        # notify
-        # TODO: message concerning line endings
-        print("saved file: {} ({})".format(filename, editor.lineEndingsHumanReadable))
         self._tabs.updateItems()
 
         # todo: this is where we once detected whether the file being saved was a style file.
 
-        # Notify done
         return True
 
     def saveFileCopy(self, editor, filename):
@@ -1433,9 +1428,6 @@ class EditorTabs(QtWidgets.QWidget):
             # Return now
             return False
 
-        print("saved file: {} ({})".format(filename, editor.lineEndingsHumanReadable))
-
-        # Notify done
         return True
 
     def saveAllFiles(self):

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -579,12 +579,6 @@ class FileMenu(Menu):
         self._lineEndingMenu = GeneralOptionsMenu(self, t, self._setLineEndings)
         self._lineEndingMenu.setOptions(["LF", "CR", "CRLF"])
 
-        # Create encoding menu
-        t = translate(
-            "menu", "Encoding ::: The character encoding of the current file."
-        )
-        self._encodingMenu = GeneralOptionsMenu(self, t, self._setEncoding)
-
         # Bind to signal
         pyzo.editors.currentChanged.connect(self.onEditorsCurrentChanged)
 
@@ -659,7 +653,6 @@ class FileMenu(Menu):
             self.addMenu(self._indentMenu, icons.page_white_gear),
             self.addMenu(self._parserMenu, icons.page_white_gear),
             self.addMenu(self._lineEndingMenu, icons.page_white_gear),
-            self.addMenu(self._encodingMenu, icons.page_white_gear),
         ]
 
         # Closing of app
@@ -699,8 +692,6 @@ class FileMenu(Menu):
             self._parserMenu.setCheckedOption(None, parserName)
             # Update line ending
             self._lineEndingMenu.setCheckedOption(None, editor.lineEndingsHumanReadable)
-            # Update encoding
-            self._updateEncoding(editor)
 
     def _setParser(self, value):
         editor = pyzo.editors.getCurrentEditor()
@@ -712,45 +703,6 @@ class FileMenu(Menu):
     def _setLineEndings(self, value):
         editor = pyzo.editors.getCurrentEditor()
         editor.lineEndings = value
-
-    def _updateEncoding(self, editor):
-        # Dict with encoding aliases (official to aliases)
-        D = {
-            "cp1250": ("windows-1252",),
-            "cp1251": ("windows-1251",),
-            "latin_1": ("iso-8859-1", "iso8859-1", "cp819", "latin", "latin1", "L1"),
-        }
-        # Dict with aliases mapping to "official value"
-        Da = {alias: orig for orig, aliasTuple in D.items() for alias in aliasTuple}
-
-        # Encodings to list
-        encodings = ["utf-8", "ascii", "latin_1", "cp1250", "cp1251"]
-
-        # Get current encoding (add if not present)
-        editorEncoding = editor.encoding
-        if editorEncoding in Da:
-            editorEncoding = Da[editorEncoding]
-        if editorEncoding not in encodings:
-            encodings.append(editorEncoding)
-
-        # Handle aliases
-        encodingNames, encodingValues = [], []
-        for encoding in encodings:
-            encodingValues.append(encoding)
-            if encoding in D:
-                name = "{} ({})".format(encoding, ", ".join(D[encoding]))
-                encodingNames.append(name)
-            else:
-                encodingNames.append(encoding)
-
-        # Update
-        self._encodingMenu.setOptions(encodingNames, encodingValues)
-        self._encodingMenu.setCheckedOption(None, editorEncoding)
-
-    def _setEncoding(self, value):
-        editor = pyzo.editors.getCurrentEditor()
-        if editor is not None:
-            editor.encoding = value
 
     def _pdfExport(self):
         dialog = PdfExport()

--- a/pyzo/core/statusbar.py
+++ b/pyzo/core/statusbar.py
@@ -16,11 +16,6 @@ class StatusBar(QtWidgets.QStatusBar):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        # File encoding
-        self.file_encoding = QtWidgets.QLabel(self)
-        self.file_encoding.setFixedWidth(100)
-        self.insertPermanentWidget(0, self.file_encoding, 0)
-
         # Cursor position
         self.cursor_pos = QtWidgets.QLabel(self)
         self.cursor_pos.setFixedWidth(190)
@@ -36,10 +31,3 @@ class StatusBar(QtWidgets.QStatusBar):
 
         position_txt = "Line: {}, Column: {} ".format(nrow, ncol)
         self.cursor_pos.setText(position_txt)
-
-    def updateFileEncodingInfo(self, editor):
-        fe_txt = ""
-        if editor:
-            fe_txt = editor.encoding.upper()
-
-        self.file_encoding.setText(fe_txt)


### PR DESCRIPTION
This PR fixes some weird behavior and flaws of Pyzo regarding handling of file encoding and BOM by the editor.

**The current situation (before this PR) is as follows:**
* When opening a file, the encoding is either utf-8 or the encoding specified via the [PEP-263 magic comment](https://peps.python.org/pep-0263/#examples).
* Invalid bytes that are encountered during decoding are silently replaced with a special character (�) -- there is no indication to the user about that, not even in the Logger tool, and the document is marked as unmodified.
* Reloading the file (e.g. after a change of the file modification date) always uses utf-8 encoding even it the file was originally opened with a different encoding. Decoding errors then abort the reloading, and the only indication about that is an exception in the Logger tool and a short message in the status bar (if enabled).
* The encoding selection in the menu (via File -> Encoding) is mostly useless. It displays the encoding from the PEP-263 magic comment, and this reflects the encoding that will be used when saving the file, but that is all. When changing that encoding manually, then saving the file and reopening or reloading that file, that encoding selection is lost. That menu cannot be used to override the encoding that should be used for opening a file.
* When saving a file, a modified or added PEP-263 magic comment will be ignored -- the encoding used will be the one that was determined when opening the file or the one from manually changing via the menu.
* The byte order mark for UTF-8 is allowed according to PEP-263, but Pyzo will remove that BOM when saving changes to the document.

**This PR changes the handling of encodings and byte-order-marks:**
The encoding of a loaded or a newly created file is not a state anymore.
The only thing the editor has to remember about encoding is if there was a BOM_UTF8 in the loaded file.

When loading text from a file, the encoding is determined as follows, similar to PEP 263:
    1) If there is a known BOM, the encoding is defined by the BOM.
    2) Otherwise, if there is a magic comment with a known encoding name,
       then this encoding name will be used.  e.g.: `# -*- coding: latin-1 -*-`
    3) Otherwise utf-8 will be used.

If decoding fails, other encoding candidates from 2) or 3) will be tried as well.
If decoding still fails, ascii with backslashreplace will be used, a warning will
be displayed, and the document will be marked as modified after loading.
The warning consists of a message box and a log entry.

And when saving text to a file:
    1) If there is a magic comment with a known encoding name in the unsaved text,
       that encoding will be used for saving the file.
    2) Otherwise utf-8 encoding will be used.

If there was a BOM_UTF8 present when originally loading the file, that BOM will
only be written to the file if the encoding for saving is utf-8 or utf-8-sig.
Other BOMs, such as BOM_UTF16_LE, will always be discarded when writing a file (because of PEP-263).


I will merge this PR in a few days.