### PR TITLE
add parser support for template string literals (t prefix)

### DIFF
--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -440,7 +440,7 @@ class CellCommentToken(CommentToken):
     defaultStyle = "bold:yes, underline:yes"
 
 
-stringLiteralPrefixes = frozenset("u|r|b|f|rb|br|rf|fr".split("|"))
+stringLiteralPrefixes = frozenset("u|r|b|f|rb|br|rf|fr|t|rt|tr".split("|"))
 
 # This regexp is used to find special stuff, such as comments, numbers and
 # strings.


### PR DESCRIPTION
This PR adds support for new "template string" literals, as defined in [PEP 750](https://peps.python.org/pep-0750/) and introduced in Python 3.14
for syntax highlighting, auto-closing quotes, ...
example: `t"Hello {name}"`