### PR TITLE
reverse frame index for frame switching

### DIFF
--- a/pyzo/pyzokernel/interpreter.py
+++ b/pyzo/pyzokernel/interpreter.py
@@ -1245,10 +1245,10 @@ class PyzoInterpreter:
 
     ## Advanced methods
 
-    def switchframe(self, frameindex=-1):
+    def switchframe(self, frameindex=0):
         """switches the globals and locals for the shell to the selected frame
 
-        frameindex -1 is the outermost frame (and index 0 the innermost one)
+        frameindex 0 is the outermost frame
 
         For normally started shells, this makes no sense, because the interpreter
         already uses the outermost frame, and all inner frames are only the ones of
@@ -1259,7 +1259,7 @@ class PyzoInterpreter:
         It could be useful to switch to another frame to inspect or modify variables
         there. To switch the globals/locals to the second outermost frame, for example,
         execute the line
-            import sys; sys._pyzoInterpreter.switchframe(-2)
+            import sys; sys._pyzoInterpreter.switchframe(1)
         in the shell. Note that the switch will be performed only after the execution
         of that line has finished.
         """
@@ -1269,6 +1269,7 @@ class PyzoInterpreter:
         while f.f_back:
             f = f.f_back
             frames.append(f)
+        frames.reverse()
 
         if self._dbFrames:
             printDirect("cannot switch frame because debugging is active\n")

--- a/pyzo/resources/code_examples/external_debugger_interface.py
+++ b/pyzo/resources/code_examples/external_debugger_interface.py
@@ -67,12 +67,12 @@ if False:
     # likely happen inside myfunc1 or myfunc2.
     # You can switch (from the outermost scope) to the scope of myfunc1 by executing
     # the following line in the shell:
-    #     import sys; sys._pyzoInterpreter.switchframe(-2)
+    #     import sys; sys._pyzoInterpreter.switchframe(1)
     # Then you can inspect/modify variable "cnt1".
     # For example, execute "cnt1 = -1234" in the shell.
     # If the start of the external shell happend inside myfunc2, then you can also
     # inspect the values there (cnt2). To switch to that frame, execute the line:
-    #     import sys; sys._pyzoInterpreter.switchframe(-3)
+    #     import sys; sys._pyzoInterpreter.switchframe(2)
 
     # Finally terminate the shell (e.g. via "Shell -> Close" in Pyzo's menu).
     # The external Python application is now running again, but with the modified cnt1 value.

--- a/pyzo/resources/code_examples/start_external_shell.py
+++ b/pyzo/resources/code_examples/start_external_shell.py
@@ -31,8 +31,8 @@ bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
 The global and local variables of the new shell are the ones of the outermost frame.
 But they can be switched to other frames, for example to frames between the outmost frame
 and the Pyzo kernel's first frame. To do this, execute for example the line
-    import sys; sys._pyzoInterpreter.switchframe(-2)
-which switches globals and locals to the second outermost frame (index -2).
+    import sys; sys._pyzoInterpreter.switchframe(1)
+which switches globals and locals to the second outermost frame (index 1).
 """
 
 


### PR DESCRIPTION
This PR changes the order of the frames introduced via #1284.
Frame index 0 is now the outermost frame, with higher values towards the inner frames.
It is also possible to index from the end (innermost frame has index -1).