### PR TITLE
prevent too large dialog windows on smaller screens

### DIFF
--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -616,7 +616,6 @@ class ShellInfoDialog(QtWidgets.QDialog):
         self.setLayout(mainLayout)
 
         self.setMinimumSize(800, 600)
-        self.resize(1024, 768)
 
         # Add an entry if there's none
         if not pyzo.config.shellConfigs2:
@@ -629,6 +628,11 @@ class ShellInfoDialog(QtWidgets.QDialog):
         self._list.setCurrentRow(0)
 
         self.show()
+
+    def sizeHint(self):
+        # We use this instead of self.resize(1024, 768) to avoid
+        # a too large dialog window on smaller screens.
+        return QtCore.QSize(1024, 768)
 
     def _addConfig(self, shellConfig=None, atIndex=-1, select=False):
         if atIndex == -1:

--- a/pyzo/core/themeEdit.py
+++ b/pyzo/core/themeEdit.py
@@ -473,10 +473,6 @@ class EditColorDialog(QtWidgets.QDialog):
         super().__init__(*args, **kwargs)
 
         self.setWindowTitle("Color scheme")
-        size = 1200, 800
-        offset = 0
-        size2 = size[0], size[1] + offset
-        self.resize(*size2)
 
         # Make a deep copy
         themes = {}
@@ -492,3 +488,8 @@ class EditColorDialog(QtWidgets.QDialog):
         layout.addWidget(self.editor, 1)
         layout.addWidget(self.editColor, 2)
         self.setLayout(layout)
+
+    def sizeHint(self):
+        # We use this instead of self.resize(1200, 800) to avoid
+        # a too large dialog window on smaller screens.
+        return QtCore.QSize(1200, 800)


### PR DESCRIPTION
When running Pyzo on a small screen size (in my case 1024 x 768 in a virtual machine), two dialogs were too large so that the accept and cancel buttons were out of reach.
I changed the code so that the large window size is only a recommendation for the Qt framework.