### PR TITLE
support encodings and BOM in files when run as script

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -31,6 +31,7 @@ import inspect  # noqa - Must be in this namespace
 import bdb
 import linecache
 import signal
+import tokenize
 
 import yoton
 from pyzokernel import guiintegration, printDirect
@@ -939,12 +940,16 @@ class PyzoInterpreter:
 
         # Get text (make sure it ends with a newline)
         try:
+            encoding = "utf-8-sig"
             with open(fname, "rb") as fd:
                 bb = fd.read()
-            encoding = "UTF-8"
-            firstline = bb.split(b"\n", 1)[0].decode("ascii", "ignore")
-            if firstline.startswith("#") and "coding" in firstline:
-                encoding = firstline.split("coding", 1)[-1].strip(" \t\r\n:=-*")
+                if PYTHON_VERSION >= 3:
+                    fd.seek(0)
+                    encoding = tokenize.detect_encoding(fd.readline)[0]
+            if PYTHON_VERSION < 3:
+                firstline = bb.split(b"\n", 1)[0].decode("ascii", "ignore")
+                if firstline.startswith("#") and "coding" in firstline:
+                    encoding = firstline.split("coding", 1)[-1].strip(" \t\r\n:=-*")
             source = bb.decode(encoding)
         except Exception:
             printDirect(


### PR DESCRIPTION
This improves the support of encodings in files when they are run **as a script** (via `PyzoInterpreter.runfile(...)` in the kernel).

For Python 2.7 this means a support of an optional BOM_UTF8. The parsing of the magic PEP 263 comment is still only partially implemented -- for example no support for the encoding information in the second line.

For Python 3 this means the best possible recognition of the encoding via `tokenize.detect_encoding`. This also correctly detects a BOM_UTF8.

Not to be confused with "Execute file/cell/..." in the "Run" menu which all use the source code decoded by the editor.