### PR TITLE
improve subprocess calls

### DIFF
--- a/freeze/pyzo_package.py
+++ b/freeze/pyzo_package.py
@@ -90,7 +90,7 @@ def package_inno_installer():
     with open(innoFile2, "wb") as f:
         f.write(text.encode())
     try:
-        subprocess.check_call([exe, "/Qp", innoFile2], cwd=dist_dir)
+        subprocess.run([exe, "/Qp", innoFile2], cwd=dist_dir, check=True)
     finally:
         os.remove(innoFile2)
 
@@ -113,7 +113,13 @@ def package_dmg():
     cmd.append(dmg_file)
 
     try:
-        subprocess.check_output(cmd, cwd=dist_dir, stderr=subprocess.STDOUT)
+        subprocess.run(
+            cmd,
+            cwd=dist_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=True,
+        )
     except subprocess.CalledProcessError as err:
         print(err.output.decode())  # hopefully helpful
         raise err

--- a/pyzo/core/kernelbroker.py
+++ b/pyzo/core/kernelbroker.py
@@ -136,16 +136,11 @@ def getCommandFromKernelInfo(info, port):
     if exe.startswith("."):
         exe = os.path.abspath(os.path.join(EXE_DIR, exe))
 
-    # Correct path when it contains spaces
-    if exe.count(" ") and exe[0] != '"':
-        exe = '"{}"'.format(exe)
-
     # Get start script
     startScript = os.path.join(pyzo.pyzoDir, "pyzokernel", "start.py")
-    startScript = '"{}"'.format(startScript)
 
     # Build command
-    command = exe + " " + startScript + " " + str(port)
+    command = [exe, startScript, str(port)]
 
     # Done
     return command
@@ -383,6 +378,13 @@ class KernelBroker:
 
         externalshell_callbackport = info.get("externalshell_callbackport")
 
+        si = None
+        if sys.platform == "win32":
+            # prevent window popping up on MS Windows
+            si = subprocess.STARTUPINFO()
+            si.dwFlags = subprocess.STARTF_USESHOWWINDOW
+            si.wShowWindow = subprocess.SW_HIDE
+
         try:
             # Wrap command in call to 'cmd'?
             if sys.platform.startswith("win"):
@@ -393,22 +395,22 @@ class KernelBroker:
                 # But we only use it if we are sure that cmd is available.
                 # See pyzo issue #240
                 try:
-                    subprocess.check_output('cmd /c "cd"', shell=True)
+                    subprocess.run(["cmd", "/c", "cd"], check=True, startupinfo=si)
                 except (IOError, subprocess.SubprocessError):
                     pass  # Do not use cmd
                 else:
-                    command = 'cmd /c "{}"'.format(command)
+                    command = ["cmd", "/c"] + command
 
             if externalshell_callbackport is None:
                 # Start process
                 self._process = subprocess.Popen(
                     command,
-                    shell=True,
                     env=env,
                     cwd=cwd,
                     stdin=subprocess.PIPE,  # Fixes issue 165
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
+                    startupinfo=si,
                 )
             else:
                 # TCP client

--- a/pyzo/tools/pyzoFileBrowser/tree.py
+++ b/pyzo/tools/pyzoFileBrowser/tree.py
@@ -882,19 +882,21 @@ class PopupMenu(pyzo.core.menu.Menu):
     def _openOutsidePyzo(self):
         path = self._item.path()
         if sys.platform.startswith("darwin"):
-            subprocess.call(("open", path))
+            subprocess.run(("open", path))
         elif sys.platform.startswith("win"):
-            if " " in path:  # http://stackoverflow.com/a/72796/2271927
-                subprocess.call(("start", "", path), shell=True)
-            else:
-                subprocess.call(("start", path), shell=True)
+            # prevent console window popping up on MS Windows
+            si = subprocess.STARTUPINFO()
+            si.dwFlags = subprocess.STARTF_USESHOWWINDOW
+            si.wShowWindow = subprocess.SW_HIDE
+            # http://stackoverflow.com/a/72796/2271927
+            subprocess.run(("start", '""', path), startupinfo=si, timeout=5.0)
         elif sys.platform.startswith("linux"):
             # xdg-open is available on all Freedesktop.org compliant distros
             # http://superuser.com/questions/38984/linux-equivalent-command-for-open-command-on-mac-windows
-            subprocess.call(("xdg-open", path))
+            subprocess.run(("xdg-open", path))
 
     def _showInFinder(self):
-        subprocess.call(("open", "-R", self._item.path()))
+        subprocess.run(("open", "-R", self._item.path()))
 
     def _copyPath(self):
         QtWidgets.qApp.clipboard().setText(self._item.path())

--- a/pyzo/util/__init__.py
+++ b/pyzo/util/__init__.py
@@ -29,14 +29,14 @@ def open_directory_outside_pyzo(dirpath, filename=None):
         filepath = None
 
     if sys.platform.startswith("darwin"):
-        subprocess.call(("open", dirpath))
+        subprocess.run(("open", dirpath))
     elif sys.platform.startswith("win"):
         if filepath is not None:
-            subprocess.call('explorer.exe /select,"{}"'.format(filepath))
+            subprocess.run(["explorer.exe", "/select,", filepath])
         else:
-            subprocess.call('explorer.exe "{}"'.format(dirpath))
+            subprocess.run(["explorer.exe", dirpath])
     elif sys.platform.startswith("linux"):
-        subprocess.call(("xdg-open", dirpath))
+        subprocess.run(("xdg-open", dirpath))
 
 
 class CalmedFunc:

--- a/pyzo/util/interpreters/pythoninterpreter.py
+++ b/pyzo/util/interpreters/pythoninterpreter.py
@@ -89,19 +89,28 @@ class PythonInterpreter:
             self._problem = "{!r} is not a valid file.".format(path)
             return ""
 
-        # shell=True prevents loads of command windows popping up on Windows,
-        # but if used on Linux it would enter interpreter mode
+        si = None
+        if sys.platform == "win32":
+            # prevent window popping up on MS Windows
+            si = subprocess.STARTUPINFO()
+            si.dwFlags = subprocess.STARTF_USESHOWWINDOW
+            si.wShowWindow = subprocess.SW_HIDE
+
         cmd = [path, "-V"]
         try:
-            v = subprocess.check_output(
-                cmd, stderr=subprocess.STDOUT, shell=sys.platform.startswith("win")
+            p = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=True,
+                startupinfo=si,
             )
         except Exception as e:  # Don't risk not catching an unforeseen exception ...
             self._problem = str(e)
             return ""
 
         # Extract the version, apply some defensive programming
-        v = v.decode("ascii", "ignore").strip().lower()
+        v = p.stdout.decode("ascii", "ignore").strip().lower()
         if v.startswith("python"):
             v = v.split(" ")[1]
         v = v.split(" ")[0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,8 +17,10 @@ print(list(sys.modules.keys()))
 
 
 def test_import1():
-    x = subprocess.check_output([sys.executable, "-c", code1])
-    modules = eval(x.decode())
+    p = subprocess.run(
+        [sys.executable, "-c", code1], check=True, stdout=subprocess.PIPE
+    )
+    modules = eval(p.stdout.decode())
     assert isinstance(modules, list)
     assert "sys" in modules
     assert "pyzo" in modules
@@ -38,8 +40,10 @@ print(list(sys.modules.keys()))
 
 
 def test_import2():
-    x = subprocess.check_output([sys.executable, "-c", code2])
-    modules = eval(x.decode())
+    p = subprocess.run(
+        [sys.executable, "-c", code2], check=True, stdout=subprocess.PIPE
+    )
+    modules = eval(p.stdout.decode())
     assert isinstance(modules, list)
     assert "sys" in modules
     assert "pyzo" in modules


### PR DESCRIPTION
* changed old subprocess high-level API (before Python v3.5) to modern high-level API
(except code executed by the Pyzo kernel, because of Python < v3.5 support)
`subprocess.call` --> `subprocess.run`
`subprocess.check_call` --> `subprocess.run`
`subprocess.check_output` --> `subprocess.run`
see https://docs.python.org/3/library/subprocess.html#older-high-level-api
* changed code to always pass command with arguments as list instead of single string calls
* added new workaround to hide Python console window in MS Windows instead of passing `shell=True`
* removed `shell=True` and replaced it with better alternatives
* added timeout for starting external files in the "File Browser" tool