### PR TITLE
fix statusbar

### DIFF
--- a/pyzo/core/statusbar.py
+++ b/pyzo/core/statusbar.py
@@ -19,7 +19,7 @@ class StatusBar(QtWidgets.QStatusBar):
         # Cursor position
         self.cursor_pos = QtWidgets.QLabel(self)
         self.cursor_pos.setFixedWidth(190)
-        self.insertPermanentWidget(1, self.cursor_pos, 0)
+        self.addPermanentWidget(self.cursor_pos)
 
     def updateCursorInfo(self, editor):
         # Get current line number


### PR DESCRIPTION
This is a fix for a bug that I introduced via #1159, causing the warning message `QStatusBar::insertPermanentWidget: Index out of range (1), appending widget` to be displayed when Pyzo was started in a terminal.