### PR TITLE
clean-up code in Qt event loop

### DIFF
--- a/pyzo/pyzokernel/guiintegration.py
+++ b/pyzo/pyzokernel/guiintegration.py
@@ -616,17 +616,12 @@ class App_qt(App_base):
         self._workaroundWindowsInBackground()
 
         # Enter Qt mainloop
-        # self._QtWidgets.real_QApplication.exec_(self.app)
+
+        # Qt5 still has "exec_" because of the "exec" keyword in Python 2
         exec_ = getattr(self._QtWidgets.real_QApplication, "exec", None)
         if exec_ is None:
             exec_ = self._QtWidgets.real_QApplication.exec_
-        try:
-            try_again = False
-            exec_(self.app)
-        except TypeError:
-            try_again = True
-        if try_again:
-            exec_()
+        exec_()
 
     def quit(self):
         # A nicer way to quit


### PR DESCRIPTION
@almarklein:
I am wondering why there is a call to the original `QApplication.exec` with an argument.
As far as I know, `QApplication.exec` (and `QApplication.exec_`) take no arguments, so the first `try` will always raise an exception.
I will merge this in a few days, unless there is a reason to keep the current code.