### PR TITLE
allow tabswitching via Ctrl+Tab when editor search has focus

### DIFF
--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -458,13 +458,15 @@ class FindReplaceWidget(QtWidgets.QFrame):
         overload event instead of KeyPressEvent.
         """
         if isinstance(event, QtGui.QKeyEvent):
-            if event.key() in (Qt.Key.Key_Tab, Qt.Key.Key_Backtab):
-                event.accept()  # focusNextPrevChild is called by Qt
-                return True
-            elif event.key() == Qt.Key.Key_Escape:
-                self.hideMe()
-                event.accept()
-                return True
+            KM = Qt.KeyboardModifier
+            if event.modifiers() in (KM.NoModifier, KM.ShiftModifier):
+                if event.key() in (Qt.Key.Key_Tab, Qt.Key.Key_Backtab):
+                    event.accept()  # focusNextPrevChild is called by Qt
+                    return True
+                elif event.key() == Qt.Key.Key_Escape:
+                    self.hideMe()
+                    event.accept()
+                    return True
         # Otherwise ... handle in default manner
         return super().event(event)
 


### PR DESCRIPTION
When the editor search widget (opened via Ctrl+F) had the focus, tab switching via Ctrl+Tab and Ctrl+Shift+Tab did not work because the keypress event was consumed.

With this fix, the Tab (and Escape) key events are not consumed anymore when a modifier key other than only Shift is pressed.