### PR TITLE
ask to save when running temporary file as script

### DIFF
--- a/pyzo/util/pyzowizard.py
+++ b/pyzo/util/pyzowizard.py
@@ -366,9 +366,10 @@ class RuncodeWizardPage2(BasePyzoWizardPage):
         translate(
             "wizard",
             """You can run the current file or the main file normally, or as a script.
-        When run as script, the shell is restarted to provide a clean
-        environment. The shell is also initialized differently so that it
-        closely resembles a normal script execution.""",
+        When run as script, the file is saved first. Then the shell is restarted to provide
+        a clean environment before executing the file.
+        The shell is also initialized differently so that it closely resembles a normal
+        script execution.""",
         ),
         translate(
             "wizard",


### PR DESCRIPTION
Before this PR, if an editor is executed via "Run (main) file as script" and the script was never saved (i.e. the editor is named "\<tmp x\>"), then executing the script is aborted and the user gets the error message "Can only run scripts that are in the file system.".

After this PR, the file-save-as dialog will appear in such a case and the script will be executed afterwards. If the file-save-as dialog is canceled, the error message "could not save the file" will be shown and script execution will be not be started.

I updated the tooltip text and the information in the Pyzo wizard to make it clearer to users that files are always saved when running them as script.

I also fixed a bug: When the script is modified outside Pyzo, Pyzo recognizes that and asks the user what to do when saving the file. If the user decides to cancel saving, script execution will now be aborted instead of running the different version in the file system.

related issue: #1192 