### PR TITLE
rework pip magic progress bar updates for newer pip versions

### DIFF
--- a/pyzo/pyzokernel/pipper.py
+++ b/pyzo/pyzokernel/pipper.py
@@ -1,9 +1,67 @@
+import re
 import sys
 import time
 import subprocess
 
 
-def subprocess_with_callback(callback, cmd, **kwargs):
+r"""
+Some explanations regarding the progress bars
+=============================================
+
+When executing "pip install ..." or "pip download ..." pip will display a progress bar
+for the download progress in the terminal.
+
+For older pip versions it was enough to just fordward the stdout of pip to the Pyzo shell
+to have a continuosly updating progress bar.
+But this stopped working with newer pip versions -- the progressbar was only displayed
+once when the whole download was already completed.
+
+
+With the curernt pip release v25.2 we have three ways to display the progress bar:
+1) use no workarounds, as in Pyzo <= v4.20:
+    The progressbar will only be displayed when finished.
+    --> bad user experience, because pip seems to be stuck for larger downloads
+2) use advanced terminal escape sequences
+    We can do this by setting some environment variables when calling pip via subprocess:
+        TERM="" (instead of "dumb")
+        TTY_COMPATIBLE=1
+    We would also have to implement or cleverly replace escape sequences such as:
+        b'\x1b[?25l'
+        b'\x1b[2K'
+        b'\x1b[?25h'
+    This would require some bigger workarounds, and future pip releases could make use of
+    different escape sequences.
+    --> not a stable interface
+3) use raw progress bars, which were introduced in pip v24.1 (2024-06-20)
+    see https://github.com/pypa/pip/issues/11508
+    To use these, we need to pass "--progress-bar=raw" to pip, if pip is new enough.
+    Instead of the rendered progress bar, pip will write simple lines such as
+        b'Progress 19398656 of 73160002\n'
+    for each update.
+    In Pyzo, we parse these lines and render our own progress bar.
+
+--> we use 3)
+
+
+more information about pip:
+    https://github.com/pypa/pip
+    https://pip.pypa.io/en/stable/news/
+"""
+
+
+def build_progress_line(current, total, fill_char):
+    bar_length = 40
+    if total > 0 and current >= 0:
+        percent = 100 * min(1, max(0, current / total))
+    else:
+        percent = 0
+    filled_length = round(percent / 100 * bar_length)
+    bar = fill_char * filled_length + " " * (bar_length - filled_length)
+    line = "[{}] {:3d} %   ({} of {})".format(bar, round(percent), current, total)
+    return line
+
+
+def subprocess_with_callback(callback, cmd, use_raw_progress_bar, **kwargs):
     """Execute command in subprocess, stdout is passed to the
     callback function. Returns the returncode of the process.
     If callback is None, simply prints any stdout.
@@ -24,19 +82,44 @@ def subprocess_with_callback(callback, cmd, **kwargs):
         callback(str(err) + "\n")
         return -1
 
-    progressBarDash = b"\xe2\x94\x81"  # U+2501, a thick horizontal line character
+    progress_bar_dash = b"\xe2\x94\x81"  # U+2501, a thick horizontal line character
     pending = b""
+    last_line_was_raw_progress_bar = False
     while p.poll() is None:
         time.sleep(0.001)
         # Read text and process
         c = p.stdout.read(1)
         pending += c
-        if c in b"-.\n" or pending.endswith(progressBarDash):
-            callback(pending.decode("utf-8", "ignore"))
-            pending = b""
+
+        if use_raw_progress_bar:
+            if c == b"\n":
+                mo = re.fullmatch(rb"Progress (\d+) of (\d+)\r?\n", pending)
+                if mo:
+                    current = int(mo[1])
+                    total = int(mo[2])
+                    pending = build_progress_line(
+                        current, total, progress_bar_dash.decode("utf-8")
+                    ).encode("utf-8")
+                    if last_line_was_raw_progress_bar:
+                        pending = b"\r" + pending
+                    last_line_was_raw_progress_bar = True
+                else:
+                    if last_line_was_raw_progress_bar:
+                        pending = b"\n" + pending
+                    last_line_was_raw_progress_bar = False
+
+                callback(pending.decode("utf-8", "ignore"))
+                pending = b""
+        else:
+            if c in b"-.\n" or pending.endswith(progress_bar_dash):
+                callback(pending.decode("utf-8", "ignore"))
+                pending = b""
 
     # Process remaining text
     pending += p.stdout.read()
+    if last_line_was_raw_progress_bar:
+        pending = b"\n" + pending
+
     callback(pending.decode("utf-8", "ignore"))
     p.stdout.close()  # avoid ResourceWarning: unclosed file <_io.BufferedReader>
 
@@ -49,21 +132,37 @@ def print_(p):
     sys.stdout.flush()
 
 
-def pip_command_exe(exe, *args):
-    """Do a pip command in the interpreter with the given exe."""
-
-    # Get pip command
-    cmd = [exe, "-m", "pip"] + list(args)
-
-    # Execute it
-    subprocess_with_callback(print_, cmd)
-
-
 def pip_command(*args):
     """Do a pip command, e.g. "install networkx".
     Installs in the current interpreter.
     """
-    pip_command_exe(sys.executable, *args)
+    args = list(args)
+    use_raw_progress_bar = True
+    if len(args) > 0 and args[0] in ["install", "download"]:
+        if get_pip_version() >= (24, 1):
+            args.insert(1, "--progress-bar=raw")
+        else:
+            use_raw_progress_bar = False
+
+    # By using use_raw_progress_bar=True as a default,
+    # writing to the Pyzo shell will only be performed on '\n'.
+    # --> better performance for "pip list" etc.
+
+    cmd = [sys.executable, "-m", "pip"] + args
+    subprocess_with_callback(print_, cmd, use_raw_progress_bar)
+
+
+def get_pip_version():
+    """Returns a tuple of mayor and minor version of the pip module."""
+    version = (0, 0)  # fallback value
+    cmd = [sys.executable, "-m", "pip", "--version"]
+    try:
+        returned_bytes = subprocess.check_output(cmd)  # e.g. b'pip 25.2 from ...'
+        version_string = returned_bytes.split(None, 2)[1].decode("ascii")
+        version = tuple(int(s) for s in version_string.split(".")[:2])
+    except Exception:
+        pass
+    return version
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When using the magic commands `pip install some_package_name` or `pip download some_package_name`, the displayed progress bar was not updated anymore with newer pip versions -- the progress bar was only printed when it already had 100 %, because pip did not send more updates to stdout.

I reworked the code so that for new pip versions >= v24.1 (released 2024-06-20) the progress bar updates work again, and I kept the old approach as a fallback solution for older pip versions.

See the large docstring at the beginning of pyzo/pyzokernel/pipper.py for more details.