### PR TITLE
fix Qt enum constant for PyQt6

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -119,7 +119,8 @@ class AutoCompletion:
 
     def setAutocompleteCaseSensitive(self, b):
         """Set the case sensitivity for autocompletion."""
-        cs = Qt.CaseSensitive if b else Qt.CaseSensitivity.CaseInsensitive
+        CS = Qt.CaseSensitivity
+        cs = CS.CaseSensitive if b else CS.CaseInsensitive
         self.__completer.setCaseSensitivity(cs)
 
     def setAutocompleteMinChars(self, n):


### PR DESCRIPTION
There was a Qt enum left that was not yet fully qualified, so this caused an error with PyQt6 if someone activated case-sensitivity for autocompletion.

fixes #1265