### PR TITLE
rework autocompletion delay for avoiding unnecessary introspections

### DIFF
--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -736,8 +736,9 @@ class BaseTextCtrl(CodeEditor):
             if (
                 ordKey >= 32 or ordKey == 8  # 8: '\b'
             ) and pyzo.config.settings.autoComplete == 1:
+                delay = ordKey != 46  # 46: '.'
                 # If a char that allows completion or backspace or dot was pressed
-                self.introspect(True)
+                self.introspect(True, delay)
             elif ordKey >= 32:
                 # Printable chars, only calltip
                 self.introspect()

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -15,7 +15,7 @@ import pyzo.codeeditor.parsers.tokens as Tokens
 from pyzo.codeeditor import CodeEditor
 
 from pyzo.qt import QtCore, QtGui, QtWidgets
-
+from pyzo.util import CalmedFunc
 
 ismacos = sys.platform.startswith("darwin")
 
@@ -344,10 +344,10 @@ class BaseTextCtrl(CodeEditor):
         self.setShowWhitespace(pyzo.config.view.showWhitespace)
         self.setHighlightMatchingBracket(pyzo.config.view.highlightMatchingBracket)
 
-        # Create timer for autocompletion delay
-        self._delayTimer = QtCore.QTimer(self)
-        self._delayTimer.setSingleShot(True)
-        self._delayTimer.timeout.connect(self._introspectNow)
+        # Create calmed function for autocompletion delay
+        self._calmedIntrospectNow = CalmedFunc(
+            self._introspectNow, pyzo.config.advanced.autoCompDelay
+        )
 
         # For buffering autocompletion and calltip info
         self._callTipBuffer_name = ""
@@ -460,26 +460,22 @@ class BaseTextCtrl(CodeEditor):
                 self.autocompleteCancel()
                 tryAutoComp = False
 
-        # Store line and (re)start timer
         cursor.setKeepPositionOnInsert(True)
-        self._delayTimer._tokensUptoCursor = tokensUptoCursor
-        self._delayTimer._cursor = cursor
-        self._delayTimer._tryAutoComp = tryAutoComp
-        self._delayTimer._advanced = advanced
 
-        if delay:
-            self._delayTimer.start(pyzo.config.advanced.autoCompDelay)
-        else:
-            self._delayTimer.start(1)  # self._introspectNow()
+        # Update the delay just in case the user changed the value.
+        # Otherwise the user would have to restart Pyzo for the changes to take effect.
+        self._calmedIntrospectNow.set_delay(pyzo.config.advanced.autoCompDelay)
 
-    def _introspectNow(self):
+        if not delay:
+            self._calmedIntrospectNow.clear_pending()
+        self._calmedIntrospectNow(tokensUptoCursor, cursor, tryAutoComp, advanced)
+
+    def _introspectNow(self, tokensUptoCursor, cursor, tryAutoComp, advanced):
         """This method is called a short while after introspect()
         by the timer. It parses the line and calls the specific methods
         to process the callTip and autoComp.
         """
-
-        tokens = self._delayTimer._tokensUptoCursor
-        advanced = self._delayTimer._advanced
+        tokens = tokensUptoCursor
 
         if pyzo.config.settings.autoCallTip:
             # Parse the line, to get the name of the function we should calltip
@@ -504,7 +500,7 @@ class BaseTextCtrl(CodeEditor):
                 # Process
                 indOfOpenParen = tokens[indParenToken].start
                 offset = (
-                    self._delayTimer._cursor.positionInBlock()
+                    cursor.positionInBlock()
                     - indOfOpenParen
                     + len(str(fullNameTokens[-1]))
                 )
@@ -513,7 +509,7 @@ class BaseTextCtrl(CodeEditor):
             else:
                 self.calltipCancel()
 
-        if self._delayTimer._tryAutoComp and pyzo.config.settings.autoComplete:
+        if tryAutoComp and pyzo.config.settings.autoComplete:
             # Parse the line, to see what name or attribute we need to auto-complete
             nameTokens, needleToken = parseLine_autocomplete(tokens)
             keyLookUp = False
@@ -673,9 +669,6 @@ class BaseTextCtrl(CodeEditor):
         ordKey = -1
         if event.text():
             ordKey = ord(event.text()[0])
-
-        # Cancel any introspection in progress
-        self._delayTimer._line = ""
 
         # Detect "control". This is awkward:
         # Command Key ⌘ -> ControlModifier -> mostly what Windows uses Control for.

--- a/pyzo/core/baseTextCtrl.py
+++ b/pyzo/core/baseTextCtrl.py
@@ -344,9 +344,17 @@ class BaseTextCtrl(CodeEditor):
         self.setShowWhitespace(pyzo.config.view.showWhitespace)
         self.setHighlightMatchingBracket(pyzo.config.view.highlightMatchingBracket)
 
-        # Create calmed function for autocompletion delay
+        # Create calmed functions to avoid unnecessary updates during a quick sequence of
+        # keystrokes.
         self._calmedIntrospectNow = CalmedFunc(
             self._introspectNow, pyzo.config.advanced.autoCompDelay
+        )
+
+        # Avoid unnecessary introspections while quickly navigating the autocompletion list
+        # via arrow keys. For now, we use the same delay parameter as for updating the
+        # autocompletion list.
+        self._calmedUpdateHelpFromAutocomplete = CalmedFunc(
+            self.updateHelpFromAutocomplete, pyzo.config.advanced.autoCompDelay
         )
 
         # For buffering autocompletion and calltip info
@@ -382,7 +390,14 @@ class BaseTextCtrl(CodeEditor):
 
     def _onAutocompleteSelectionChanged(self, name):
         # overridden in the editor (PyzoEditor class)
-        self.updateHelpFromAutocomplete(name)
+
+        # Update the delay just in case the user changed the value.
+        # Otherwise the user would have to restart Pyzo for the changes to take effect.
+        self._calmedUpdateHelpFromAutocomplete.set_delay(
+            pyzo.config.advanced.autoCompDelay
+        )
+
+        self._calmedUpdateHelpFromAutocomplete(name)
 
     def setAutoCompletionAcceptKeysFromStr(self, keys):
         """Set the keys that can accept an autocompletion from a comma delimited string."""

--- a/pyzo/util/__init__.py
+++ b/pyzo/util/__init__.py
@@ -3,6 +3,8 @@ import os
 import sys
 import subprocess
 
+from pyzo.qt import QtCore
+
 
 def parse_version_crudely(version_string):
     """extracts the leading number parts of a version string to a tuple
@@ -35,3 +37,51 @@ def open_directory_outside_pyzo(dirpath, filename=None):
             subprocess.call('explorer.exe "{}"'.format(dirpath))
     elif sys.platform.startswith("linux"):
         subprocess.call(("xdg-open", dirpath))
+
+
+class CalmedFunc:
+    """Class for delayed execution of a function so that newer calls will replace the
+    not yet executed older calls.
+
+    If there is no newer call within a certain amount of time ("delay_ms"), the function
+    will be executed with the arguments from the newest call.
+
+    The first call after a longer break (after "delay_ms" or after initialization)
+    will be executed immediately. The next execution will not happen before "delay_ms"
+    since the previous execution, unless method "clear_pending" is called before.
+    """
+
+    def __init__(self, func, delay_ms):
+        self._func = func
+        self._t = QtCore.QTimer(singleShot=True)
+        self._t.timeout.connect(self._timer_callback)
+        self._quick_start = False
+        self._wait_after_quick_start = False
+        self.set_delay(delay_ms)
+
+    def set_delay(self, delay_ms):
+        self._delay_ms = delay_ms
+
+    def clear_pending(self):
+        self._t.stop()
+
+    def __call__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+        self._wait_after_quick_start = False
+        if self._t.isActive():
+            self._t.start(self._delay_ms)
+        else:
+            self._quick_start = True
+            self._t.start(1)
+
+    def _timer_callback(self):
+        if self._wait_after_quick_start:
+            self._wait_after_quick_start = False
+            return
+
+        self._func(*self._args, **self._kwargs)
+
+        if self._quick_start:
+            self._wait_after_quick_start = True
+            self._t.start(self._delay_ms)


### PR DESCRIPTION
There was a timer that delayed introspection for autocompletion to prevent too many unnecessary look-ups while the user quickly types many characters.

I replaced that with a new class `CalmedFunc` that internally also uses a timer. That class is then used in other places as well to avoid code duplication.

The new class also changes the behavior:
Introspection and autocompletion are not delayed anymore for the first character typed after a "cool-down" time (which is the same as the autocompletion delay time).

Entering a dot (`.`) will now also trigger immediate autocompletion (without waiting before).

And I also added a delayed update of the interactive help when changing the selection in the autocompletion list.
Previously, changing the selection in the autocompletion list via arrow keys could result in many unnecessary introspections and help text updates when the arrow key was pressed for several seconds. This resulted in a visible lag of help text updates in the "Interactive help" tool.
Now, introspections for help text updates are only performed after a certain time since the last key press, or immediately when there was a "cool-down" time before the key press.