### PR TITLE
add supported file extensions .FCMacro and .ino

### DIFF
--- a/pyzo/codeeditor/parsers/c_parser.py
+++ b/pyzo/codeeditor/parsers/c_parser.py
@@ -58,7 +58,7 @@ commentEndProg = re.compile(r"\*/")
 class CParser(Parser):
     """A C parser."""
 
-    _extensions = [".c", ".h", ".cpp", "cxx", "hxx"]
+    _extensions = [".c", ".h", ".cpp", ".cxx", ".hxx", ".ino"]
     _keywords = [
         "auto",
         "bool",

--- a/pyzo/codeeditor/parsers/python_parser.py
+++ b/pyzo/codeeditor/parsers/python_parser.py
@@ -836,7 +836,7 @@ class PythonParser(Parser):
 class PythonParser(PythonParser):  # Ambiguous Python parser
     """Parser for either Python2 or Python3, and we do not know which."""
 
-    _extensions = [".py", ".pyw"]
+    _extensions = [".py", ".pyw", ".FCMacro"]
     _shebangKeywords = ["python"]
     # The list of keywords is overridden by the Python2/3 specific parsers
     _keywords = pythonKeywords

--- a/pyzo/core/editorTabs.py
+++ b/pyzo/core/editorTabs.py
@@ -1255,9 +1255,9 @@ class EditorTabs(QtWidgets.QWidget):
 
         # show dialog
         msg = translate("editorTabs", "Select one or more files to open")
-        filter = "Python (*.py *.pyw);;"
+        filter = "Python (*.py *.pyw *.FCMacro);;"
         filter += "Pyrex (*.pyi *.pyx *.pxd);;"
-        filter += "C (*.c *.h *.cpp *.c++);;"
+        filter += "C (*.c *.h *.cpp *.c++ *.ino);;"  # ino ... Arduino .c file
         # filter += "Py+Cy+C (*.py *.pyw *.pyi *.pyx *.pxd *.c *.h *.cpp);;"
         filter += "All (*)"
         if True:
@@ -1504,9 +1504,9 @@ class EditorTabs(QtWidgets.QWidget):
 
         # show dialog
         msg = translate("editorTabs", "Select the file to save to")
-        filter = "Python (*.py *.pyw);;"
+        filter = "Python (*.py *.pyw *.FCMacro);;"
         filter += "Pyrex (*.pyi *.pyx *.pxd);;"
-        filter += "C (*.c *.h *.cpp);;"
+        filter += "C (*.c *.h *.cpp *.ino);;"
         # filter += "Py+Cy+C (*.py *.pyw *.pyi *.pyx *.pxd *.c *.h *.cpp);;"
         filter += "All (*.*)"
         if startfilename is None:


### PR DESCRIPTION
This PR adds file extensions to the file open and save-as dialogs and to the syntax highlighting parser.

.FCMacro ... FreeCAD Python macro
.ino ... Arduino C file