### PR TITLE
ignore newly introduced rule RUF059 in ruff linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,4 +86,5 @@ ignore = [
     "RUF002", # Docstring contains ambiguous RIGHT SINGLE QUOTATION MARK
     "RUF005", # Consider `[1, *bb]` instead of `[1] + bb`
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF059", # RUF059 Unpacked variable `...` is never used
 ]


### PR DESCRIPTION
Ruff 0.13.0 introduced a new rule RUF059 that made the linter complain about unused unpacked variables, for example: `protocol, hostname, port = split_address(address)`
RUF059 would complain if any of the three variables is not used afterwards

I added this rule to the ignore list because the variable names give useful information about what the function is returning besides the used variables.