### PR TITLE
fix document path in title bar when executing main file as script

### DIFF
--- a/pyzo/core/editor.py
+++ b/pyzo/core/editor.py
@@ -704,7 +704,10 @@ class PyzoEditor(BaseTextCtrl):
         self._modifyTime = os.path.getmtime(self._filename)
 
         # update title (in case of a rename)
-        self.setTitleInMainWindow()
+        # Saving could be triggered for a non-active editor, e.g. when running the
+        # main file as a script.
+        if self is pyzo.editors.getCurrentEditor():
+            self.setTitleInMainWindow()
 
         # allow item to update its texts (no need: onModifiedChanged does this)
         # self.somethingChanged.emit()


### PR DESCRIPTION
The title bar of the Pyzo application normally shows the filepath of the current editor.
But when running the main file as a script (e.g. via Ctrl+Shift+M), the filepath in the title bar was updated to the main file even if the editor tab of the main file was not active.

This PR fixes the bug.