### PR TITLE
fix parenthesis highlighter for cursors with text selection

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -339,6 +339,11 @@ class HighlightMatchingBracket:
             return
 
         cursor = QtGui.QTextCursor(self.textCursor())
+
+        # We need to clear the selection because otherwise movePosition(MoveOperation.Right)
+        # moves the cursor to the right end of the selection instead of advancing by one step.
+        cursor.clearSelection()
+
         if cursor.atBlockStart():
             cursor.movePosition(cursor.MoveOperation.Right)
             movedRight = True


### PR DESCRIPTION
As reported in #1183, highlighting parens/brackets/braces did not work when having a cursor with a selected text.
There was also a bug with highlighting when having text selection from left to right (instead of right to left).

Examples to reproduces the problem:
