### PR TITLE
keep scrollbar pos in editor on Ctrl+A, Ctrl+C with long last line

### DIFF
--- a/pyzo/codeeditor/extensions/behaviour.py
+++ b/pyzo/codeeditor/extensions/behaviour.py
@@ -482,12 +482,16 @@ class SmartCopyAndPaste:
 
                 # Setting the textcursor might scroll to another place
                 # (e.g. Ctrl+A, Ctrl+C would scroll to the very bottom).
+                # And if the last line is a very long line, Ctrl+A, Ctrl+C
+                # would scroll to the very right.
                 # To prevent this, we store and then restore the position
-                # of the vertical scrollbar
-                sb = self.verticalScrollBar()
-                scrollbarPos = sb.value()
+                # of the scrollbars.
+                vsb = self.verticalScrollBar()
+                hsb = self.horizontalScrollBar()
+                vpos, hpos = vsb.value(), hsb.value()
                 self.setTextCursor(cursor)
-                sb.setValue(scrollbarPos)
+                vsb.setValue(vpos)
+                hsb.setValue(hpos)
 
         # Call our supers copy slot to do the actual copying
         super().copy()


### PR DESCRIPTION
To reproduce the problem:
Create a new file in Pyzo (new editor tab).
Insert the following two lines, without a newline after the second line:
```
abc
abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc 
```
If there is no horizontal scrollbar in the editor, reduce the with of the Pyzo IDE window till you see one.
Move the text cursor to the very left so that the scrollbar is on the very left.
Press Ctrl+A to select all text.
Press Ctrl+C to copy the selected text.
The horizontal scrollbar is now moved to the very right.

This PR fixes the described problem.