### PR TITLE
allow doing introspection only in the kernel's main thread

### DIFF
--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -304,8 +304,8 @@ class KernelBroker:
         # We use the stat-interpreter to set the status to dead when kernel dies
         self._stat_interpreter = yoton.StateChannel(ct, "stat-interpreter")
 
-        # Create introspect channel so we can interrupt and terminate
-        self._reqp_introspect = yoton.ReqChannel(ct, "reqp-introspect")
+        # Create control channel so we can interrupt and terminate the kernel
+        self._reqp_control = yoton.ReqChannel(ct, "reqp-control")
 
     def _reset(self, destroy=False):
         """Reset state.
@@ -349,7 +349,7 @@ class KernelBroker:
             self._strm_prompt = None
             #
             self._ctrl_broker = None
-            self._reqp_introspect = None
+            self._reqp_control = None
 
     def startKernelIfConnected(self, timeout=10.0):
         """Start the kernel as soon as there is a connection."""
@@ -599,7 +599,7 @@ class KernelBroker:
             self._strm_broker.send("Cannot interrupt: process is dead.\n")
         # Kernel receives and acts
         elif sys.platform.startswith("win"):
-            self._reqp_introspect.interrupt()
+            self._reqp_control.interrupt()
         else:
             # Use POSIX to interrupt, which is more reliable
             # (the introspect thread might not get a chance)
@@ -611,7 +611,7 @@ class KernelBroker:
         if self._process is None:
             self._strm_broker.send("Cannot interrupt: process is dead.\n")
         elif sys.platform == "win32":
-            self._reqp_introspect.interrupt(signum=signal.SIGFPE)
+            self._reqp_control.interrupt(signum=signal.SIGFPE)
         else:
             pid = self._kernelCon.pid2
             os.kill(pid, signal.SIGFPE)
@@ -686,7 +686,7 @@ class KernelTerminator:
             pass
 
         elif action == "TERM":
-            self._broker._reqp_introspect.terminate()
+            self._broker._reqp_control.terminate()
             self._do("INT", 0.5)
 
         elif action == "INT":
@@ -696,7 +696,7 @@ class KernelTerminator:
             self._count += 1
             # Handle
             if self._count < 5:
-                self._broker._reqp_introspect.interrupt()
+                self._broker._reqp_control.interrupt()
                 self._do("INT", 0.1)
             else:
                 self._do("KILL", 0)

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1282,7 +1282,8 @@ class PythonShell(BaseShell):
         self._stat_startup.received.bind(self._onReceivedStartupInfo)
 
         # Create introspection request channel
-        self._request = yoton.ReqChannel(ct, "reqp-introspect")
+        default_future_timeout = 0.5  # default timeout for returned Future objects
+        self._request = yoton.ReqChannel(ct, "reqp-introspect", default_future_timeout)
 
         # Connect! The broker will only start the kernel AFTER
         # we connect, so we do not miss out on anything.

--- a/pyzo/core/shellInfoDialog.py
+++ b/pyzo/core/shellInfoDialog.py
@@ -362,7 +362,11 @@ class ShellInfo_argv(ShellInfoLineEdit):
 
 
 class ShellInfo_environ(QtWidgets.QPlainTextEdit):
-    EXAMPLE = "PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1\nEXAMPLE_VAR1=value1"
+    EXAMPLE = (
+        "PYZO_PROCESS_EVENTS_WHILE_DEBUGGING=1\n"
+        "PYZO_INTROSPECT_IN_MAIN_THREAD=1\n"
+        "EXAMPLE_VAR1=value1"
+    )
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/pyzo/pyzokernel/control.py
+++ b/pyzo/pyzokernel/control.py
@@ -1,0 +1,39 @@
+import sys
+import signal
+import yoton
+
+
+if sys.version_info[0] < 3:
+    import thread
+else:
+    import _thread as thread
+
+
+class PyzoKernelControl(yoton.RepChannel):
+    """This is a RepChannel object that runs a thread to control the kernel from the IDE."""
+
+    def interrupt(self, command=None, signum=signal.SIGINT):
+        """Interrupt the main thread.
+
+        This does not work if the main thread is running extension code.
+
+        Note that on POSIX we can send an OS INT signal, which is faster
+        and maybe more effective in some situations.
+
+        signum must be signal.SIGINT for kernels running Python < 3.10
+        """
+        if signum == signal.SIGINT:
+            thread.interrupt_main()
+        else:
+            if sys.version_info < (3, 10):
+                print("This feature is not implemented for Python versions < 3.10!")
+                return
+            thread.interrupt_main(signum)
+
+    def terminate(self, command=None):
+        """terminate()
+
+        Ask the kernel to terminate by closing the stdin.
+
+        """
+        sys.stdin._channel.close()

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -669,6 +669,11 @@ class PyzoInterpreter:
         sys.__stdout__.flush()
         sys.__stderr__.flush()
 
+        if self.introspector._run_mode == 0:
+            # Introspection was set up without its own thread or event loop (see start.py).
+            # So we have to regularly process introspection requests here.
+            self.introspector._process_events_local()
+
         # Set status and prompt?
         # Prompt is allowed to be an object with __str__ method
         # We also compare prompt strings because stack frame changes

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -1,14 +1,6 @@
 import sys
-import signal
 import yoton
 import inspect  # noqa - used in eval()
-
-
-PYTHON_VERSION = sys.version_info[0]
-if PYTHON_VERSION < 3:
-    import thread
-else:
-    import _thread as thread
 
 
 # we keep this file in ascii encoding to stay compatible with Python 2.7 kernels
@@ -16,9 +8,7 @@ THREE_DOTS_CHAR = b"\xe2\x80\xa6".decode("utf-8")
 
 
 class PyzoIntrospector(yoton.RepChannel):
-    """This is a RepChannel object that runs a thread to respond to
-    requests from the IDE.
-    """
+    """This is a RepChannel object to respond to requests from the IDE."""
 
     def _getNameSpace(self, name=""):
         """Get the namespace to apply introspection in.
@@ -127,7 +117,7 @@ class PyzoIntrospector(yoton.RepChannel):
                 name += "("
                 if name in sigs:
                     hasSig = True
-            if not hasSig and PYTHON_VERSION >= 3:
+            if not hasSig and sys.version_info[0] >= 3:
                 # Also get the signature for objects where inspect.signature does not
                 # work and where the function/method has a differnt name, e.g.:
                 # import sys; myfunc = sys.getsizeof
@@ -500,36 +490,6 @@ class PyzoIntrospector(yoton.RepChannel):
             return eval(command, None, NS)
         except Exception:
             return "Error evaluating: " + command
-
-    def interrupt(self, command=None, signum=signal.SIGINT):
-        """Interrupt the main thread.
-
-        This does not work if the main thread is running extension code.
-
-        A bit of a hack to do this in the introspector, but it's the
-        easiest way and prevents having to launch another thread just
-        to wait for an interrupt/terminate command.
-
-        Note that on POSIX we can send an OS INT signal, which is faster
-        and maybe more effective in some situations.
-
-        signum must be signal.SIGINT for kernels running Python < 3.10
-        """
-        if signum == signal.SIGINT:
-            thread.interrupt_main()
-        else:
-            if sys.version_info < (3, 10):
-                print("This feature is not implemented for Python versions < 3.10!")
-                return
-            thread.interrupt_main(signum)
-
-    def terminate(self, command=None):
-        """terminate()
-
-        Ask the kernel to terminate by closing the stdin.
-
-        """
-        sys.stdin._channel.close()
 
 
 ##

--- a/pyzo/pyzokernel/start.py
+++ b/pyzo/pyzokernel/start.py
@@ -137,7 +137,7 @@ __pyzo__.control = PyzoKernelControl(ct, "reqp-control")
 # Delete local variables
 del yoton, PyzoInterpreter, PyzoIntrospector, pyzo_excepthook
 del ct, port
-del os, sys, time
+del sys, time
 
 # Delete stuff we do not want
 for name in [
@@ -151,7 +151,13 @@ del name
 ## Start and stop
 
 # Start introspector and kernel controller
-__pyzo__.introspector.set_mode("thread")
+
+if os.getenv("PYZO_INTROSPECT_IN_MAIN_THREAD", "") == "1":
+    __pyzo__.introspector.set_mode(0)  # process channel events in main thread
+else:
+    __pyzo__.introspector.set_mode("thread")  # starts the thread
+del os
+
 __pyzo__.control.set_mode("thread")
 
 # Run the interpreter

--- a/pyzo/pyzokernel/start.py
+++ b/pyzo/pyzokernel/start.py
@@ -25,9 +25,10 @@ strm-action: for the kernel to push actions to the ide
 
 stat-interpreter): status of the interpreter (ready, busy, very busy, more, etc)
 stat-debug (OBJECT): debug status
-stat-startup (OBJECT): Used to pass startup parameters to the kernel
+stat-startup (OBJECT): used to pass startup parameters to the kernel
 
-reqp-introspect (OBJECT): To query information from the kernel (and for interruping)
+reqp-introspect (OBJECT): used to query information from the kernel
+reqp-control (OBJECT): used to control the kernel from the shell (Pyzo-GUI), e.g. interrupting
 
 """
 
@@ -116,6 +117,7 @@ def pyzo_excepthook(type, value, tb):
 # Delay import, so we can detect syntax errors using the except hook
 from pyzokernel.interpreter import PyzoInterpreter
 from pyzokernel.introspection import PyzoIntrospector
+from pyzokernel.control import PyzoKernelControl
 
 # Create interpreter instance and give dict in which to run all code
 __pyzo__ = PyzoInterpreter(__main__.__dict__, "<console>")
@@ -127,6 +129,8 @@ __pyzo__.context = ct
 # Create introspection req channel (store at interpreter instance)
 __pyzo__.introspector = PyzoIntrospector(ct, "reqp-introspect")
 
+# Create introspection req channel (store at interpreter instance)
+__pyzo__.control = PyzoKernelControl(ct, "reqp-control")
 
 ## Clean up
 
@@ -146,9 +150,11 @@ del name
 
 ## Start and stop
 
-# Start introspector and enter the interpreter
+# Start introspector and kernel controller
 __pyzo__.introspector.set_mode("thread")
+__pyzo__.control.set_mode("thread")
 
+# Run the interpreter
 try:
     __pyzo__.run()
 
@@ -170,6 +176,7 @@ finally:
     # not do this on Python 3.2 (at least Windows) the exit delays 10s. (issue 79)
     try:
         __pyzo__.introspector.set_mode(0)
+        __pyzo__.control.set_mode(0)
         __pyzo__.context.close()
     except Exception:
         pass

--- a/pyzo/yoton/channels/channels_reqrep.py
+++ b/pyzo/yoton/channels/channels_reqrep.py
@@ -51,7 +51,7 @@ class Future(object):
 
     """
 
-    def __init__(self, req_channel, req, request_id):
+    def __init__(self, req_channel, req, request_id, timeout=10.0):
         # For being a Future object
         self._result = None
         self._status = 0  # 0:waiting, 1:running, 2:canceled, 3:error, 4:success
@@ -67,7 +67,7 @@ class Future(object):
         # For resending
         self._first_send_time = time.time()
         self._next_send_time = self._first_send_time + 0.5
-        self._auto_cancel_timeout = 10.0
+        self._auto_cancel_timeout = timeout
 
     def _send(self, msg):
         """For sending pre-request messages 'req?', 'req-'."""
@@ -392,7 +392,7 @@ class ReqChannel(BaseChannel):
     # Each item has an attribute specifying whether a replier has
     # acknowledged it (and which one).
 
-    def __init__(self, context, slot_base):
+    def __init__(self, context, slot_base, default_future_timeout=10.0):
         BaseChannel.__init__(self, context, slot_base, OBJECT)
 
         # Queue with pending requests
@@ -414,6 +414,10 @@ class ReqChannel(BaseChannel):
         self._timer = yoton.events.Timer(0.5, False)
         self._timer.bind(self._process_events_local)
         self._timer.start()
+
+        # Set the default timeout for Future objects.
+        # (The timeout of each Future object can later be re-adjusted.)
+        self._default_future_timeout = default_future_timeout
 
     def _messaging_patterns(self):
         return "req-rep", "rep-req"
@@ -448,7 +452,7 @@ class ReqChannel(BaseChannel):
         request_id = self._request_counter = self._request_counter + 1
 
         # Create new item for this request and store under the request id
-        item = Future(self, bb, request_id)
+        item = Future(self, bb, request_id, self._default_future_timeout)
         self._request_items[request_id] = item
 
         # Send pre-request (ask repliers who want to reply to a request)


### PR DESCRIPTION
Some modules report errors or warnings when one of its objects is accessed from a thread other than the kernel's main thread, for example FreeCAD `ViewObject` objects since [this change](https://github.com/FreeCAD/FreeCAD/pull/21292).

This new feature makes it possible to configure a shell so that introspection is performed only in the kernel's main thread instead of a different thread.

The feature is activated by adding line
`PYZO_INTROSPECT_IN_MAIN_THREAD=1`
to the "environ" field of the shell config.