### PR TITLE
SourceSctructure font change and comment cell display

### DIFF
--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -176,6 +176,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
         prevEditor = self._getCurEditorFromRef()
         if prevEditor is not None:
             prevEditor.cursorPositionChanged.disconnect(self.callbackPosChanged)
+            prevEditor.fontChanged.disconnect(self.updateStructure)
         self._curEditorRef = None
 
         # Get editor and clear list
@@ -350,7 +351,9 @@ class PyzoSourceStructure(QtWidgets.QWidget):
                     text = "- " + object.name
                 elif type in ("cell", "##", "#%%", "# %%"):
                     type = "cell"
-                    text = "## {:<120}".format(object.name) # pad to length 120 with whitespaces
+                    # pad to length 120 with whitespaces so that the
+                    # whole line is underlined
+                    text = "## {:<120}".format(object.name)
                 else:
                     text = "{} {}".format(type, object.name)
 
@@ -358,7 +361,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
                 thisItem = QtWidgets.QTreeWidgetItem(parentItem, [text])
                 color = QtGui.QColor(colors[object.type])
                 thisItem.setForeground(0, QtGui.QBrush(color))
-                font = curEditor.font() # Same font as code editor
+                font = curEditor.font()  # Same font as code editor
                 font.setBold(True)
                 if type == "cell":
                     font.setUnderline(True)

--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -194,6 +194,9 @@ class PyzoSourceStructure(QtWidgets.QWidget):
             self.updateStructure()
 
             editor.cursorPositionChanged.connect(self.callbackPosChanged)
+            
+            # Update when code editor font changes
+            editor.fontChanged.connect(self.updateStructure)
 
     def callbackPosChanged(self, *args):
         self.updateSelection()
@@ -347,7 +350,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
                     text = "- " + object.name
                 elif type in ("cell", "##", "#%%", "# %%"):
                     type = "cell"
-                    text = "## " + object.name + " " * 120
+                    text = "## {:<120}".format(object.name) # pad to length 120 with whitespaces
                 else:
                     text = "{} {}".format(type, object.name)
 
@@ -355,7 +358,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
                 thisItem = QtWidgets.QTreeWidgetItem(parentItem, [text])
                 color = QtGui.QColor(colors[object.type])
                 thisItem.setForeground(0, QtGui.QBrush(color))
-                font = thisItem.font(0)
+                font = curEditor.font() # Same font as code editor
                 font.setBold(True)
                 if type == "cell":
                     font.setUnderline(True)

--- a/pyzo/tools/pyzoSourceStructure.py
+++ b/pyzo/tools/pyzoSourceStructure.py
@@ -194,7 +194,7 @@ class PyzoSourceStructure(QtWidgets.QWidget):
             self.updateStructure()
 
             editor.cursorPositionChanged.connect(self.callbackPosChanged)
-            
+
             # Update when code editor font changes
             editor.fontChanged.connect(self.updateStructure)
 


### PR DESCRIPTION
# Changes
- Change font of source structure tool to match codeeditor
- force update of source structure tool when font of code editor changes
- update cell display text to be of length 120 at least to align the underlining.

# Motivation
This change was motivated by the fact that the underlining isn't justified in the source structure tool for comment cells, which is quite visible in files with a lot of cell comments. This stems from two sources:
1. A fixed pad of 120 whitespaces after the cell name
2. The use of a non-monospace font (sans serif, I think).

Therefore, I propose a change that forces the font of the source structure to match the font of the code editor (which is always monospace), and pad the name of the cell comment to 120 rather than add 120 whitespaces.