### PR TITLE
fix update of breakpoints after changing filepath in editor

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1386,7 +1386,14 @@ class EditorTabs(QtWidgets.QWidget):
         if filename:
             if saveCopyAs:
                 return self.saveFileCopy(editor, filename)
-            return self.saveFile(editor, filename)
+
+            oldId = editor.id()
+            saveOk = self.saveFile(editor, filename)
+            if editor.id() != oldId:
+                # We update all editors instead of only the current editor because otherwise
+                # breakpoints with the old filename (or <tmp x>) would not be removed.
+                self.updateBreakPoints()
+            return saveOk
         else:
             return False  # Cancel was pressed
 
@@ -1427,9 +1434,6 @@ class EditorTabs(QtWidgets.QWidget):
             m.exec()
             # Return now
             return False
-
-        # get actual normalized filename
-        filename = editor._filename
 
         self._tabs.updateItems()
 


### PR DESCRIPTION
### How to reproduce the problem
* create a new editor tab \<tmp x\>
* enter any valid Python command, e.g. `a = 1`
* set a breakpoint in that line
* save the file, e.g. as "/tmp/aa.py"
* run the file via Run -> Execute file
--> The code is executed but breakpoint is not triggered because it is still registered as file "\<tmp x\>" instead of "/tmp/aa.py".

### Fix
I added some code to update the breakpoints when the file in the editor is saved as a new/different file.
And I removed an unused assignment.