### PR TITLE
Fix auto-closing quotes for upper case string literal prefixes

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -632,7 +632,7 @@ class AutoCloseQuotesAndBrackets:
                     )  # don't add a fourth " when typing " after two "
                     or (
                         isinstance(tokenL, IdentifierToken)
-                        and str(tokenL) not in stringLiteralPrefixes
+                        and str(tokenL).lower() not in stringLiteralPrefixes
                     )
                 ):
                     super().keyPressEvent(event)


### PR DESCRIPTION
Hi,

This is a very small PR to make double-quoting consistent for upper-case and lower-case string litteral.

# Duplicating the inconsistency

type any valid lower-case string litteral identifier such as `f`, then press a quote as if to open a string `"`. This quote should automatically be doubled:

<img src="https://github.com/user-attachments/assets/f0943721-569c-4a82-ad19-fc78fab38c13" height="20" />

now do the same for an upper case string litteral (`F` here):

<img src="https://github.com/user-attachments/assets/f46d2574-ccaf-45a5-ae0a-67267b4caaad" height="20" />

Note that this behavior is the same even if the string identifer is only partly upper-case:

<img src="https://github.com/user-attachments/assets/d0b128ec-379f-4a4b-afae-59dab4682def" height="20" />

# Change implemented

Now a double quote is added as long as the prefix is valid:

<img src="https://github.com/user-attachments/assets/31e8b442-fb2c-4912-a45e-b7fc400e585d" height="65" />

