### PR TITLE
improve Qt wrapper for legacy exec_ and print_ methods

### DIFF
--- a/pyzo/_start.py
+++ b/pyzo/_start.py
@@ -286,10 +286,7 @@ def start():
         timer.start()
 
     # Enter the main loop
-    if hasattr(QtWidgets.qApp, "exec"):
-        QtWidgets.qApp.exec()
-    else:
-        QtWidgets.qApp.exec_()
+    QtWidgets.qApp.exec()
 
 
 ## Init

--- a/pyzo/core/pdfExport.py
+++ b/pyzo/core/pdfExport.py
@@ -90,7 +90,7 @@ class PdfExport(QtWidgets.QDialog):
         self._bottomLayout.addWidget(self._btnExport)
         self._bottomLayout.addWidget(self._btnDone)
 
-        self._preview.paintRequested.connect(self._editor.print_)
+        self._preview.paintRequested.connect(self._editor.print)
 
         self._updatePreview()
 
@@ -170,7 +170,7 @@ class PdfExport(QtWidgets.QDialog):
 
         self._printer.setOutputFileName(filename)
         self._updateTemporaryEditor()
-        self._editor.print_(self._printer)
+        self._editor.print(self._printer)
 
         if self._printer.printerState() == self._printer.PrinterState.Error:
             # Notify in logger

--- a/pyzo/qt/__init__.py
+++ b/pyzo/qt/__init__.py
@@ -121,15 +121,27 @@ if API in ("PySide2", "PyQt5"):
 if API == "PyQt6":
     QtWidgets.QFileSystemModel = QtGui.QFileSystemModel
 
-    import inspect
 
-    QtWidgets.QPlainTextEdit.print_ = inspect.getattr_static(
-        QtWidgets.QPlainTextEdit, "print"
-    )
-    QtWidgets.QMenu.exec_ = inspect.getattr_static(QtWidgets.QMenu, "exec")
-    del inspect
+@property
+def old_exec(self):
+    return self.exec_
 
-## QtPrintSupport fixes
 
-if API == "PyQt6":
-    QtPrintSupport.QPrintPreviewWidget.print_ = QtPrintSupport.QPrintPreviewWidget.print
+@property
+def old_print(self):
+    return self.print_
+
+
+if API in ("PySide2", "PyQt5"):
+    QtWidgets.QMenu.exec = old_exec
+    QtWidgets.QApplication.exec = old_exec
+    QtWidgets.QPlainTextEdit.print = old_print
+
+if API == "PySide6":
+    # In PySide6 v6.10.1 QPlainTextEdit still has "print_" but no "print" method.
+    # We check that before in case that it will be added in a future version.
+    if not hasattr(QtWidgets.QPlainTextEdit, "print"):
+        QtWidgets.QPlainTextEdit.print = old_print
+
+del old_exec
+del old_print

--- a/pyzo/tools/pyzoInteractiveHelp.py
+++ b/pyzo/tools/pyzoInteractiveHelp.py
@@ -476,7 +476,7 @@ class PyzoInteractiveHelp(QtWidgets.QWidget):
         )
         help.triggered.connect(partial(self.helpOnThis, pos=pos))
         menu.insertAction(menu.actions()[0], help)
-        menu.exec_(self.mapToGlobal(pos))
+        menu.exec(self.mapToGlobal(pos))
 
     def helpOnThis(self, pos):
         name = self._browser.textCursor().selectedText().strip()


### PR DESCRIPTION
The context menu in the "Interactive help" tool caused a warning from PySide6 because of the old `menu.exec_` instead of `menu.exec`.

I improved Pyzo's Qt wrapper so that we can use `exec` and `print` everywhere in the code (instead of `exec_` and `print_`), no matter if PySide2/6 or PyQt5/6 are used.