### PR TITLE
fix autocompletion with auto-import

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1434,10 +1434,9 @@ class PythonShell(BaseShell):
                     time.sleep(0.2)
                     # To be sure, decrease the expiration date on the buffer
                     aco.setBuffer(timeout=1)
-                    # Repost request
-                    future = self._request.signature(aco.name)
-                    future.add_done_callback(self._processAutoComp_response)
-                    future.aco = aco
+
+                    # repost request; self._importAttempts will prevent infinite loop
+                    self.processAutoComp(aco)
         else:
             # If still required, show list, otherwise only store result
             if self._currentACO is aco:


### PR DESCRIPTION
Autocompletion with auto-import is supposed to automatically import a module and then show the autocompletion list.

For example, when starting a new shell and creating a new editor with the contents
```python3
import sys
...
```
and then typing `sys.`, the command `import sys  # auto-import` is automatically executed in the shell after typing the dot, but in reality, no autocompletion is shown.
As far as I have seen, this is an old bug which was introduced in Pyzo 3.0 (around 13 years ago).
Instead of re-trying the `dir` introspection method after the import, the call signature was requested, which makes no sense.

When using an enum class, there was an autocompletion list, but the list entries were just the unique characters of the call signature string:
```python3
import enum

class MyEnum(enum.Enum):
    my_value = 1

MyEnum.
```

I fixed that, and now autocompletion with auto-import works properly, for example:
```python3

import numpy as np

# type a dot after "np" in the next line to see the autocompletion list
np

##

import sys

# type a dot after "sys" in the next line to see the autocompletion list
sys
```


