### PR TITLE
set default shortcut for stopping debugging to Ctrl+Shift+P

### DIFF
--- a/pyzo/resources/defaultConfig.ssdf
+++ b/pyzo/resources/defaultConfig.ssdf
@@ -135,6 +135,7 @@ shortcuts2 = dict:
     shell__restart = 'Ctrl+K,'
     shell__terminate = 'Ctrl+Shift+K,'
     shell__postmortem_debug_from_last_traceback = 'Ctrl+P,'
+    shell__stop_debugging = 'Ctrl+Shift+P,'
     view__select_editor = 'Ctrl+9,F2'
     view__select_shell = 'Ctrl+0,F1'
     view__views = 'Ctrl+Shift+A,'


### PR DESCRIPTION
I have already used this new shortcut for some time and I perceive it as quite comfortable.

When debugging, almost everything is done via the keyboard, like running the script and then entering post-mortem debugging via Ctrl+P.
Before running the script again, the debug mode has to be stopped, and this is where it was always necessary to move the hand to the mouse and to click that icon.
I chose Ctrl+Shift+P as the shortcut, because it is the "shifted" shortcut version of entering post-mortem-debugging.

I will wait a bit with merging this PR in case there are contrary opinions, like possible issues with macOS.