### PR TITLE
fix code for new ruff linter rule B905

### DIFF
--- a/pyzo/codeeditor/extensions/appearance.py
+++ b/pyzo/codeeditor/extensions/appearance.py
@@ -246,7 +246,7 @@ class HighlightMatchingBracket:
     _BRACKS_CLOSE = ")]}"
     _BRACKS = _BRACKS_OPEN + _BRACKS_CLOSE
     _matchingBrackets = dict(
-        zip(_BRACKS_OPEN + _BRACKS_CLOSE, _BRACKS_CLOSE + _BRACKS_OPEN)
+        zip(_BRACKS_OPEN + _BRACKS_CLOSE, _BRACKS_CLOSE + _BRACKS_OPEN)  # noqa: B905
     )
 
     def highlightMatchingBracket(self):

--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -503,7 +503,7 @@ class GeneralOptionsMenu(Menu):
         # Get values
         if values is None:
             values = options
-        for option, value in zip(options, values):
+        for option, value in zip(options, values):  # noqa: B905
             self.addGroupItem(option, None, cb, value)
 
 

--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -59,7 +59,7 @@ def _detect_equalbang(line):
         # iteration on two successive elements, https://docs.python.org/3/library/itertools.html#itertools-recipes
         first, second = itertools.tee(gtoks)
         next(second, None)
-        for tok1, tok2 in zip(first, second):
+        for tok1, tok2 in zip(first, second):  # noqa: B905
             if (
                 tok1.type == token.OP
                 and tok1.string == "="


### PR DESCRIPTION
Ruff linter rule B905 "zip-without-explicit-strict" wants to have a `strict` keyword in every call to `zip`, but the `strict` argument was only introduced in Python 3.10.

We still support lower Python versions for the IDE and the shell/kernel, so we have to ignore that rule.