### PR TITLE
improve performance when introspecting large objects

### DIFF
--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1474,13 +1474,8 @@ class PythonShell(BaseShell):
                     for name, type_, kind, repr_ in response
                     if name[0] == "["
                 ]
-                maxKeyEntries = 200
-                if len(foundNames) > maxKeyEntries:
-                    foundNames = (
-                        foundNames[: maxKeyEntries - 1]
-                        + ["# ... too many entries"]
-                        + foundNames[-1:]
-                    )
+                if response and response[-1][0] == "# ... too many entries":
+                    foundNames.append(response[-1][0])
             else:  # if attribute or name auto-completion
                 foundNames = response
         aco.addNames(foundNames)

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -1624,9 +1624,6 @@ class PythonShell(BaseShell):
             if sub:
                 M = sub.recv_selected()
                 # M = [sub.recv()] # Slow version (for testing)
-            # New prompt?
-            if sub is self._strm_prompt:
-                self.stateChanged.emit(self)
 
         # Write all pending messages that are later than any other message
         if sub:

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -6,6 +6,63 @@ import inspect  # noqa - used in eval()
 # we keep this file in ascii encoding to stay compatible with Python 2.7 kernels
 THREE_DOTS_CHAR = b"\xe2\x80\xa6".decode("utf-8")
 
+_getReprPrefixPostfix = {
+    "list": ("[", "]"),
+    "tuple": ("(", ")"),
+    "dict": ("{", "}"),
+    "frozendict": ("frozendict(", ")"),
+    "set": ("{", "}"),  # only for non-empty sets
+    "frozenset": ("frozenset(", ")"),
+}
+
+
+def getRepr(obj, maxChars, _path=(), _sList=None):
+    """like repr(obj)[:maxChars], but more efficient for large objects"""
+
+    if _sList is None:
+        # the first list element is the total string length of all elements
+        _sList = [0]
+    tn = obj.__class__.__name__
+    if tn in _getReprPrefixPostfix:
+        prefix, postfix = _getReprPrefixPostfix[tn]
+        if tn == "set" and not obj:
+            prefix, postfix = "set(", ")"
+
+        _sList.append(prefix)
+        _sList[0] += len(prefix)
+        _pathSub = _path + (obj,)
+        if obj in _path:
+            _sList.append("...")
+            _sList[0] += 3
+        else:
+            for i, subObj in enumerate(obj):
+                if i > 0:
+                    _sList.append(", ")
+                    _sList[0] += 2
+                if _sList[0] >= maxChars:
+                    break
+
+                getRepr(subObj, maxChars, _pathSub, _sList)
+                if tn in ("dict", "frozendict"):
+                    _sList.append(": ")
+                    _sList[0] += 2
+                    getRepr(obj[subObj], maxChars, _pathSub, _sList)
+        _sList.append(postfix)
+        _sList[0] += len(postfix)
+    elif hasattr(obj, "__len__"):
+        # e.g.: str, bytes, bytearray
+        s = repr(obj[:maxChars])
+        _sList.append(s)
+        _sList[0] += len(s)
+    else:
+        s = repr(obj)
+        _sList.append(s)
+        _sList[0] += len(s)
+
+    if not _path:
+        return "".join(_sList[1:])[:maxChars]
+
+
 # Functions/objects like "dir" could be redefined in the namespace of the user's code.
 # To use our known "dir", we assign it to a rather unique variable name that is only
 # visible in a global namespace used for introspection, e.g.:
@@ -16,7 +73,7 @@ INTERNAL_OBJECT_NAMES = [
     "hasattr",
     "dir",
     "str",
-    "repr",
+    "getRepr",
 ]
 
 internalNS = {}  # namespace for eval/exec (look-up table for unique_name to object)
@@ -360,34 +417,35 @@ class PyzoIntrospector(yoton.RepChannel):
                         repres = "<array scalar %s (%s)>" % (val.dtype.name, str(val))
                     else:
                         repres = "<array empty %s>" % (val.dtype.name)
-                elif kind == "list":
-                    values_repr = ""
-                    for el in val:
-                        values_repr += ", " + repr(el)
-                        if len(values_repr) > 70:
-                            values_repr = values_repr[:69] + THREE_DOTS_CHAR
-                            break
-                    repres = "<%i-element list: %s>" % (len(val), values_repr[2:])
-                elif kind == "tuple":
-                    values_repr = ""
-                    for el in val:
-                        values_repr += ", " + repr(el)
-                        if len(values_repr) > 70:
-                            values_repr = values_repr[:69] + THREE_DOTS_CHAR
-                            break
-                    repres = "<%i-element tuple: %s>" % (len(val), values_repr[2:])
-                elif kind == "dict":
-                    values_repr = ""
-                    for k, v in val.items():
-                        values_repr += ", " + repr(k) + ": " + repr(v)
-                        if len(values_repr) > 70:
-                            values_repr = values_repr[:69] + THREE_DOTS_CHAR
-                            break
-                    repres = "<%i-item dict: %s>" % (len(val), values_repr[2:])
+                elif kind in (
+                    "list",
+                    "tuple",
+                    "dict",
+                    "frozendict",
+                    "set",
+                    "frozenset",
+                ):
+                    maxChars = 70
+                    values_repr = getRepr(val, maxChars + 1)
+                    if len(values_repr) > maxChars:
+                        values_repr = values_repr[: maxChars - 1] + THREE_DOTS_CHAR
+
+                    if kind in ("frozendict", "frozenset"):
+                        values_repr = values_repr[len(kind + "({") : -1]
+                    else:
+                        values_repr = values_repr[1:-1]
+
+                    if kind in ("dict", "frozendict"):
+                        elem = "item"
+                    else:
+                        elem = "element"
+
+                    repres = "<{}-{} {}: {}>".format(len(val), elem, kind, values_repr)
                 else:
-                    repres = repr(val)
-                    if len(repres) > 80:
-                        repres = repres[:79] + THREE_DOTS_CHAR
+                    maxChars = 80
+                    repres = getRepr(val, maxChars + 1)
+                    if len(repres) > maxChars:
+                        repres = repres[: maxChars - 1] + THREE_DOTS_CHAR
                 # Store
                 tmp = (name, typeName, kind, repres)
                 names.append(tmp)
@@ -458,7 +516,15 @@ class PyzoIntrospector(yoton.RepChannel):
                 h_text = eval("%s.__doc__" % (objectName), {}, NS)
 
             # collect more data
-            h_repr = eval(inames["repr"] + "(%s)" % (objectName), internalNS, NS)
+            maxChars = 200
+            h_repr = eval(
+                "{}({}, {})".format(inames["getRepr"], objectName, maxChars + 1),
+                internalNS,
+                NS,
+            )
+            if len(h_repr) > maxChars:
+                h_repr = h_repr[: maxChars - 1] + THREE_DOTS_CHAR
+
             try:
                 h_class = eval("%s.__class__.__name__" % (objectName), {}, NS)
             except Exception:
@@ -474,9 +540,6 @@ class PyzoIntrospector(yoton.RepChannel):
             if not h_fun:
                 h_fun = ""  # signature not available
 
-            # cut repr if too long
-            if len(h_repr) > 200:
-                h_repr = h_repr[:200] + "..."
             # replace newlines so we can separates the different parts
             h_repr = h_repr.replace("\n", "\r")
 
@@ -504,11 +567,13 @@ class PyzoIntrospector(yoton.RepChannel):
         """
         NS = self._getNameSpace()
         maxChars = 150
-
         returnValue = []
         for expr in sequenceOfExpressions:
+            exprOrig = expr
+            if expr.startswith("repr(") and expr.endswith(")"):
+                expr = "{}({}, {})".format(inames["getRepr"], expr[5:-1], maxChars + 1)
             try:
-                result = str(eval(expr, None, NS))[: maxChars + 1]
+                result = str(eval(expr, internalNS, NS))
                 if len(result) > maxChars:
                     result = result[: maxChars - 1] + THREE_DOTS_CHAR
                 success = True
@@ -516,7 +581,7 @@ class PyzoIntrospector(yoton.RepChannel):
                 result = str(e)
                 success = False
 
-            returnValue.append((expr, success, result))
+            returnValue.append((exprOrig, success, result))
 
         return returnValue
 

--- a/pyzo/pyzokernel/introspection.py
+++ b/pyzo/pyzokernel/introspection.py
@@ -117,10 +117,12 @@ class PyzoIntrospector(yoton.RepChannel):
                     NS = {"[" + repr(el) + "]": ob[el] for el in ob.keys()}
                 elif isinstance(ob, (list, tuple)):
                     NS = {}
-                    count = -1
-                    for el in ob:
-                        count += 1
-                        NS["[%i]" % count] = el
+                    for i, el in enumerate(ob):
+                        if i >= 1000:
+                            NS["[{}]".format(len(ob) - 1)] = ob[-1]  # add last object
+                            NS["# ... too many entries"] = None
+                            break
+                        NS["[{}]".format(i)] = el
                 else:
                     keys = dir(ob)
                     NS = {}
@@ -143,6 +145,18 @@ class PyzoIntrospector(yoton.RepChannel):
         of one of the above. When none of the above, both elements in
         the tuple are an empty string.
         """
+
+        if not callable(objectName):
+            # Return early if the object not is callable.
+            # With this we avoid unnecessary delays and CPU and memory usage.
+            #
+            # For example, when executing
+            #   inspect.signature(obj)
+            # where obj is a very long list, an exception
+            #   f"TypeError: {repr(obj)} is not a callable object'
+            # will be raised, and executing "repr(obj)" of a very long list could take a
+            # few seconds and consume a lot of memory.
+            return "", ""
 
         # if a class, get init
         # not if an instance! -> try __call__ instead
@@ -490,6 +504,8 @@ class PyzoIntrospector(yoton.RepChannel):
         NS = self._getNameSpace()
 
         try:
+            if objectName.endswith("[# ... too many entries]"):
+                raise IndexError()
             # collect docstring
             h_text = ""
             # Try using the class (for properties)

--- a/pyzo/pyzokernel/magic.py
+++ b/pyzo/pyzokernel/magic.py
@@ -15,6 +15,8 @@ import token
 import keyword
 import itertools
 
+from pyzokernel.introspection import getRepr
+
 
 # Set Python version and get some names
 PYTHON_VERSION = sys.version_info[0]
@@ -386,9 +388,10 @@ class Magician:
             cls = ""
             if hasattr(ob, "__class__"):
                 cls = ob.__class__.__name__
-            rep = repr(ob)
             text += self._justify(name, 20, 2) + self._justify(cls, 20, 2)
-            text += self._justify(rep, 40, 2) + "\n"
+            reprlen = 40
+            rep = getRepr(ob, reprlen + 1)
+            text += self._justify(rep, reprlen, 2) + "\n"
         # Done
         print(text)
         return ""

--- a/pyzo/tools/pyzoExpressionViewer.py
+++ b/pyzo/tools/pyzoExpressionViewer.py
@@ -39,7 +39,7 @@ class ExpressionProxy(QtCore.QObject):
         when finished, signal "haveNewData" will be emitted
         """
         shell = pyzo.shells.getCurrentShell()
-        if self._expressions and shell and shell._state.lower() != "busy":
+        if self._expressions and shell and shell._state not in ("Busy", "Very busy"):
             future = shell._request.evalMultiple(self._expressions)
             future.add_done_callback(self._processResponse)
 

--- a/pyzo/tools/pyzoWorkspace.py
+++ b/pyzo/tools/pyzoWorkspace.py
@@ -102,7 +102,7 @@ class WorkspaceProxy(QtCore.QObject):
         shell = pyzo.shells.getCurrentShell()
         if not shell:
             self._variables = []
-        elif shell._state.lower() != "busy":
+        elif shell._state not in ("Busy", "Very busy"):
             future = shell._request.dir2(self._name)
             future.add_done_callback(self._processResponse)
 


### PR DESCRIPTION
When working with large objects, such as
`mydata = bytes(500_000_000)`
the Workspace tool starts flickering because introspection takes very long. During introspection, the shell changes its state from ready to busy and back to ready. The state changes trigger another introspection to update entries in the Workspace tool, so there is an infinite loop.
Also, when just typing the first characters of "mydata" in the shell, autocompletion will tell the "Interactive help" tool to display information about the object. This triggers introspection as well and takes a few seconds.


I improved the performance via several measures:

Introspection now use an own function to get the character-limited representation string of an object.
`repr(big_data)[:80]` generates a huge string even though we only keep the first few characters. This consumes too much CPU time and memory. Therefore I implemented a new function `getRepr` which stops building the repr-string once the maximum string length is reached. My first thought was to use the "reprlib" in the Python standard library, but it is not quite what we need here.

Introspection for updates of entries in the Workspace tool were unnecessarily often. Updates were requested in the shell state "Very busy", because the corresponding check only compared with "Busy". And a prompt change in the shell, even though the shell state remained the same, also triggered an update. The prompt change happend every time code was executed in the shell, but this also triggered the busy->ready state change, so there was no need for two triggers.
I changed the code accordingly to prevent these unnecessary updates.

Introspection of indices for lists and tuples collected all possible index values. I added the restriction in the introspection code instead of restricting the elements in the autocompletion list of the IDE.

The expression `inspect.signature(obj)` which is used in the `_getSignature` method of the introspection class, raises an exception if the object is not callable, and the exception contains `repr(obj)`. This means, if `obj` is a huge list, the exception has an even larger text which consumes CPU time and memory. The `_getSignature` function is not only used for calltips but also automatically called when showing an entry in the "Interactive help" tool.
I fixed the problem by checking if the object is `callable` at all at the beginning of `_getSignature`, so the inspect call will not be reached anymore for non-callable objects.


And, as a byproduct, the Workspace tool now also displays `set`, `frozenset` and `frozendict` like `tuple`, `list` and `dict`, i.e. showing the number of elements etc. in the "Repr" column.
