### PR TITLE
fix autocompletion for parsed class members (without introspection)

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1417,9 +1417,10 @@ class PythonShell(BaseShell):
         aco.addNames(foundNames)
 
         # Process list
-        if aco.name and not foundNames:
-            # No names found for the requested name. This means
-            # it does not exist, let's try to import it
+        if aco.name and not foundNames and not aco.names:
+            # No names found for the requested name, and no names from
+            # fictive class members (via code parser in the editor).
+            # Let's try to import it.
             importNames, importLines = pyzo.parser.getFictiveImports(editor1)
             baseName = aco.nameInImportNames(importNames)
             if baseName:


### PR DESCRIPTION
```python3
class MyClass:
    def my_method(self):
        pass
```
When the code above is entered in the editor, without having a `MyClass` object in the shell, autocompletion for object `MyClass` is done via parsing the code ("fictive" class members, etc.).
When typing `MyClass.m` in the editor, autocompletion immediately suggests `my_method`, so this works fine.
But when only typing `MyClass.` in the editor, there is no autocompletion list.

The cause of the problem was that with `MyClass.` Pyzo expected `MyClass` to be a Python package that was not yet imported and tried to do an auto-import, but there is no line `import MyClass` in the editor. Then Pyzo proceeded to abort autocompletion even though there were detected fictive class members in the auto completion list.


I fixed that, so that autocompletion without introspection also works when typing `MyClass.`.
