### PR TITLE
improve editor file reloading and add automatic reloading

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1533,6 +1533,7 @@ class EditorTabs(QtWidgets.QWidget):
                         break
             else:
                 self._tabs.removeTab(editor)
+            editor.close()  # close event of the editor will do some clean-up
 
         # Clear any breakpoints that it may have had
         self.updateBreakPoints()

--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -70,6 +70,7 @@ advanced = dict:
     titleText = '{fileName} ({fullPath}) - Interactive Editor for Python'
     find_autoHide_timeout = 10
     useNativeFileDialogs = 1
+    autoReloadFilesInEditor = 0
 
 tools = dict:
     pyzologger = dict:


### PR DESCRIPTION
Before this PR there was the danger of data loss after reloading:
User adds changes to a file and saves it (and keeps the file open in the Pyzo editor).
An external program rewrites the file.
The user switches focus in Pyzo and gets the "File was changed" dialog.
User presses "Keep this version".
User closes Pyzo. Changes are lost because Pyzo does not even ask to save the version in the editor.
With this PR, when pressing "Keep this version" the document in the editor is marked as modified.

Pyzo does a file modification check as well when the user saves the file (e.g. via Ctrl+S).
Before this PR, the check displayed a message box with choices "Keep this version" and "Reload". In my opinion, "Reload" is a bit out of place when saving a file.
With this PR, the check while saving gets its own dialog with choices "Cancel saving" and "Overwrite file".

When checking for external changes to a loaded file, indicated via the file modification metadata of the filesystem, the originally loaded/saved data from the Pyzo editor will be compared to the new data in the file. If the contents are equal, the file is considered unmodified. The Pyzo editor keeps the whole original binary data in memory for that comparison when loading and saving a file.

If a file that is opened with unsaved changes in the Pyzo editor was changed on the storage, Pyzo will ask to either "Keep this version" or to "Reload".
But if the opened file has no unsaved changes (white symbol instead of red symbol with floppy disk), Pyzo will now also give the third choice "Always reload". When clicking that button, the "auto reload" feature will be activated, and the user gets informed about that auto-reload feature and how to disable it again (in the "Advanced settings" dialog). The auto-reload feature will automatically reload files that are not marked as modified in the Pyzo editor instead of asking the user.

A use case for auto reloading is when having the same files open in Pyzo and another editor application, as mentioned in #1155. Auto reloading might also be useful when switching branches in git, for example.