### PR TITLE
rework keyboard navigation for autocompletion list

### DIFF
--- a/pyzo/codeeditor/extensions/autocompletion.py
+++ b/pyzo/codeeditor/extensions/autocompletion.py
@@ -364,21 +364,28 @@ class AutoCompletion:
         if self.potentiallyAutoComplete(event) > 1:
             return  # Consume
 
-        if self.autocompleteActive() and modifiers == Qt.KeyboardModifier.NoModifier:
-            if key in (K.Key_PageUp, K.Key_PageDown):
-                QtWidgets.qApp.sendEvent(self.__completerWindow, event)
-                return True
-
+        if self.autocompleteActive():
             row = self.__completerWindow.currentIndex().row()
             newRow = None
-            if key == K.Key_Up:
-                newRow = row - 1
-            elif key == K.Key_Down:
-                newRow = row + 1
-            elif key == K.Key_Home:
-                newRow = 0
-            elif key == K.Key_End:
-                newRow = -1  # last element (after modulo operation)
+
+            if key in (K.Key_PageUp, K.Key_PageDown):
+                # PageUp and PageDown are forwarded to the list widget
+                if modifiers == Qt.KeyboardModifier.NoModifier:
+                    QtWidgets.qApp.sendEvent(self.__completerWindow, event)
+                    return True
+
+                # Shift+PageUp and Shift+PageDown will select the first resp. last entry
+                if modifiers == Qt.KeyboardModifier.ShiftModifier:
+                    if key == K.Key_PageUp:
+                        newRow = 0
+                    elif key == K.Key_PageDown:
+                        newRow = -1  # last element (after modulo operation)
+
+            elif modifiers == Qt.KeyboardModifier.NoModifier:
+                if key == K.Key_Up:
+                    newRow = row - 1
+                elif key == K.Key_Down:
+                    newRow = row + 1
 
             if newRow is not None:
                 model = self.__completerWindow.model()

--- a/pyzo/core/shell.py
+++ b/pyzo/core/shell.py
@@ -476,7 +476,10 @@ class BaseShell(BaseTextCtrl):
             if not (self.autocompleteActive() or self.calltipActive()):
                 self.clearCommand()
 
-        if event.key() in (Qt.Key.Key_PageUp, Qt.Key.Key_PageDown):
+        if (
+            event.key() in (Qt.Key.Key_PageUp, Qt.Key.Key_PageDown)
+            and not self.autocompleteActive()
+        ):
             # The cursor should not move. So we have to ignore the event.
             # But we still want to be able to scroll the shell.
             # --> We send the event directly to the base class so
@@ -484,9 +487,7 @@ class BaseShell(BaseTextCtrl):
             pyzo.codeeditor.CodeEditorBase.keyPressEvent(self, event)
             return
 
-        if event.key() == Qt.Key.Key_Home and not (
-            self.autocompleteActive() and not event.modifiers()
-        ):
+        if event.key() == Qt.Key.Key_Home:
             # Home goes to the prompt.
             cursor = self.textCursor()
             if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:


### PR DESCRIPTION
This PR reworks some changes from #1273:

Home and End keys are reverted to the old behavior (only move the text cursor instead of navigating the autocompletion list).

Shift+PageUp and Shift+PageDown now select the first resp. last entry of the autocompletion list (instead of Home and End keys).

Fixed PageUp and PageDown for navigating the autocompletion list which got broken in #1285.
