### PR TITLE
upgrade CI/CD workflows from macOS 13 to 15 for Intel CPUs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,10 +78,10 @@ jobs:
         name: dist-artifact-win32
 
   # A MacOS build for x86_64 (aka amd64). Via Rosetta this should work on all modern Macs.
-  # Use macos-13 to select x86_64
+  # Use macos-15-intel to select x86_64
   macos_x86_64:
     name: Build MacOS x86_64
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
             pyversion: '3.10'
             qtlib: pyqt5
           # --- PySide2 requires macOS with Intel CPU
-          - os: macos-13  # ... has Intel instead of Apple Silicon
+          - os: macos-15-intel  # ... has Intel instead of Apple Silicon
             pyversion: '3.9'
             qtlib: pyside2
           # --- Older Python versions and qt libs


### PR DESCRIPTION
because of deprecation

https://github.com/actions/runner-images/issues/13046