### PR TITLE
Security: Command Injection via untrusted file paths in subprocess.call

### DIFF
--- a/pyzo/util/__init__.py
+++ b/pyzo/util/__init__.py
@@ -32,9 +32,9 @@ def open_directory_outside_pyzo(dirpath, filename=None):
         subprocess.call(("open", dirpath))
     elif sys.platform.startswith("win"):
         if filepath is not None:
-            subprocess.call('explorer.exe /select,"{}"'.format(filepath))
+            subprocess.call(["explorer.exe", "/select,", filepath])
         else:
-            subprocess.call('explorer.exe "{}"'.format(dirpath))
+            subprocess.call(["explorer.exe", dirpath])
     elif sys.platform.startswith("linux"):
         subprocess.call(("xdg-open", dirpath))
 


### PR DESCRIPTION
## Summary

Security: Command Injection via untrusted file paths in subprocess.call

## Problem

**Severity**: `Medium` | **File**: `pyzo/util/__init__.py:L24`

The `open_directory_outside_pyzo` function uses `subprocess.call` with `shell=False` (the default) by passing a single string argument. On POSIX systems, this causes the entire string to be treated as the executable filename. If `dirpath` or `filepath` contain spaces or shell metacharacters, this will lead to unexpected behavior or errors. If this function is ever called with `shell=True` or migrated to `os.system`, it would allow arbitrary command execution.

## Solution

Pass arguments as a list to `subprocess.call` instead of a single string. For example: `subprocess.call(['explorer.exe', '/select,', filepath])` and `subprocess.call(['explorer.exe', dirpath])`.

## Changes

- `pyzo/util/__init__.py` (modified)