### PR TITLE
prevent continuation of code execution when stopping the debugger

### DIFF
--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -5,6 +5,17 @@ import bdb
 import traceback
 
 
+# Patch bdb so that "stop debugging" stops code execution even when using
+# "except Exception:" clauses, which catch the BdbQuit error.
+# see https://github.com/python/cpython/issues/149309
+if issubclass(bdb.BdbQuit, Exception):
+
+    class BdbQuit(BaseException):
+        pass
+
+    bdb.BdbQuit = BdbQuit
+
+
 class Debugger(bdb.Bdb):
     """Debugger for the pyzo kernel, based on bdb."""
 


### PR DESCRIPTION
When stopping the debugger (e.g. via "Shell -> Stop debugging"), the debugger class in Python's `bdb` module raises a `BdbQuit` exception.

The problem is that this exception is derived from class `Exception`. Therefore it can be caught in the `except Exception` clause of the user's Python code and ignored. This can result in further unexpected execution of the user's code.

Here is an example:
```python3
try:
    print('this is before the breakpoint')
    a = 123  # <-- set a breakpoint in this line
    print('this is after the breakpoint, when continuing execution')
except Exception as e:
    print('this is after the breakpoint, when quitting the debugger')
    print('got an exception, but ignoring it:', repr(e))

print('deleting important files :-(')
```

This fix patches the `BdbQuit` class in the `bdb` module so that it is derived from `BaseException`.
It is still possible to catch this via an `except:` clause, but that is discouraged coding style.