### PR TITLE
prevent flood of exceptions when the shell's working directory is deleted

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1627,28 +1627,26 @@ class ShellContextMenu(ShellMenu):
         return self._shell
 
     def _editItemCallback(self, action):
-        # If the widget has a 'name' attribute, call it
+        msg = ""
         if action == "opendir":
             curdir = self._shell.get_kernel_cd()
-            fileBrowser = pyzo.toolManager.getTool("pyzofilebrowser")
-            if curdir and fileBrowser:
-                fileBrowser.setPath(curdir)
+            # Show error dialog
+            if curdir == "?":
+                msg = translate(
+                    "menu", "Could not determine the current working directory."
+                )
+            else:
+                fileBrowser = pyzo.toolManager.getTool("pyzofilebrowser")
+                if curdir and fileBrowser:
+                    fileBrowser.setPath(curdir)
         elif action == "changedir":
             fileBrowser = pyzo.toolManager.getTool("pyzofilebrowser")
             if fileBrowser:
                 self._shell.executeCommand("cd " + fileBrowser.path() + "\n")
         elif action == "changedirtoeditor":
-            msg = ""
             editor = pyzo.editors.getCurrentEditor()
-            if editor is None:
-                msg += translate("menu", "No editor selected.")
-            # Show error dialog
-            if msg:
-                m = QtWidgets.QMessageBox(self)
-                m.setWindowTitle(translate("menu dialog", "Could not change dir"))
-                m.setText(translate("menu", "Could not change dir" + ":\n\n" + msg))
-                m.setIcon(m.Icon.Warning)
-                m.exec()
+            if editor is not None:
+                msg = translate("menu", "No editor selected.")
             else:
                 self._shell.executeCommand(
                     "cd " + os.path.dirname(editor.filename) + "\n"
@@ -1657,6 +1655,14 @@ class ShellContextMenu(ShellMenu):
             self._shell.helpOnText(self._pos)
         else:
             getattr(self._shell, action)()
+
+        if msg:
+            # Show error dialog
+            m = QtWidgets.QMessageBox(self)
+            m.setWindowTitle(translate("menu dialog", "Could not change dir"))
+            m.setText(translate("menu", "Could not change dir" + ":\n\n" + msg))
+            m.setIcon(m.Icon.Warning)
+            m.exec()
 
     def _updateShells(self):
         pass

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1242,7 +1242,10 @@ class PythonShell(BaseShell):
     #             c.received.bind(self.poll)
 
     def get_kernel_cd(self):
-        """Get current working dir of kernel."""
+        """Get current working dir of kernel.
+
+        Returns the working directory, or "?" if it could not be determined.
+        """
         return self._stat_cd.recv()
 
     def _onReceivedStartupInfo(self, channel):

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -690,7 +690,14 @@ class PyzoInterpreter:
                 self.context._stat_interpreter.send("More")
             else:
                 self.context._stat_interpreter.send("Ready")
-            self.context._stat_cd.send(os.getcwd())
+            try:
+                cwd = os.getcwd()
+            except Exception:
+                # On Linux, if the current working directory has been deleted,
+                # then a FileNotFoundError Exception is raised.
+                # We cannot send an empty string, so we send a "?" to indicate the error.
+                cwd = "?"
+            self.context._stat_cd.send(cwd)
 
         # Are we still connected?
         if sys.stdin.closed or not self.context.connection_count:

--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -307,9 +307,13 @@ class Magician:
                 except Exception:
                     print('Could not change to directory "%s".' % path)
                     return ""
+            try:
                 newPath = os.getcwd()
-            else:
-                newPath = os.getcwd()
+            except Exception:
+                # On Linux, if the current working directory has been deleted,
+                # then a FileNotFoundError Exception is raised.
+                print("Could not determine the current working directory.")
+                return ""
             # Done
             print(repr(newPath))
             return ""


### PR DESCRIPTION
When the current working directory of the Python interpreter in the shell is deleted, the Pyzo kernel floods the shell with FileNotFoundError.
This problem can be reproduced in Linux by executing the following code:
```python3
import os
p = '/tmp/abcd'
os.makedirs(p)
os.chdir(p)
os.rmdir(p)
```

To fix this problem, the exception will be caught in the kernel code, and a string with value "?" will be communicated to the Pyzo IDE instead of the undefined current working directory. The CWD of the shell is only used in Pyzo for the shell context menu "Open current directory in file browser". When this action is performed with an undefined CWD, an error dialog will be shown.
And I also changed the `cd` magic command so that a custom error message will be shown instead of the exception.