### PR TITLE
update CI and CD workflow to use/include Python 3.14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
@@ -84,10 +84,10 @@ jobs:
     runs-on: macos-15-intel
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
@@ -150,10 +150,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install dependencies
       run: |
           python -m pip install --upgrade pip
@@ -257,7 +257,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Download assets
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         include:
           # Main test builds, 3 OS's times 4 Qt toolkits
           - os: windows-latest
+            pyversion: '3.14'
+            qtlib: pyside6
+          - os: windows-latest
             pyversion: '3.13'
             qtlib: pyside6
           - os: windows-latest
@@ -58,6 +61,9 @@ jobs:
             qtlib: pyside2
           # ---
           - os: ubuntu-latest
+            pyversion: '3.14'
+            qtlib: pyside6
+          - os: ubuntu-latest
             pyversion: '3.13'
             qtlib: pyside6
           - os: ubuntu-latest
@@ -73,6 +79,9 @@ jobs:
             pyversion: '3.9'
             qtlib: pyside2
           # ---
+          - os: macos-latest
+            pyversion: '3.14'
+            qtlib: pyside6
           - os: macos-latest
             pyversion: '3.13'
             qtlib: pyside6


### PR DESCRIPTION
Previously, the newest used Python version was v3.13.

CI now also runs checks with Python v3.14.
CD creates Pyzo binaries containing Python v3.14.
CD uses Python v3.14 internally when publishing the packages.