### PR TITLE
fix Qt warning in Snippets tool and add more snippets

### DIFF
--- a/pyzo/resources/code_examples/snippets_example.py
+++ b/pyzo/resources/code_examples/snippets_example.py
@@ -79,3 +79,15 @@ import scipy.signal
 filter_b_a = scipy.signal.bessel(2, fc/(fs/2), 'lowpass')
 sig_f = scipy.signal.lfilter(*filter_b_a, sig)
 
+
+## SNIP: time_elapsed
+from time import perf_counter as _get_time
+# from time import time as _get_time
+t_start = _get_time()
+...
+print('elapsed:', t_delta := _get_time() - t_start, 's')
+
+
+## SNIP: Qt_import_PySide6
+from PySide6 import QtCore, QtGui, QtWidgets
+

--- a/pyzo/tools/pyzoSnippets.py
+++ b/pyzo/tools/pyzoSnippets.py
@@ -31,13 +31,13 @@ class PyzoSnippets(QtWidgets.QWidget):
         self._loadSnippets()
 
         # setup layout
-        self._layout = QtWidgets.QVBoxLayout(self)
+        self._layout = QtWidgets.QVBoxLayout()
         self.setLayout(self._layout)
-        self._hlayout = QtWidgets.QHBoxLayout(self)
+        self._hlayout = QtWidgets.QHBoxLayout()
         self._layout.addLayout(self._hlayout)
 
         # create tree widget
-        self._tree = QtWidgets.QTreeWidget(self)
+        self._tree = QtWidgets.QTreeWidget()
         self._tree.setHeaderHidden(True)
         self._tree.itemSelectionChanged.connect(self._onSelectionChanged)
         self._tree.itemDoubleClicked.connect(self._onItemDoubleClicked)
@@ -66,12 +66,12 @@ class PyzoSnippets(QtWidgets.QWidget):
         )
 
         # create search line edit
-        self._searchText = QtWidgets.QLineEdit(self)
+        self._searchText = QtWidgets.QLineEdit()
         self._searchText.textChanged.connect(self._updateTreeWidget)
         self._hlayout.addWidget(self._searchText)
 
         # create menu button
-        btn = QtWidgets.QToolButton(self)
+        btn = QtWidgets.QToolButton()
         self._menuButton = btn
         self._hlayout.addWidget(btn)
         btn.setIcon(pyzo.icons.application_view_list)


### PR DESCRIPTION
When starting Pyzo with the Snippets tool enabled there was a warning in the console:
`QLayout: Attempting to add QLayout "" to PyzoSnippets "", which already has a layout`

I fixed that and also added two more code snippets to the examples.