### PR TITLE
fix shell action "change current directory to editor file path"

### DIFF
--- a/pyzo/core/menu.py
+++ b/pyzo/core/menu.py
@@ -1660,7 +1660,7 @@ class ShellContextMenu(ShellMenu):
                 self._shell.executeCommand("cd " + fileBrowser.path() + "\n")
         elif action == "changedirtoeditor":
             editor = pyzo.editors.getCurrentEditor()
-            if editor is not None:
+            if editor is None:
                 msg = translate("menu", "No editor selected.")
             else:
                 self._shell.executeCommand(


### PR DESCRIPTION
This is a fix for the shell's context menu action "Change current directory to editor file path".