### PR TITLE
do not add pathsep at start or end of PYTHONPATH

### DIFF
--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -169,7 +169,7 @@ def getEnvFromKernelInfo(info):
     # Add entry to Pythonpath, so that we can import yoton
     # Note: an empty entry might cause trouble if the start-directory is
     # somehow overriden (see issue 128).
-    pythonPath = pyzo.pyzoDir + os.pathsep + pythonPath
+    pythonPath = (pyzo.pyzoDir + os.pathsep + pythonPath).strip(os.pathsep)
 
     # Prepare environment, remove references to tk libraries,
     # since they're wrong when frozen. Python will insert the


### PR DESCRIPTION
The PYTHONPATH environment variable of the Pyzo kernel had a value like:
```python3
>>> import os; os.environ['PYTHONPATH']
'/path/to/pyzo:'
```
With this fix, it is now:
```python3
>>> import os; os.environ['PYTHONPATH']
'/path/to/pyzo'
```

I stumbled upon this when playing around with starting a kernel/shell with a python.exe (MS Windows binary, executed via `wine`) in a Pyzo IDE run in Linux.