### PR TITLE
set cursor info text in status bar to dynamic width

### DIFF
--- a/pyzo/core/statusbar.py
+++ b/pyzo/core/statusbar.py
@@ -18,7 +18,6 @@ class StatusBar(QtWidgets.QStatusBar):
 
         # Cursor position
         self.cursor_pos = QtWidgets.QLabel(self)
-        self.cursor_pos.setFixedWidth(190)
         self.addPermanentWidget(self.cursor_pos)
 
     def updateCursorInfo(self, editor):


### PR DESCRIPTION
The label on the very right of the status bar will now have dynamic width. This prevents larger numbers of line number, column number and selection length to be cut off.