### PR TITLE
allow copying in "History viewer" tool via Ctrl+C or menu Edit->Copy

### DIFF
--- a/pyzo/tools/pyzoHistoryViewer.py
+++ b/pyzo/tools/pyzoHistoryViewer.py
@@ -6,6 +6,7 @@ History class, which is a Qt model, and the PyzoHistoryViewer, which is a Qt vie
 
 """
 
+import types
 import pyzo
 from pyzo.qt import QtCore, QtGui, QtWidgets  # noqa
 from pyzo import translate
@@ -13,6 +14,10 @@ from pyzo.core.menu import Menu
 
 tool_name = translate("pyzoHistoryViewer", "History viewer")
 tool_summary = "Shows the last used commands."
+
+
+def copyForListWidget(self):
+    self.parent().copy()  # call the copy method of class PyzoHistoryViewer
 
 
 class PyzoHistoryViewer(QtWidgets.QWidget):
@@ -95,6 +100,12 @@ class PyzoHistoryViewer(QtWidgets.QWidget):
         pyzo.command_history.command_added.connect(self._on_command_added)
         pyzo.command_history.command_removed.connect(self._on_command_removed)
         pyzo.command_history.commands_reset.connect(self._on_commands_reset)
+
+        # Patch a copy method to the list widget. We need this because the Ctrl+C
+        # shortcut triggers the "Edit -> Copy" menu action. And in _editItemCallback
+        # the "copy" method of the widget with the focus is called.
+        # Otherwise Ctrl+C does not work to copy selected lines in the widget.
+        self._list.copy = types.MethodType(copyForListWidget, self._list)
 
     def _on_search(self):
         needle = self._search.text()


### PR DESCRIPTION
Selected entries in the "History viewer" list widget could only be copied via the context menu, but not with the default shortcuts such as Ctrl+C. The reason for this is that Ctrl+C triggered the "Edit -> Copy" menu action. The custom action callback `_editItemCallback` then obtained the widget with the focus and called its `copy` method. But unlike a text widget, a QListWidget has no copy method, thus resulting in no action performed.

I patched a `copy` method to the list widget object so that copying via Ctrl+C (or via Copy from the menu) works now for the History viewer tool.

As a side note:
While testing this, I observed that the selected items have a specific order:
When adding list items one by one to the selection (with Ctrl key pressed), the order of the copied lines is the same as the chronological order of the selection. But when selecting a range (with Shift key pressed) from bottom to top, then the first line is the (normally selected) bottom entry, and the remaing lines are from top towards the bottom.
I keep this behavior because it could be handy to pick and copy history entries in a specific order.