### PR TITLE
always close autocompletion pop-up when clicking in the editor resp. shell

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -63,10 +63,6 @@ class AutoCompletion:
         # Text position corresponding to first character of the word being completed
         self.__autocompleteStart = None
 
-        # text position where the last update of the completion list was performed
-        # (after typing a new character)
-        self.__autocompleteCursorLastUpdate = None
-
         # We show the popup when this many chars have been input
         self.__autocompleteMinChars = 3
         self.__autocompleteFromObject = False
@@ -80,7 +76,6 @@ class AutoCompletion:
         self.__highlightedCompletion = None
         self.__completer.activated.connect(self.onAutoComplete)
         self.__completer.highlighted.connect(self._setHighlightedCompletion)
-        self.cursorPositionChanged.connect(self.__onCursorPositionChanged)
 
     def _setHighlightedCompletion(self, value):
         """Keeping track of the highlighted item allows us
@@ -177,7 +172,6 @@ class AutoCompletion:
         self.__completerWindow.hide()
         self.__autocompleteStart = None
         self.__autocompleteVisible = False
-        self.__autocompleteCursorLastUpdate = None
         if self.__finishedCallback is not None:
             self.__finishedCallback()
 
@@ -275,8 +269,6 @@ class AutoCompletion:
         cursor.setPosition(
             self.__autocompleteStart.position(), cursor.MoveMode.KeepAnchor
         )
-
-        self.__autocompleteCursorLastUpdate = self.textCursor()
 
         prefix = cursor.selectedText()
         if (
@@ -403,13 +395,7 @@ class AutoCompletion:
             self.__positionAutocompleter()
             self.__updateAutocompleterPrefix()
 
-    def __onCursorPositionChanged(self, *args):
+    def mousePressEvent(self, event):
         if self.autocompleteActive():
-            # If the user moves the cursor using the mouse and sets the cursor
-            # outside the word/attribute to be autocompleted, then cancel autocompletion.
-            if (
-                not self._AutoCompletion__autocompleteStart.position()
-                < self.textCursor().position()
-                <= self.__autocompleteCursorLastUpdate.position()
-            ):
-                self.autocompleteCancel()
+            self.autocompleteCancel()
+        super().mousePressEvent(event)


### PR DESCRIPTION
Autocompletion will now always be canceled when clicking in the QPlainTextEdit widget. This is a more general approach than #1180.