### PR TITLE
fix resetting color in terminal emulation

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1093,7 +1093,9 @@ class ShellWriter:
                 clr = self.COLORS[param - 30]
                 format.setForeground(QtGui.QColor(clr))
             elif param == 39:  # reset the foreground color
-                format.setForeground(defaultFormat.foreground().color())
+                fg = defaultFormat.foreground()
+                # we also need to set the brush style because it could be BrushStyle.NoBrush
+                format.setForeground(QtGui.QBrush(fg.color(), fg.style()))
             elif 40 <= param <= 47:
                 pass  # cannot set background text in QPlainTextEdit
             else:

--- a/pyzo/resources/code_examples/pyzo_terminal_emulation.py
+++ b/pyzo/resources/code_examples/pyzo_terminal_emulation.py
@@ -160,6 +160,23 @@ yellow = build_fmt(Fmt.yellow)
 print(f'Hello {underline}world {bold_red}via {blue_italic}Py{yellow}thon{normal}!')
 
 
+## resetting only the text color via escape code 39
+
+print(
+    '\x1b[3m'
+    'italic'  # --> default color, italic
+    '  '
+    '\x1b[31m'
+    'italic red'  # --> as before, but with red text
+    '  '
+    '\x1b[39m'  # --> reset text color, but keep italic
+    'normal color'
+    '  '
+    '\x1b[0m'  # --> reset whole format (use color, and remove italic)
+    'normal'
+)
+
+
 ## progress bar example
 
 import time


### PR DESCRIPTION
Text formatting via terminal emulation escape sequences did not work properly for escape code 39 ("default foreground color").

The problem can be reproduced by executing
`print('normal  \x1b[39m should also be normal  \x1b[0m normal')`
The bug causes the text "should also be normal" to be printed in black.

This PR fixes the problem.


