### PR TITLE
implement frame switching for (externally started) shells

### DIFF
--- a/pyzo/pyzokernel/debug.py
+++ b/pyzo/pyzokernel/debug.py
@@ -166,7 +166,7 @@ class Debugger(bdb.Bdb):
         # Reset
         self._debugmode = 0
         interpreter.locals = interpreter._main_locals
-        interpreter.globals = None
+        interpreter.globals = interpreter._main_globals
         interpreter._dbFrames = []
         self.writestatus()
 

--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -129,15 +129,17 @@ class PyzoInterpreter:
     # - support post mortem debugging
     # - support for magic commands
 
-    def __init__(self, locals, filename="<console>"):
+    def __init__(self, globals, locals, filename="<console>"):
         # Init variables for locals and globals (globals only for debugging)
+        self.globals = globals
         self.locals = locals
-        self.globals = None
 
         # Store filename
         self._filename = filename
 
-        # Store ref of locals that is our main
+        # Store ref of globals and locals so that we can restore them
+        # after a debugging session with different frames.
+        self._main_globals = globals
         self._main_locals = locals
 
         # Flag to ignore sys exit, to allow running some scripts
@@ -1051,7 +1053,7 @@ class PyzoInterpreter:
                 # the tracing is disabled for better performance.
                 self.debugger.set_on()
                 self.apply_breakpoints()
-                glob, loc = self.locals, None
+                glob, loc = self.globals, self.locals
             exec(code, glob, loc)
         except bdb.BdbQuit:
             self.dbstop_handler()
@@ -1240,6 +1242,53 @@ class PyzoInterpreter:
             new_nr = old_nr + offset
             return line[:i1] + line[i2:i3] + str(new_nr) + line[i4:]
         return line
+
+    ## Advanced methods
+
+    def switchframe(self, frameindex=-1):
+        """switches the globals and locals for the shell to the selected frame
+
+        frameindex -1 is the outermost frame (and index 0 the innermost one)
+
+        For normally started shells, this makes no sense, because the interpreter
+        already uses the outermost frame, and all inner frames are only the ones of
+        the Pyzo kernel.
+
+        But when running an externally started shell, there could be more frames between
+        the outermost frame and the first frame of the Pyzo kernel.
+        It could be useful to switch to another frame to inspect or modify variables
+        there. To switch the globals/locals to the second outermost frame, for example,
+        execute the line
+            import sys; sys._pyzoInterpreter.switchframe(-2)
+        in the shell. Note that the switch will be performed only after the execution
+        of that line has finished.
+        """
+        f = sys._getframe()
+
+        frames = [f]
+        while f.f_back:
+            f = f.f_back
+            frames.append(f)
+
+        if self._dbFrames:
+            printDirect("cannot switch frame because debugging is active\n")
+            return
+
+        try:
+            f = frames[frameindex]
+        except IndexError:
+            printDirect("cannot switch frame because frameindex is invalid\n")
+            return
+
+        fname, lineno = self.correctfilenameandlineno(f.f_code.co_filename, f.f_lineno)
+
+        printDirect("setting new base frame for the Pyzo interpreter:\n")
+        printDirect(
+            '    File "{}", line {}, in {}\n'.format(fname, lineno, f.f_code.co_name)
+        )
+
+        self._main_locals = self.locals = f.f_locals
+        self._main_globals = self.globals = f.f_globals
 
 
 class ExecutedSourceCollection:

--- a/pyzo/pyzokernel/start.py
+++ b/pyzo/pyzokernel/start.py
@@ -119,9 +119,12 @@ from pyzokernel.interpreter import PyzoInterpreter
 from pyzokernel.introspection import PyzoIntrospector
 from pyzokernel.control import PyzoKernelControl
 
-# Create interpreter instance and give dict in which to run all code
-__pyzo__ = PyzoInterpreter(__main__.__dict__, "<console>")
+# Create interpreter instance and give namespace in which to run all code
+_locals = __main__.__dict__
+_globals = _locals
+__pyzo__ = PyzoInterpreter(_globals, _locals, "<console>")
 sys._pyzoInterpreter = __pyzo__
+del _locals, _globals
 
 # Store context
 __pyzo__.context = ct

--- a/pyzo/resources/code_examples/external_debugger_interface.py
+++ b/pyzo/resources/code_examples/external_debugger_interface.py
@@ -15,13 +15,25 @@ and to debug the application from a new shell inside the Pyzo IDE.
 import os
 import time
 
-print('example Python application')
-print('this process has PID', os.getpid())
-cnt = 0
-while True:
-    cnt += 1
-    print('cnt:', cnt)
-    time.sleep(1.0)
+def myfunc1():
+
+    def myfunc2():
+        cnt2 = 1
+        while cnt2 < 5:
+            time.sleep(0.2)
+            print('cnt2:', cnt2)
+            cnt2 += 1
+
+    print('example Python application')
+    print('this process has PID', os.getpid())
+    cnt1 = 0
+    while True:
+        cnt1 += 1
+        print('cnt1:', cnt1)
+        time.sleep(2.0)
+        myfunc2()
+
+myfunc1()
 
 
 ##
@@ -47,9 +59,22 @@ if False:
     # Python application is paused.
 
     # Now you can inspect variables and execute code, like in any other shell in Pyzo.
+    # The shell starts with the outermost frame for global and local variables, so
+    # you only see "myfunc1" and the imports in the current scope.
 
-    # Execute "cnt = -1234" in the shell.
+    # The code for starting the external shell could be called anywhere where it is
+    # convenient for the Python interpreter. For the example code above, it will most
+    # likely happen inside myfunc1 or myfunc2.
+    # You can switch (from the outermost scope) to the scope of myfunc1 by executing
+    # the following line in the shell:
+    #     import sys; sys._pyzoInterpreter.switchframe(-2)
+    # Then you can inspect/modify variable "cnt1".
+    # For example, execute "cnt1 = -1234" in the shell.
+    # If the start of the external shell happend inside myfunc2, then you can also
+    # inspect the values there (cnt2). To switch to that frame, execute the line:
+    #     import sys; sys._pyzoInterpreter.switchframe(-3)
+
     # Finally terminate the shell (e.g. via "Shell -> Close" in Pyzo's menu).
-    # The external Python application is now running again, but with the modified cnt value.
+    # The external Python application is now running again, but with the modified cnt1 value.
 
     # You can reconnect again by executing this code cell again.

--- a/pyzo/resources/code_examples/start_external_shell.py
+++ b/pyzo/resources/code_examples/start_external_shell.py
@@ -27,6 +27,12 @@ freeze till the shell is closed again. But you can re-enter the kernel anytime.
 bpy.ops.mesh.primitive_cube_add(size=3, location=(0, 0, 0))
 bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
 # https://docs.blender.org/api/current/info_gotcha.html#can-i-redraw-during-script-execution
+
+The global and local variables of the new shell are the ones of the outermost frame.
+But they can be switched to other frames, for example to frames between the outmost frame
+and the Pyzo kernel's first frame. To do this, execute for example the line
+    import sys; sys._pyzoInterpreter.switchframe(-2)
+which switches globals and locals to the second outermost frame (index -2).
 """
 
 


### PR DESCRIPTION
These changes make it possible to switch frames of the shell/kernel when debugging is not active.
Normally, the namespace (globals and locals) is the outermost frame (`__main__.__dict__`), but when starting the shell/kernel externally, there are frames between the outermost frame and the first frame of the Pyzo kernel. To inspect these frames or modify them, just execute for example
`import sys; sys._pyzoInterpreter.switchframe(-2)` which switches to the second outermost frame, and what you see als local and global variables in the shell will then be the variables according to that stack frame.
See the updated examples in folder "pyzo/resources/code_examples" for more information.