### PR TITLE
keep selection in autocompletion list when pressing the Shift key

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -395,7 +395,7 @@ class AutoCompletion:
         # Apply the key that was pressed
         super().keyPressEvent(event)
 
-        if self.autocompleteActive():
+        if self.autocompleteActive() and key != Qt.Key.Key_Shift:
             # While we type, the start of the autocompletion may move due to line
             # wrapping, so reposition after every key stroke
             self.__positionAutocompleter()


### PR DESCRIPTION
There was a bug in the autocompletion list.
For example, the autocompletion for `os.` shows the first entries: "abc", "abort", and "access".
When selecting the "access" entry via up/down keys and then pressing the Shift key, the autocompletion list was regenerated and the first match selected, in this case "abc".

With this fix, the Shift key press does not regenerate the autocompletion list anymore, and the selection stays the same.