### PR TITLE
remove class left in global namespace

### DIFF
--- a/pyzo/pyzokernel/start.py
+++ b/pyzo/pyzokernel/start.py
@@ -135,7 +135,7 @@ __pyzo__.control = PyzoKernelControl(ct, "reqp-control")
 ## Clean up
 
 # Delete local variables
-del yoton, PyzoInterpreter, PyzoIntrospector, pyzo_excepthook
+del yoton, PyzoInterpreter, PyzoIntrospector, PyzoKernelControl, pyzo_excepthook
 del ct, port
 del sys, time
 


### PR DESCRIPTION
In #1269 I forgot to remove the imported class from the global namespace of the interpreter.