### PR TITLE
improve autocompletion for derived classes via introspection (e.g. enum.Enum)

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -917,9 +917,6 @@ class PyzoEditor(BaseTextCtrl):
         if aco.tryUsingBuffer():
             return
 
-        # Init name to poll by remote process (can be changed!)
-        nameForShell = aco.name
-
         # Get normal fictive namespace
         fictiveNS = pyzo.parser.getFictiveNameSpace(self)
         fictiveNS = set(fictiveNS)
@@ -954,13 +951,11 @@ class PyzoEditor(BaseTextCtrl):
                             # current class, see https://github.com/pyzo/pyzo/issues/944
                             break
                 else:
-                    nameForShell = className
                     break
 
         # If there's a shell, let it finish the autocompletion
         shell = pyzo.shells.getCurrentShell()
         if shell:
-            aco.name = nameForShell  # might be the same or a base class
             shell.processAutoComp(aco)
         else:
             # Otherwise we finish it ourselves


### PR DESCRIPTION
Autocompletion for enum classes does not list the enum members (via introspection), for example:

```python3
import enum

class MyEnum(enum.Enum):
    my_value1 = 1
    my_value2 = 2


# type a dot after "MyEnum" in the next line to see the autocompletion list
MyEnum
```

This is because method `processAutoComp` changes the name of the object to be introspected from `MyEnum` to `enum.Enum`.

With the changes in this PR, autocompletion will use the actual class as the object to be inspected, e.g. `MyEnum` for the example above. This will then show the enum values in the autocompletion list.

@almarklein:
This change of `nameForShell` was done when a base class was not found in the "fictive" namespace from the editor's code parser, and this was already since the first Pyzo version 2.1 that I encountered on GitHub. Is there any case where this change of `nameForShell` is necessary?
