### PR TITLE
fix interactive help for autocompletion when Snippets tool active

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -988,8 +988,7 @@ class PyzoEditor(BaseTextCtrl):
             if fullName is not None and snipTool.isSnipName(fullName):
                 snipTool.showHelpForSnip(fullName)
                 return
-        else:
-            super()._onAutocompleteSelectionChanged(name)
+        super()._onAutocompleteSelectionChanged(name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes the problem that the interactive help was not updated when changing the selection in the autocompletion list when the Snippets tool was active and a non-snippet object was being autocompleted.