### PR TITLE
update syntax parser in Logger tool to Python3

### DIFF
--- a/pyzo/tools/pyzoLogger.py
+++ b/pyzo/tools/pyzoLogger.py
@@ -50,7 +50,7 @@ class PyzoLoggerShell(BaseShell):
         super().__init__(parent)
 
         # Set style to Python, or autocompletion does not work
-        self.setParser("python")
+        self.setParser("python3")
 
         # Change background color to make the logger look different from shell
         f1 = self.getStyleElementFormat("Editor.text")


### PR DESCRIPTION
In the "Logger" tool, identifiers like "print" and "exec" were still formatted as keywords.
But the logger is part of the Pyzo IDE which is run by a Python interpreter >= v3.6, so it makes no sense to still use syntax highlighting for old Python2.

Therefore I updated the parser to "python3".