### PR TITLE
fix "pip install" magic for filepaths

### DIFF
--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -170,7 +170,7 @@ class Magician:
         if interpreter._ipython and _detect_equalbang(line):
             return self.equalbang_quirk(line, command)
 
-        have_hard_chars = "cd ", "?"
+        have_hard_chars = "cd ", "?", "pip install "
         if PYTHON_VERSION >= 3 and not command.lower().startswith(have_hard_chars):
             try:
                 if _should_not_interpret_as_magic(line):


### PR DESCRIPTION
The line `pip install /tmp/abc_1.0_def/something.whl` was not recognized as a magic command when entered in the shell.
This was because `tokenize.tokenize` failed for `1.0_` in function `_should_not_interpret_as_magic` in file "magic.py".

I fixed this by allowing any characters after "pip install " for being recognized as a magic command.